### PR TITLE
[SYSTEMML-880] [WIP] Initial version of pushdown loop for Python DSL

### DIFF
--- a/src/main/python/systemml/__init__.py
+++ b/src/main/python/systemml/__init__.py
@@ -22,7 +22,9 @@
 from .mlcontext import *
 from .defmatrix import *
 from .converters import *
+from .pushdown import *
 
 __all__ = mlcontext.__all__
 __all__ += defmatrix.__all__
 __all__ += converters.__all__
+__all__ += pushdown.__all__

--- a/src/main/python/systemml/mlcontext.py
+++ b/src/main/python/systemml/mlcontext.py
@@ -87,6 +87,7 @@ def _py2java(sc, obj):
     if isinstance(obj, Matrix):
         obj = obj._java_matrix
     # TODO: Port this private PySpark function.
+    # TODO: Handle Numpy Array
     obj = pyspark.mllib.common._py2java(sc, obj)
     return obj
 

--- a/src/main/python/systemml/pushdown.py
+++ b/src/main/python/systemml/pushdown.py
@@ -1,0 +1,62 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+from .defmatrix import *
+from . import MLContext, pydml
+
+from dill.source import getsource
+from textwrap import dedent
+
+__all__ = ['parallelize']
+
+def parallelize(fn):
+    """
+    The current implementation can only pushdown subset of Python that maps to PyDML.
+    Also, the inputs and outputs need to be explicitly specified.
+    We will relax this constraints in future version by performing AST analysis.
+    """
+    def inner(*args, **kwargs):
+        if matrix.ml is None:
+            raise Exception('Expected setSparkContext(sc) to be called.')
+        # ------------------------------------------------------------------------------------
+        # Assumption that @parallelize and function definition has one line. Fix this by having a class that extends ast.NodeVisitor
+        if 'inputs' not in kwargs or 'outputs' not in kwargs:
+            raise ValueError('The function to parallelize should contains exactly two named arguments with keys: inputs, outputs')
+        codeWithParallelizeHeader = getsource(fn)
+        # ------------------------------------------------------------------------------------
+        codeWithoutParallelizeHeader = ''.join(['\n', dedent(codeWithParallelizeHeader.split("\n",2)[2]), '\n'])
+        # print "Executing code as pydml:\n" + codeWithoutParallelizeHeader
+        script = pydml(codeWithoutParallelizeHeader)
+        for name, value in kwargs['inputs'].items():
+            if isinstance(value, matrix):
+                # TODO: Uncomment this after _py2java allow NumPy array
+                # value.eval()
+                # script.input(name, value.data)
+                script.input(name, value.toDataFrame())
+            else:
+                script.input(name, value)
+        map(lambda o: script.output(o), kwargs['outputs'])        
+        matrix.ml = MLContext(matrix.sc)
+        results = matrix.ml.execute(script)
+        return map(lambda o: results.get(o), kwargs['outputs'])
+    return inner
+
+        


### PR DESCRIPTION
Design decisions:
1.  In the initial version, I decided not to parse and walk the Python AST. The key assumption is that the **code to be pushed-down has to map to PyDML**. This will help us to identify the gaps in PyDML as well (for example: `dot(H, H.transpose())` instead of `H.dot(H.transpose))`. Also, cases such as `sml.matrix` is not handled.
2. The inputs and outputs need to be specified. There is a tradeoff here between **simplicity of the API+Implementation and optimization scope**. 
- Alternative to the current implementation is that inputs+outputs are not specified and the function to be pushed-down has access to all the variables in the global scope. In this case, we walk down the AST and identify all the variables on RHS and treat them as outputs and all other variables not created as input (hand-waving lil bit here). 
- Another alternative is to not require providing variable name in string format: `'H'`, but this was difficult  to implement due to pass-by-value and point 1.
- Also, I could not find a way to enable the decorator (`@parallelize`) on statement block instead of function.

``` python
import systemml as sml
from systemml import random
sml.setSparkContext(sc)

m, n = 100, 20
k = 40
V = sml.random.uniform(size=(m, n))
W = sml.random.uniform(size=(m, k))
H = sml.random.uniform(size=(k, n))

@sml.parallelize
def push_down_loop(inputs, outputs):
    max_iters = 200
    for i in range(0, max_iters):
        H = H * dot(W.transpose(), V)/dot(W.transpose(), dot(W, H))
        W = W * dot(V, H.transpose())/dot(W, dot(H, H.transpose()))

# The returned values as Matrix class
ret = push_down_loop(inputs={'H': H, 'W':W, 'V': V}, outputs=['H', 'W'])
H = ret[0].toNumPy()
W = ret[1].toNumPy()
```

@iyounus @dusenberrymw @mboehm7 @frreiss @bertholdreinwald @nakul02  @deroneriksson  @asurve 
