### PR TITLE
[SYSTEMML-1583] [WIP] Read caffemodel using Caffe2DML

### DIFF
--- a/src/main/python/systemml/converters.py
+++ b/src/main/python/systemml/converters.py
@@ -19,7 +19,7 @@
 #
 #-------------------------------------------------------------
 
-__all__ = [ 'getNumCols', 'convertToMatrixBlock', 'convertToNumPyArr', 'convertToPandasDF', 'SUPPORTED_TYPES' , 'convertToLabeledDF', 'convertImageToNumPyArr']
+__all__ = [ 'getNumCols', 'convertToMatrixBlock', 'convert_caffemodel', 'convertToNumPyArr', 'convertToPandasDF', 'SUPPORTED_TYPES' , 'convertToLabeledDF', 'convertImageToNumPyArr']
 
 import numpy as np
 import pandas as pd
@@ -36,6 +36,40 @@ def getNumCols(numPyArr):
     else:
         return numPyArr.shape[1]
 
+def convert_caffemodel(caffe2dmlObj, network_file, caffemodel_file):
+    """
+    Saves the weights and bias in the caffemodel file to output_dir. This method requires caffe to be installed.
+    Parameters
+    ----------
+    caffe2dmlObj: Caffe2DML object
+        Caffe2DML object which should be used for registering the weights and bias
+    
+    network_file: string
+        Path to the input network file
+        
+    caffemodel_file: string
+        Path to the input caffemodel file
+    """
+    import caffe
+    net = caffe.Net(network_file, caffemodel_file, caffe.TEST)
+    for layerName in net.params.keys():
+    num_parameters = len(net.params[layerName])
+    if num_parameters == 0:
+        continue
+    elif num_parameters == 2:
+        # Weights and Biases
+        w = net.params[layerName][0].data
+        w = w.reshape(w.shape[0], -1)
+        b = net.params[layerName][1].data
+        b = b.reshape(b.shape[0], -1)
+        layerType = net.layers[list(net._layer_names).index(layerName)].type
+        if layerType == 'InnerProduct':
+            b = b.T
+            w = w.T
+        caffe2dmlObj.estimator.setInput(layerName + '_bias', convertToMatrixBlock(caffe2dmlObj.sc, b))
+        caffe2dmlObj.estimator.setInput(layerName + '_weight', convertToMatrixBlock(caffe2dmlObj.sc, w))
+    else:
+        raise ValueError('Unsupported number of parameters:' + str(num_parameters))
 
 def convertToLabeledDF(sparkSession, X, y=None):
     from pyspark.ml.feature import VectorAssembler

--- a/src/main/python/systemml/converters.py
+++ b/src/main/python/systemml/converters.py
@@ -53,23 +53,23 @@ def convert_caffemodel(caffe2dmlObj, network_file, caffemodel_file):
     import caffe
     net = caffe.Net(network_file, caffemodel_file, caffe.TEST)
     for layerName in net.params.keys():
-    num_parameters = len(net.params[layerName])
-    if num_parameters == 0:
-        continue
-    elif num_parameters == 2:
-        # Weights and Biases
-        w = net.params[layerName][0].data
-        w = w.reshape(w.shape[0], -1)
-        b = net.params[layerName][1].data
-        b = b.reshape(b.shape[0], -1)
-        layerType = net.layers[list(net._layer_names).index(layerName)].type
-        if layerType == 'InnerProduct':
-            b = b.T
-            w = w.T
-        caffe2dmlObj.estimator.setInput(layerName + '_bias', convertToMatrixBlock(caffe2dmlObj.sc, b))
-        caffe2dmlObj.estimator.setInput(layerName + '_weight', convertToMatrixBlock(caffe2dmlObj.sc, w))
-    else:
-        raise ValueError('Unsupported number of parameters:' + str(num_parameters))
+        num_parameters = len(net.params[layerName])
+        if num_parameters == 0:
+            continue
+        elif num_parameters == 2:
+            # Weights and Biases
+            w = net.params[layerName][0].data
+            w = w.reshape(w.shape[0], -1)
+            b = net.params[layerName][1].data
+            b = b.reshape(b.shape[0], -1)
+            layerType = net.layers[list(net._layer_names).index(layerName)].type
+            if layerType == 'InnerProduct':
+                b = b.T
+                w = w.T
+            caffe2dmlObj.estimator.setInput(layerName + '_bias', convertToMatrixBlock(caffe2dmlObj.sc, b))
+            caffe2dmlObj.estimator.setInput(layerName + '_weight', convertToMatrixBlock(caffe2dmlObj.sc, w))
+        else:
+            raise ValueError('Unsupported number of parameters:' + str(num_parameters))
 
 def convertToLabeledDF(sparkSession, X, y=None):
     from pyspark.ml.feature import VectorAssembler

--- a/src/main/python/systemml/converters.py
+++ b/src/main/python/systemml/converters.py
@@ -66,8 +66,8 @@ def convert_caffemodel(caffe2dmlObj, network_file, caffemodel_file):
             if layerType == 'InnerProduct':
                 b = b.T
                 w = w.T
-            caffe2dmlObj.estimator.setInput(layerName + '_bias', convertToMatrixBlock(caffe2dmlObj.sc, b))
-            caffe2dmlObj.estimator.setInput(layerName + '_weight', convertToMatrixBlock(caffe2dmlObj.sc, w))
+            caffe2dmlObj.estimator.setInputMatrixBlock(layerName + '_bias', convertToMatrixBlock(caffe2dmlObj.sc, b))
+            caffe2dmlObj.estimator.setInputMatrixBlock(layerName + '_weight', convertToMatrixBlock(caffe2dmlObj.sc, w))
         else:
             raise ValueError('Unsupported number of parameters:' + str(num_parameters))
 

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -637,6 +637,7 @@ class Caffe2DML(BaseSystemMLClassifier):
                 network_file_path = unicodedata.normalize('NFKD', self.estimator.getNetworkFilePath()).encode('ascii','ignore')
             else:
                 network_file_path = deploy_net
+            self.model = self.sc._jvm.org.apache.sysml.api.dl.Caffe2DMLModel(self.estimator)
             convert_caffemodel(self, network_file_path, weights)
         elif weights is not None:
             self.estimator.setInput("$weights", str(weights))

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -606,7 +606,7 @@ class Caffe2DML(BaseSystemMLClassifier):
     >>> caffe2DML = Caffe2DML(sqlCtx, 'lenet_solver.proto').set(max_iter=500)
     >>> caffe2DML.fit(X, y)
     """
-    def __init__(self, sqlCtx, solver, input_shape, weights=None, deployNet=None, ignore_weights=None, transferUsingDF=False, tensorboard_log_dir=None):
+    def __init__(self, sqlCtx, solver, input_shape, weights=None, deploy_net=None, ignore_weights=None, transferUsingDF=False, tensorboard_log_dir=None):
         """
         Performs training/prediction for a given caffe network. 
 
@@ -616,7 +616,7 @@ class Caffe2DML(BaseSystemMLClassifier):
         solver: caffe solver file path
         input_shape: 3-element list (number of channels, input height, input width)
         weights: directory whether learned weights are stored (default: None)
-        deployNet: optional deploy network used if weights are passed as .caffemodel (default: None)
+        deploy_net: optional deploy network used if weights are passed as .caffemodel (default: None)
         ignore_weights: names of layers to not read from the weights directory (list of string, default:None)
         transferUsingDF: whether to pass the input dataset via PySpark DataFrame (default: False)
         tensorboard_log_dir: directory to store the event logs (default: None, we use a temporary directory)
@@ -632,12 +632,12 @@ class Caffe2DML(BaseSystemMLClassifier):
         self.estimator = self.sc._jvm.org.apache.sysml.api.dl.Caffe2DML(self.sc._jsc.sc(), solver, str(input_shape[0]), str(input_shape[1]), str(input_shape[2]))
         self.weights = weights
         if weights is not None and weights.endswith('.caffemodel'):
-            if deployNet is None:
+            if deploy_net is None:
                 import unicodedata
-                networkFilePath = unicodedata.normalize('NFKD', self.estimator.getNetworkFilePath()).encode('ascii','ignore')
+                network_file_path = unicodedata.normalize('NFKD', self.estimator.getNetworkFilePath()).encode('ascii','ignore')
             else:
-                networkFilePath = deployNet
-            convert_caffemodel(self.estimator, networkFilePath, weights)
+                network_file_path = deploy_net
+            convert_caffemodel(self.estimator, network_file_path, weights)
         elif weights is not None:
             self.estimator.setInput("$weights", str(weights))
             self._loadLabelTxt()

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -606,7 +606,7 @@ class Caffe2DML(BaseSystemMLClassifier):
     >>> caffe2DML = Caffe2DML(sqlCtx, 'lenet_solver.proto').set(max_iter=500)
     >>> caffe2DML.fit(X, y)
     """
-    def __init__(self, sqlCtx, solver, input_shape, weights=None, ignore_weights=None, transferUsingDF=False, tensorboard_log_dir=None):
+    def __init__(self, sqlCtx, solver, input_shape, weights=None, deployNet=None, ignore_weights=None, transferUsingDF=False, tensorboard_log_dir=None):
         """
         Performs training/prediction for a given caffe network. 
 
@@ -616,6 +616,7 @@ class Caffe2DML(BaseSystemMLClassifier):
         solver: caffe solver file path
         input_shape: 3-element list (number of channels, input height, input width)
         weights: directory whether learned weights are stored (default: None)
+        deployNet: optional deploy network used if weights are passed as .caffemodel (default: None)
         ignore_weights: names of layers to not read from the weights directory (list of string, default:None)
         transferUsingDF: whether to pass the input dataset via PySpark DataFrame (default: False)
         tensorboard_log_dir: directory to store the event logs (default: None, we use a temporary directory)
@@ -631,8 +632,11 @@ class Caffe2DML(BaseSystemMLClassifier):
         self.estimator = self.sc._jvm.org.apache.sysml.api.dl.Caffe2DML(self.sc._jsc.sc(), solver, str(input_shape[0]), str(input_shape[1]), str(input_shape[2]))
         self.weights = weights
         if weights is not None and weights.endswith('.caffemodel'):
-            import unicodedata
-            networkFilePath = unicodedata.normalize('NFKD', self.estimator.getNetworkFilePath()).encode('ascii','ignore')
+            if deployNet is None:
+                import unicodedata
+                networkFilePath = unicodedata.normalize('NFKD', self.estimator.getNetworkFilePath()).encode('ascii','ignore')
+            else:
+                networkFilePath = deployNet
             convert_caffemodel(self.estimator, networkFilePath, weights)
         elif weights is not None:
             self.estimator.setInput("$weights", str(weights))

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -631,7 +631,9 @@ class Caffe2DML(BaseSystemMLClassifier):
         self.estimator = self.sc._jvm.org.apache.sysml.api.dl.Caffe2DML(self.sc._jsc.sc(), solver, str(input_shape[0]), str(input_shape[1]), str(input_shape[2]))
         self.weights = weights
         if weights is not None and weights.endswith('.caffemodel'):
-            convert_caffemodel(self.estimator, self.estimator.getNetworkFilePath(), weights)
+            import unicodedata
+            networkFilePath = unicodedata.normalize('NFKD', self.estimator.getNetworkFilePath()).encode('ascii','ignore')
+            convert_caffemodel(self.estimator, networkFilePath, weights)
         elif weights is not None:
             self.estimator.setInput("$weights", str(weights))
             self._loadLabelTxt()

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -276,8 +276,10 @@ class BaseSystemMLClassifier(BaseSystemMLEstimator):
     def decode(self, y):
         if self.le is not None:
             return self.le.inverse_transform(np.asarray(y - 1, dtype=int))
-        else:
+        elif self.labelMap is not None:
             return [ self.labelMap[int(i)] for i in y ]
+        else:
+            return y
         
     def predict(self, X):
         predictions = np.asarray(super(BaseSystemMLClassifier, self).predict(X))
@@ -639,6 +641,8 @@ class Caffe2DML(BaseSystemMLClassifier):
                 network_file_path = deploy_net
             self.model = self.sc._jvm.org.apache.sysml.api.dl.Caffe2DMLModel(self.estimator)
             convert_caffemodel(self, network_file_path, weights)
+            self.le = None
+            self.labelMap = None
         elif weights is not None:
             self.estimator.setInput("$weights", str(weights))
             self._loadLabelTxt()

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -661,8 +661,8 @@ class Caffe2DML(BaseSystemMLClassifier):
     def _loadLabelTxt(self, labels=None, format="binary", sep="/"):
         self.model = self.sc._jvm.org.apache.sysml.api.dl.Caffe2DMLModel(self.estimator)
         if labels is not None:
-            df = self.sqlCtx.read.csv(self.weights + sep + 'labels.txt', header=False).toPandas()
-        elif(self.weights is not None):
+            df = self.sqlCtx.read.csv(labels, header=False).toPandas()
+        elif self.weights is not None:
             df = self.sqlCtx.read.csv(self.weights + sep + 'labels.txt', header=False).toPandas()
         else:
             raise ValueError('Either labels or weights should be not None')

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -630,7 +630,9 @@ class Caffe2DML(BaseSystemMLClassifier):
         solver = self.sc._jvm.org.apache.sysml.api.dl.Utils.readCaffeSolver(solver)
         self.estimator = self.sc._jvm.org.apache.sysml.api.dl.Caffe2DML(self.sc._jsc.sc(), solver, str(input_shape[0]), str(input_shape[1]), str(input_shape[2]))
         self.weights = weights
-        if weights is not None:
+        if weights is not None and weights.endswith('.caffemodel'):
+            convert_caffemodel(self.estimator, self.estimator.getNetworkFilePath(), weights)
+        elif weights is not None:
             self.estimator.setInput("$weights", str(weights))
             self._loadLabelTxt()
             if ignore_weights is not None:

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -645,8 +645,6 @@ class Caffe2DML(BaseSystemMLClassifier):
             start_time = time.time()
             convert_caffemodel(self, network_file_path, weights)
             print("Time to read caffemodel = %s seconds." % (time.time() - start_time))
-            self.le = None
-            self.labelMap = None
         elif weights is not None:
             self.estimator.setInput("$weights", str(weights))
             self._loadLabelTxt()

--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -637,7 +637,7 @@ class Caffe2DML(BaseSystemMLClassifier):
                 network_file_path = unicodedata.normalize('NFKD', self.estimator.getNetworkFilePath()).encode('ascii','ignore')
             else:
                 network_file_path = deploy_net
-            convert_caffemodel(self.estimator, network_file_path, weights)
+            convert_caffemodel(self, network_file_path, weights)
         elif weights is not None:
             self.estimator.setInput("$weights", str(weights))
             self._loadLabelTxt()

--- a/src/main/scala/org/apache/sysml/api/dl/Caffe2DML.scala
+++ b/src/main/scala/org/apache/sysml/api/dl/Caffe2DML.scala
@@ -99,6 +99,9 @@ class Caffe2DML(val sc: SparkContext, val solverParam:Caffe.SolverParameter,
     val ret = baseFit(df, sc)
     new Caffe2DMLModel(ret, Utils.numClasses(net), sc, solver, net, lrPolicy, this)
   }
+  
+  def getNetworkFilePath():String = solverParam.getNet
+  def getOutputNumClasses(): String = Utils.numClasses(net)
 	// --------------------------------------------------------------
   
   // Used for simplifying transfer learning
@@ -312,6 +315,11 @@ class Caffe2DML(val sc: SparkContext, val solverParam:Caffe.SolverParameter,
 		  net.getLayers.filter(l => !layersToIgnore.contains(l)).map(net.getCaffeLayer(_)).filter(_.weight != null).map(l => tabDMLScript.append(read(l.weight, l.param.getName + "_weight.mtx")))
 		  net.getLayers.filter(l => !layersToIgnore.contains(l)).map(net.getCaffeLayer(_)).filter(_.bias != null).map(l => tabDMLScript.append(read(l.bias, l.param.getName + "_bias.mtx")))
 	  }
+	  else if(registeredInputs.size() > 0) {
+	    // Called by .caffemodel
+	    net.getLayers.filter(l => !layersToIgnore.contains(l)).map(net.getCaffeLayer(_)).filter(_.weight != null).map(l => tabDMLScript.append(l.weight + " = " + l.param.getName + "_weight"))
+	    net.getLayers.filter(l => !layersToIgnore.contains(l)).map(net.getCaffeLayer(_)).filter(_.bias != null).map(l => tabDMLScript.append(l.bias + " = " + l.param.getName + "_bias"))
+	  }
 	  net.getLayers.map(layer => solver.init(tabDMLScript, net.getCaffeLayer(layer)))
 	  
 	  // Split into training and validation set
@@ -446,6 +454,12 @@ class Caffe2DMLModel(val mloutput: MLResults,
 		  // fit was not called
 		  net.getLayers.map(net.getCaffeLayer(_)).filter(_.weight != null).map(l => tabDMLScript.append(read(l.weight, l.param.getName + "_weight.mtx")))
 		  net.getLayers.map(net.getCaffeLayer(_)).filter(_.bias != null).map(l => tabDMLScript.append(read(l.bias, l.param.getName + "_bias.mtx")))
+	  }
+	  else if(estimator.registeredInputs.size() > 0) {
+	    // Called by .caffemodel
+	    net.getLayers.map(net.getCaffeLayer(_)).filter(_.weight != null).map(l => tabDMLScript.append(l.weight + " = " + l.param.getName + "_weight"))
+		  net.getLayers.map(net.getCaffeLayer(_)).filter(_.bias != null).map(l => tabDMLScript.append(l.bias + " = " +  l.param.getName + "_bias"))
+	    
 	  }
 	  else if(mloutput == null) {
 		  throw new DMLRuntimeException("Cannot call predict/score without calling either fit or by providing weights")

--- a/src/main/scala/org/apache/sysml/api/dl/Caffe2DML.scala
+++ b/src/main/scala/org/apache/sysml/api/dl/Caffe2DML.scala
@@ -317,8 +317,8 @@ class Caffe2DML(val sc: SparkContext, val solverParam:Caffe.SolverParameter,
 	  }
 	  else if(registeredInputs.size() > 0) {
 	    // Called by .caffemodel
-	    net.getLayers.filter(l => !layersToIgnore.contains(l)).map(net.getCaffeLayer(_)).filter(_.weight != null).map(l => tabDMLScript.append(l.weight + " = " + l.param.getName + "_weight"))
-	    net.getLayers.filter(l => !layersToIgnore.contains(l)).map(net.getCaffeLayer(_)).filter(_.bias != null).map(l => tabDMLScript.append(l.bias + " = " + l.param.getName + "_bias"))
+	    net.getLayers.filter(l => !layersToIgnore.contains(l)).map(net.getCaffeLayer(_)).filter(_.weight != null).map(l => tabDMLScript.append(l.weight + " = " + l.param.getName + "_weight" + "\n"))
+	    net.getLayers.filter(l => !layersToIgnore.contains(l)).map(net.getCaffeLayer(_)).filter(_.bias != null).map(l => tabDMLScript.append(l.bias + " = " + l.param.getName + "_bias" + "\n"))
 	  }
 	  net.getLayers.map(layer => solver.init(tabDMLScript, net.getCaffeLayer(layer)))
 	  
@@ -457,8 +457,8 @@ class Caffe2DMLModel(val mloutput: MLResults,
 	  }
 	  else if(estimator.registeredInputs.size() > 0) {
 	    // Called by .caffemodel
-	    net.getLayers.map(net.getCaffeLayer(_)).filter(_.weight != null).map(l => tabDMLScript.append(l.weight + " = " + l.param.getName + "_weight"))
-		  net.getLayers.map(net.getCaffeLayer(_)).filter(_.bias != null).map(l => tabDMLScript.append(l.bias + " = " +  l.param.getName + "_bias"))
+	    net.getLayers.map(net.getCaffeLayer(_)).filter(_.weight != null).map(l => tabDMLScript.append(l.weight + " = " + l.param.getName + "_weight" + "\n"))
+		  net.getLayers.map(net.getCaffeLayer(_)).filter(_.bias != null).map(l => tabDMLScript.append(l.bias + " = " +  l.param.getName + "_bias" + "\n"))
 	    
 	  }
 	  else if(mloutput == null) {

--- a/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
@@ -81,7 +81,7 @@ trait BaseSystemMLEstimatorOrModel {
   def setStatistics(statistics1:Boolean):BaseSystemMLEstimatorOrModel = { statistics = statistics1; this}
   def setStatisticsMaxHeavyHitters(statisticsMaxHeavyHitters1:Int):BaseSystemMLEstimatorOrModel = { statisticsMaxHeavyHitters = statisticsMaxHeavyHitters1; this}
   def setConfigProperty(key:String, value:String):BaseSystemMLEstimatorOrModel = { config.put(key, value); this}
-  def setInput(key:String, mb:MatrixBlock): BaseSystemMLEstimatorOrModel = { registeredInputs.put(key, mb); this}
+  def setInputMatrixBlock(key:String, mb:MatrixBlock): BaseSystemMLEstimatorOrModel = { registeredInputs.put(key, mb); this}
   def updateML(ml:MLContext):Unit = {
     ml.setGPU(enableGPU); ml.setForceGPU(forceGPU);
     ml.setExplain(explain); ml.setStatistics(statistics); ml.setStatisticsMaxHeavyHitters(statisticsMaxHeavyHitters); 
@@ -91,7 +91,7 @@ trait BaseSystemMLEstimatorOrModel {
     other.setGPU(enableGPU); other.setForceGPU(forceGPU);
     other.setExplain(explain); other.setStatistics(statistics); other.setStatisticsMaxHeavyHitters(statisticsMaxHeavyHitters);
     config.map(x => other.setConfigProperty(x._1, x._2))
-    registeredInputs.map(x => other.setInput(x._1, x._2))
+    registeredInputs.map(x => other.setInputMatrixBlock(x._1, x._2))
     return other
   }
 }

--- a/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
+++ b/src/main/scala/org/apache/sysml/api/ml/BaseSystemMLClassifier.scala
@@ -74,12 +74,14 @@ trait BaseSystemMLEstimatorOrModel {
   var statistics:Boolean = false
   var statisticsMaxHeavyHitters:Int = 10
   val config:HashMap[String, String] = new HashMap[String, String]()
+  val registeredInputs:HashMap[String, MatrixBlock] = new HashMap[String, MatrixBlock]()
   def setGPU(enableGPU1:Boolean):BaseSystemMLEstimatorOrModel = { enableGPU = enableGPU1; this}
   def setForceGPU(enableGPU1:Boolean):BaseSystemMLEstimatorOrModel = { forceGPU = enableGPU1; this}
   def setExplain(explain1:Boolean):BaseSystemMLEstimatorOrModel = { explain = explain1; this}
   def setStatistics(statistics1:Boolean):BaseSystemMLEstimatorOrModel = { statistics = statistics1; this}
   def setStatisticsMaxHeavyHitters(statisticsMaxHeavyHitters1:Int):BaseSystemMLEstimatorOrModel = { statisticsMaxHeavyHitters = statisticsMaxHeavyHitters1; this}
   def setConfigProperty(key:String, value:String):BaseSystemMLEstimatorOrModel = { config.put(key, value); this}
+  def setInput(key:String, mb:MatrixBlock): BaseSystemMLEstimatorOrModel = { registeredInputs.put(key, mb); this}
   def updateML(ml:MLContext):Unit = {
     ml.setGPU(enableGPU); ml.setForceGPU(forceGPU);
     ml.setExplain(explain); ml.setStatistics(statistics); ml.setStatisticsMaxHeavyHitters(statisticsMaxHeavyHitters); 
@@ -89,6 +91,7 @@ trait BaseSystemMLEstimatorOrModel {
     other.setGPU(enableGPU); other.setForceGPU(forceGPU);
     other.setExplain(explain); other.setStatistics(statistics); other.setStatisticsMaxHeavyHitters(statisticsMaxHeavyHitters);
     config.map(x => other.setConfigProperty(x._1, x._2))
+    registeredInputs.map(x => other.setInput(x._1, x._2))
     return other
   }
 }
@@ -131,6 +134,7 @@ trait BaseSystemMLClassifier extends BaseSystemMLEstimator {
     y_mb.recomputeNonZeros();
     val ret = getTrainingScript(isSingleNode)
     val script = ret._1.in(ret._2, X_mb).in(ret._3, y_mb)
+    registeredInputs.map(x => script.in(x._1, x._2))
     ml.execute(script)
   }
   def baseFit(df: ScriptsUtils.SparkDataType, sc: SparkContext): MLResults = {
@@ -144,6 +148,7 @@ trait BaseSystemMLClassifier extends BaseSystemMLEstimator {
     val ret = getTrainingScript(isSingleNode)
     val Xbin = new BinaryBlockMatrix(Xin, mcXin)
     val script = ret._1.in(ret._2, Xbin).in(ret._3, yin)
+    registeredInputs.map(x => script.in(x._1, x._2))
     ml.execute(script)
   }
 }
@@ -155,6 +160,7 @@ trait BaseSystemMLClassifierModel extends BaseSystemMLEstimatorModel {
     val ml = new MLContext(sc)
     updateML(ml)
     val script = getPredictionScript(mloutput, isSingleNode)
+    registeredInputs.map(x => script._1.in(x._1, x._2))
     // Uncomment for debugging
     // ml.setExplainLevel(ExplainLevel.RECOMPILE_RUNTIME)
     val modelPredict = ml.execute(script._1.in(script._2, X, new MatrixMetadata(X.getNumRows, X.getNumColumns, X.getNonZeros)))
@@ -175,6 +181,7 @@ trait BaseSystemMLClassifierModel extends BaseSystemMLEstimatorModel {
     val mcXin = new MatrixCharacteristics()
     val Xin = RDDConverterUtils.dataFrameToBinaryBlock(df.rdd.sparkContext, df.asInstanceOf[DataFrame].select("features"), mcXin, false, true)
     val script = getPredictionScript(mloutput, isSingleNode)
+    registeredInputs.map(x => script._1.in(x._1, x._2))
     val Xin_bin = new BinaryBlockMatrix(Xin, mcXin)
     val modelPredict = ml.execute(script._1.in(script._2, Xin_bin))
     val predLabelOut = PredictionUtils.computePredictedClassLabelsFromProbability(modelPredict, isSingleNode, sc, probVar)


### PR DESCRIPTION
This PR will serve as placeholder for discussion, so please donot merge.

- This PR doesnot resolve SYSTEMML-1583 as it still requires [caffe](https://github.com/niketanpansare/incubator-systemml/blob/prep_caffemodel/src/main/python/systemml/converters.py#L53) to be installed.
- This PR converts the numpy array from caffemode directly to MatrixBlock. This works well if the array is reasonably small, but if the array is very large, then it could take long time due to P4J (~45 seconds for converting VGG model to MatrixBlocks). Also, this approach requires large driver memory.

```python
# pyspark --driver-memory 10g
from systemml.mllearn import Caffe2DML
from pyspark.sql import SQLContext
import numpy as np
import urllib, os, scipy.ndimage
from PIL import Image
import systemml as sml

# ImageNet specific parameters
img_shape = (3, 224, 224)
num_classes = 1000

# Downloads a jpg image, resizes it to 224 and return as numpy array in N X CHW format
url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/58/MountainLion.jpg/312px-MountainLion.jpg'
outFile = 'test.jpg'
urllib.urlretrieve(url, outFile)
input_image = sml.convertImageToNumPyArr(Image.open(outFile), img_shape=img_shape)

# Download the proto files for VGG network
#urllib.urlretrieve('http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_16_layers.caffemodel', 'VGG_ILSVRC_16_layers.caffemodel')
urllib.urlretrieve('https://raw.githubusercontent.com/niketanpansare/model_zoo/master/caffe/vision/vgg/ilsvrc12/VGG_ILSVRC_19_layers_solver.proto', 'VGG_ILSVRC_19_layers_solver.proto')
urllib.urlretrieve('https://raw.githubusercontent.com/niketanpansare/model_zoo/master/caffe/vision/vgg/ilsvrc12/VGG_ILSVRC_19_layers_network.proto', 'VGG_ILSVRC_19_layers_network.proto')
urllib.urlretrieve('https://raw.githubusercontent.com/niketanpansare/model_zoo/master/caffe/vision/vgg/ilsvrc12/VGG_ILSVRC_19_layers_deploy.prototxt', 'VGG_ILSVRC_19_layers_deploy.prototxt')
urllib.urlretrieve('https://raw.githubusercontent.com/niketanpansare/model_zoo/master/caffe/vision/vgg/ilsvrc12/VGG_ILSVRC_19_pretrained_weights/labels.txt', 'labels.txt')

# Load the pretrained model and predict the downloaded image
home_dir = os.path.expanduser('~')
vgg_pretrained_weight_dir = os.path.join(home_dir, 'VGG_trained_models', 'VGG_ILSVRC_19_layers.caffemodel')
vgg = Caffe2DML(sqlCtx, solver='VGG_ILSVRC_19_layers_solver.proto', deploy_net='VGG_ILSVRC_19_layers_deploy.prototxt', labels='labels.txt', weights=vgg_pretrained_weight_dir, input_shape=img_shape)
vgg.predict(input_image)
```

@frreiss @asurve @bertholdreinwald  @dusenberrymw 