### PR TITLE
[WIP][SYSTEMML-298] Print matrices without as.scalar or toString

### DIFF
--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
@@ -258,8 +258,10 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 			Hop left = bop.getInput().get(0);
 			Hop right = bop.getInput().get(1);
 			//X/1 or X*1 -> X 
-			if(    left.getDataType()==DataType.MATRIX 
-				&& right instanceof LiteralOp && ((LiteralOp)right).getDoubleValue()==1.0 )
+			if(left.getDataType()==DataType.MATRIX 
+				&& right instanceof LiteralOp
+				&& (right.getValueType() != ValueType.STRING)
+				&& ((LiteralOp)right).getDoubleValue()==1.0 )
 			{
 				if( bop.getOp()==OpOp2.DIV || bop.getOp()==OpOp2.MULT )
 				{
@@ -270,8 +272,10 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 				}
 			}
 			//X-0 -> X 
-			else if(    left.getDataType()==DataType.MATRIX 
-					&& right instanceof LiteralOp && ((LiteralOp)right).getDoubleValue()==0.0 )
+			else if(left.getDataType()==DataType.MATRIX 
+					&& right instanceof LiteralOp
+					&& (right.getValueType() != ValueType.STRING)
+					&& ((LiteralOp)right).getDoubleValue()==0.0 )
 			{
 				if( bop.getOp()==OpOp2.MINUS )
 				{
@@ -282,8 +286,10 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 				}
 			}
 			//1*X -> X
-			else if(   right.getDataType()==DataType.MATRIX 
-					&& left instanceof LiteralOp && ((LiteralOp)left).getDoubleValue()==1.0 )
+			else if(right.getDataType()==DataType.MATRIX 
+					&& left instanceof LiteralOp
+					&& (left.getValueType() != ValueType.STRING)
+					&& ((LiteralOp)left).getDoubleValue()==1.0 )
 			{
 				if( bop.getOp()==OpOp2.MULT )
 				{
@@ -296,8 +302,10 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 			//-1*X -> -X
 			//note: this rewrite is necessary since the new antlr parser always converts 
 			//-X to -1*X due to mechanical reasons
-			else if(   right.getDataType()==DataType.MATRIX 
-					&& left instanceof LiteralOp && ((LiteralOp)left).getDoubleValue()==-1.0 )
+			else if(right.getDataType()==DataType.MATRIX 
+					&& left instanceof LiteralOp
+					&& (left.getValueType() != ValueType.STRING)
+					&& ((LiteralOp)left).getDoubleValue()==-1.0 )
 			{
 				if( bop.getOp()==OpOp2.MULT )
 				{
@@ -309,8 +317,10 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 				}
 			}
 			//X*-1 -> -X (see comment above)
-			else if(   left.getDataType()==DataType.MATRIX 
-					&& right instanceof LiteralOp && ((LiteralOp)right).getDoubleValue()==-1.0 )
+			else if(left.getDataType()==DataType.MATRIX 
+					&& right instanceof LiteralOp
+					&& (right.getValueType() != ValueType.STRING)
+					&& ((LiteralOp)right).getDoubleValue()==-1.0 )
 			{
 				if( bop.getOp()==OpOp2.MULT )
 				{
@@ -350,8 +360,10 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 			//the creation of multiple datagen ops and thus potentially different results if seed not specified)
 			
 			//left input rand and hence output matrix double, right scalar literal
-			if( left instanceof DataGenOp && ((DataGenOp)left).getOp()==DataGenMethod.RAND &&
-				right instanceof LiteralOp && left.getParent().size()==1 )
+			if( left instanceof DataGenOp && ((DataGenOp)left).getOp()==DataGenMethod.RAND
+				&& right instanceof LiteralOp
+				&& (right.getValueType() != ValueType.STRING)
+				&& left.getParent().size()==1 )
 			{
 				DataGenOp inputGen = (DataGenOp)left;
 				HashMap<String,Integer> params = inputGen.getParamIndexMap();

--- a/src/main/java/org/apache/sysml/parser/Expression.java
+++ b/src/main/java/org/apache/sysml/parser/Expression.java
@@ -405,6 +405,10 @@ public abstract class Expression
 			return d1;
 
 		if (cast) {
+			if (d1 == DataType.MATRIX && d2 == DataType.SCALAR && identifier2.getValueType() == ValueType.STRING)
+				return DataType.SCALAR;
+			if (d1 == DataType.SCALAR && identifier1.getValueType() == ValueType.STRING && d2 == DataType.MATRIX)
+				return DataType.SCALAR;
 			if (d1 == DataType.MATRIX && d2 == DataType.SCALAR)
 				return DataType.MATRIX;
 			if (d1 == DataType.SCALAR && d2 == DataType.MATRIX)

--- a/src/main/java/org/apache/sysml/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/StatementBlock.java
@@ -731,13 +731,22 @@ public class StatementBlock extends LiveVariableAnalysis
 				raiseValidateError("control statement (WhileStatement, IfStatement, ForStatement) should not be in generic statement block. Likely a parsing error", conditional);
 			}
 
+			// note: this can be removed if no validate errors raised
 			else if (current instanceof PrintStatement) {
 				PrintStatement pstmt = (PrintStatement) current;
 				List<Expression> expressions = pstmt.getExpressions();
 				for (Expression expression : expressions) {
 					expression.validateExpression(ids.getVariables(), currConstVars, conditional);
 					if (expression.getOutput().getDataType() != Expression.DataType.SCALAR) {
-						raiseValidateError("print statement can only print scalars", conditional);
+						Identifier out = expression.getOutput();
+						if (out instanceof IndexedIdentifier) {
+							IndexedIdentifier ii = (IndexedIdentifier) out;
+							if (ii.getColLowerEqualsUpper() && ii.getRowLowerEqualsUpper()) {
+								// single cell
+							} else {
+								// raiseValidateError("print statement can not implicitly print ranges of cells", conditional);
+							}
+						}
 					}
 				}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/BinaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/BinaryCPInstruction.java
@@ -71,7 +71,7 @@ public abstract class BinaryCPInstruction extends ComputationCPInstruction
 		throws DMLRuntimeException 
 	{
 		// check for valid data type of output
-		if((in1.getDataType() == DataType.MATRIX || in2.getDataType() == DataType.MATRIX) && out.getDataType() != DataType.MATRIX)
+		if((in1.getDataType() == DataType.MATRIX && in2.getDataType() == DataType.MATRIX) && out.getDataType() != DataType.MATRIX)
 			throw new DMLRuntimeException("Element-wise matrix operations between variables " + in1.getName() + 
 					" and " + in2.getName() + " must produce a matrix, which " + out.getName() + " is not");
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
@@ -28,6 +28,7 @@ import org.apache.sysml.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
+import org.apache.sysml.runtime.util.DataConverter;
 import org.apache.sysml.runtime.util.IndexRange;
 import org.apache.sysml.utils.Statistics;
 
@@ -73,7 +74,17 @@ public final class MatrixIndexingCPInstruction extends IndexingCPInstruction
 			}	
 			
 			//unpin output
-			ec.setMatrixOutput(output.getName(), resultBlock);
+			DataType outDataType = output.getDataType();
+			if (outDataType == DataType.SCALAR) {
+				if ((resultBlock.getNumRows() == 1) && (resultBlock.getNumColumns() == 1)) {
+					ec.setScalarOutput(output.getName(), new DoubleObject(resultBlock.getValue(0, 0)));
+				} else {
+					String matrixString = DataConverter.toString(resultBlock);
+					ec.setScalarOutput(output.getName(), new StringObject(matrixString));
+				}
+			} else {
+				ec.setMatrixOutput(output.getName(), resultBlock);
+			}
 		}
 		//left indexing
 		else if ( opcode.equalsIgnoreCase("leftIndex"))

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarMatrixArithmeticCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarMatrixArithmeticCPInstruction.java
@@ -20,11 +20,13 @@
 package org.apache.sysml.runtime.instructions.cp;
 
 import org.apache.sysml.parser.Expression.DataType;
+import org.apache.sysml.parser.Expression.ValueType;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ScalarOperator;
+import org.apache.sysml.runtime.util.DataConverter;
 
 // TODO rename to MatrixScalar...
 public class ScalarMatrixArithmeticCPInstruction extends ArithmeticBinaryCPInstruction
@@ -38,29 +40,96 @@ public class ScalarMatrixArithmeticCPInstruction extends ArithmeticBinaryCPInstr
 											   String istr){
 		super(op, in1, in2, out, opcode, istr);
 	}
-	
-	@Override
-	public void processInstruction(ExecutionContext ec) 
-		throws DMLRuntimeException
-	{
-		CPOperand mat = ( input1.getDataType() == DataType.MATRIX ) ? input1 : input2;
-		CPOperand scalar = ( input1.getDataType() == DataType.MATRIX ) ? input2 : input1;
-		
-		MatrixBlock inBlock = ec.getMatrixInput(mat.getName());
-		ScalarObject constant = (ScalarObject) ec.getScalarInput(scalar.getName(), scalar.getValueType(), scalar.isLiteral());
 
-		ScalarOperator sc_op = (ScalarOperator) _optr;
-		sc_op.setConstant(constant.getDoubleValue());
-		
-		MatrixBlock retBlock = (MatrixBlock) inBlock.scalarOperations(sc_op, new MatrixBlock());
-		
-		ec.releaseMatrixInput(mat.getName());
-		
-		// Ensure right dense/sparse output representation (guarded by released input memory)
-		if( checkGuardedRepresentationChange(inBlock, retBlock) ) {
- 			retBlock.examSparsity();
- 		}
-		
-		ec.setMatrixOutput(output.getName(), retBlock);
+	@Override
+	public void processInstruction(ExecutionContext ec) throws DMLRuntimeException {
+		CPOperand mat = (input1.getDataType() == DataType.MATRIX) ? input1 : input2;
+		CPOperand scalar = (input1.getDataType() == DataType.MATRIX) ? input2 : input1;
+
+		ValueType svt = scalar.getValueType();
+		ValueType mvt = mat.getValueType();
+
+		if (mvt == ValueType.STRING) { // print("this " + X[1,1] + " that");
+			ScalarObject matObj = (ScalarObject) ec.getScalarInput(mat.getName(), mat.getValueType(), mat.isLiteral());
+			ScalarObject scalarObj = (ScalarObject) ec.getScalarInput(scalar.getName(), scalar.getValueType(),
+					scalar.isLiteral());
+			boolean matrixThenScalar = false;
+			if (input1.getDataType() == DataType.MATRIX) {
+				matrixThenScalar = true;
+			}
+			String outString = null;
+			if (matrixThenScalar) {
+				outString = matObj.toString() + scalarObj.toString();
+			} else {
+				outString = scalarObj.toString() + matObj.toString();
+			}
+			StringObject so = new StringObject(outString);
+			ec.setScalarOutput(output.getName(), so);
+		} else if (svt == ValueType.STRING) { // print("this " + X[1,1]); or
+												// print(X[1,1] + " that");
+			MatrixBlock inBlock = ec.getMatrixInput(mat.getName());
+			if ((inBlock.getNumRows() == 1) && (inBlock.getNumColumns() == 1)) {
+				DoubleObject doubleObject = new DoubleObject(inBlock.getValue(0, 0));
+
+				ScalarObject scalarObj = (ScalarObject) ec.getScalarInput(scalar.getName(), scalar.getValueType(),
+						scalar.isLiteral());
+
+				boolean matrixThenScalar = false;
+				if (input1.getDataType() == DataType.MATRIX) {
+					matrixThenScalar = true;
+				}
+
+				String outString = null;
+				if (matrixThenScalar) {
+					outString = doubleObject.toString() + scalarObj.toString();
+				} else {
+					outString = scalarObj.toString() + doubleObject.toString();
+				}
+				StringObject so = new StringObject(outString);
+
+				ec.releaseMatrixInput(mat.getName());
+				ec.setScalarOutput(output.getName(), so);
+			} else {
+				String matrixString = DataConverter.toString(inBlock);
+				ec.releaseMatrixInput(mat.getName());
+
+				ScalarObject scalarObj = (ScalarObject) ec.getScalarInput(scalar.getName(), scalar.getValueType(),
+						scalar.isLiteral());
+
+				boolean matrixThenScalar = false;
+				if (input1.getDataType() == DataType.MATRIX) {
+					matrixThenScalar = true;
+				}
+
+				String outString = null;
+				if (matrixThenScalar) {
+					outString = matrixString + scalarObj.toString();
+				} else {
+					outString = scalarObj.toString() + matrixString;
+				}
+				StringObject so = new StringObject(outString);
+
+				ec.setScalarOutput(output.getName(), so);
+			}
+		} else {
+			MatrixBlock inBlock = ec.getMatrixInput(mat.getName());
+			ScalarObject constant = (ScalarObject) ec.getScalarInput(scalar.getName(), scalar.getValueType(),
+					scalar.isLiteral());
+
+			ScalarOperator sc_op = (ScalarOperator) _optr;
+			sc_op.setConstant(constant.getDoubleValue());
+
+			MatrixBlock retBlock = (MatrixBlock) inBlock.scalarOperations(sc_op, new MatrixBlock());
+
+			ec.releaseMatrixInput(mat.getName());
+
+			// Ensure right dense/sparse output representation (guarded by
+			// released input memory)
+			if (checkGuardedRepresentationChange(inBlock, retBlock)) {
+				retBlock.examSparsity();
+			}
+
+			ec.setMatrixOutput(output.getName(), retBlock);
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/MLContextTest.java
@@ -2665,6 +2665,171 @@ public class MLContextTest extends AutomatedTestBase {
 		ml.execute(script);
 	}
 
+	@Test
+	public void testPrintMatrixCellWithAsScalar() {
+		System.out.println("MLContextTest - print matrix cell with as.scalar");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);print(as.scalar(A[1,1]));";
+		setExpectedStdOut("1.0");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintMatrixCell() {
+		System.out.println("MLContextTest - print matrix cell");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);print(A[1,2]);";
+		setExpectedStdOut("2.0");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintStringMatrixCellConcatenation() {
+		System.out.println("MLContextTest - print string/matrix-cell concatenation");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);print('one two '+A[1,3]);";
+		setExpectedStdOut("one two 3.0");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintMatrixCellStringConcatenation() {
+		System.out.println("MLContextTest - print matrix-cell/string concatenation");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);print(A[2,1]+' five six');";
+		setExpectedStdOut("4.0 five six");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintStringMatrixCellStringConcatenation() {
+		System.out.println("MLContextTest - print string/matrix-cell/string concatenation");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);print('four '+A[2,2]+' six');";
+		setExpectedStdOut("four 5.0 six");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintMatrixCellStringMatrixCellConcatenation() {
+		System.out.println("MLContextTest - print matrix-cell/string/matrix-cell concatenation");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);print(A[1,1]+' two '+A[1,3]);";
+		setExpectedStdOut("1.0 two 3.0");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintSingleCellMatrix() {
+		System.out.println("MLContextTest - print single cell matrix");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);B=A[2,3];print(B);";
+		setExpectedStdOut("6.0");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintStringSingleCellMatrixConcatenation() {
+		System.out.println("MLContextTest - print string/single-cell-matrix concatenation");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);B=A[2,3];print('five '+B);";
+		setExpectedStdOut("five 6.0");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintSingleCellMatrixStringConcatenation() {
+		System.out.println("MLContextTest - print single-cell-matrix/string concatenation");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);B=A[2,3];print(B+' seven');";
+		setExpectedStdOut("6.0 seven");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintStringSingleCellMatrixStringConcatenation() {
+		System.out.println("MLContextTest - print string/single-cell-matrix/string concatenation");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);B=A[2,3];print('five '+B+' seven');";
+		setExpectedStdOut("five 6.0 seven");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintSingleCellMatrixStringSingleCellMatrixConcatenation() {
+		System.out.println("MLContextTest - print single-cell-matrix/string/single-cell-matrix concatenation");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);B=A[2,3];C=A[2,1];print(C+' five '+B);";
+		setExpectedStdOut("4.0 five 6.0");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintMatrix() {
+		System.out.println("MLContextTest - print matrix");
+
+		String s = "A=matrix('1 2 3 4 5 6',rows=2,cols=3);print(A);";
+		setExpectedStdOut("1.000 2.000 3.000"); // or "4.000 5.000 6.000"
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintMatrix2() {
+		System.out.println("MLContextTest - print matrix 2");
+
+		String s = "print(matrix('1 2 3 4',rows=2,cols=2));";
+		setExpectedStdOut("1.000 2.000"); // or "3.000 4.000"
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintStringMatrix() {
+		System.out.println("MLContextTest - print string/matrix");
+
+		// A:1.000 2.000
+		// 3.000 4.000
+		String s = "A=matrix('1 2 3 4',rows=2,cols=2);print('A:'+A);";
+		setExpectedStdOut("A:1.000 2.000");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintMatrixString() {
+		System.out.println("MLContextTest - print matrix/string");
+
+		// 1.000 2.000
+		// 3.000 4.000
+		// !!!
+		String s = "A=matrix('1 2 3 4',rows=2,cols=2);print(A+'!!!');";
+		setExpectedStdOut("1.000 2.000");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintStringMatrixString() {
+		System.out.println("MLContextTest - print string/matrix/string");
+
+		// A:1.000 2.000
+		// 3.000 4.000
+		// !!!
+		String s = "A=matrix('1 2 3 4',rows=2,cols=2);print('A:'+A+'!!!');";
+		setExpectedStdOut("A:1.000 2.000");
+		ml.execute(dml(s));
+	}
+
+	@Test
+	public void testPrintMatrixStringMatrix() {
+		System.out.println("MLContextTest - print matrix/string/matrix");
+
+		// 1.000 1.000
+		// 1.000 1.000
+		// ^^^2.000 2.000
+		// 2.000 2.000
+		String s = "A=matrix(1,rows=2,cols=2);B=matrix(2,rows=2,cols=2);print(A+'^^^'+B);";
+		setExpectedStdOut("^^^2.000 2.000");
+		ml.execute(dml(s));
+	}
+
 	// NOTE: Uncomment these tests once they work
 
 	// @SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
This is a work-in-progress to potentially simplify DML for beginners by removing the need when printing to cast single cells using as.scalar (`print(as.scalar(A[1,1])`) or matrices using toString (`print(toString(A)`). This would allow DML such as `print(A[1,1])` and `print(A)`.

This PR handles the following situations:
```
A = matrix("1 2 3 4 5 6", rows=2, cols=3);
print(as.scalar(A[1,1]));
print(A[1,2]);
print("one two " + A[1,3]);
print(A[2,1] + " five six");
print("four " + A[2,2] + " six");
print(A[1,1] + " two " + A[1,3]);
B = A[2,3];
print(B);
print("five " + B);
print(B + " seven");
print("five " + B + " seven");
C=A[2,1];
print(C+' five '+B);
print(A);
print("$$$" + A);
print(A + "!!!");
print("@@@" + A + "%%%");
D=matrix("1 2 3 4", rows=2, cols=2);
print(D + "***" + A);
print(A[1:2,2:3]);
print("^^^" + A[1:2,2:3]);
print(A[1:2,2:3] + "###");
print("[[[" + A[1:1,1:3] + "]]]");
```

This PR does not handle all potential situations, such as `print(A+B)` where A and B are matrices. However, it is potentially a nice starting point for integrating some of these features or at least for discussion.
