### PR TITLE
[SYSTEMML-1662] Extend Hop Validator

### DIFF
--- a/src/main/java/org/apache/sysml/hops/AggBinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/AggBinaryOp.java
@@ -115,7 +115,12 @@ public class AggBinaryOp extends Hop implements MultiThreadedHop
 		//compute unknown dims and nnz
 		refreshSizeInformation();
 	}
-	
+
+	@Override
+	public int getArity() {
+		return 2;
+	}
+
 	public void setHasLeftPMInput(boolean flag) {
 		_hasLeftPMInput = flag;
 	}

--- a/src/main/java/org/apache/sysml/hops/AggBinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/AggBinaryOp.java
@@ -118,8 +118,7 @@ public class AggBinaryOp extends Hop implements MultiThreadedHop
 
 	@Override
 	public void checkArity() throws HopsException {
-		int sz = _input.size();
-		HopsException.check(sz == 2, this, "should have arity 2 but has arity %d", sz);
+		HopsException.check(_input.size() == 2, this, "should have arity 2 but has arity %d", _input.size());
 	}
 
 	public void setHasLeftPMInput(boolean flag) {

--- a/src/main/java/org/apache/sysml/hops/AggBinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/AggBinaryOp.java
@@ -117,8 +117,9 @@ public class AggBinaryOp extends Hop implements MultiThreadedHop
 	}
 
 	@Override
-	public int getArity() {
-		return 2;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		HopsException.check(sz == 2, this, "should have arity 2 but has arity %d", sz);
 	}
 
 	public void setHasLeftPMInput(boolean flag) {

--- a/src/main/java/org/apache/sysml/hops/AggUnaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/AggUnaryOp.java
@@ -72,7 +72,12 @@ public class AggUnaryOp extends Hop implements MultiThreadedHop
 		getInput().add(0, inp);
 		inp.getParent().add(this);
 	}
-	
+
+	@Override
+	public int getArity() {
+		return 1;
+	}
+
 	public AggOp getOp()
 	{
 		return _op;

--- a/src/main/java/org/apache/sysml/hops/AggUnaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/AggUnaryOp.java
@@ -75,8 +75,7 @@ public class AggUnaryOp extends Hop implements MultiThreadedHop
 
 	@Override
 	public void checkArity() throws HopsException {
-		int sz = _input.size();
-		HopsException.check(sz == 1, this, "should have arity 1 but has arity %d", sz);
+		HopsException.check(_input.size() == 1, this, "should have arity 1 but has arity %d", _input.size());
 	}
 
 	public AggOp getOp()

--- a/src/main/java/org/apache/sysml/hops/AggUnaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/AggUnaryOp.java
@@ -74,8 +74,9 @@ public class AggUnaryOp extends Hop implements MultiThreadedHop
 	}
 
 	@Override
-	public int getArity() {
-		return 1;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		HopsException.check(sz == 1, this, "should have arity 1 but has arity %d", sz);
 	}
 
 	public AggOp getOp()

--- a/src/main/java/org/apache/sysml/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/BinaryOp.java
@@ -111,6 +111,11 @@ public class BinaryOp extends Hop
 		refreshSizeInformation();
 	}
 
+	@Override
+	public int getArity() {
+		return 2;
+	}
+
 	public OpOp2 getOp() {
 		return op;
 	}

--- a/src/main/java/org/apache/sysml/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/BinaryOp.java
@@ -112,8 +112,9 @@ public class BinaryOp extends Hop
 	}
 
 	@Override
-	public int getArity() {
-		return 2;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		HopsException.check(sz == 2, this, "should have arity 2 but has arity %d", sz);
 	}
 
 	public OpOp2 getOp() {

--- a/src/main/java/org/apache/sysml/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/BinaryOp.java
@@ -113,8 +113,7 @@ public class BinaryOp extends Hop
 
 	@Override
 	public void checkArity() throws HopsException {
-		int sz = _input.size();
-		HopsException.check(sz == 2, this, "should have arity 2 but has arity %d", sz);
+		HopsException.check(_input.size() == 2, this, "should have arity 2 but has arity %d", _input.size());
 	}
 
 	public OpOp2 getOp() {

--- a/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
+++ b/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
@@ -59,6 +59,11 @@ public class ConvolutionOp extends Hop  implements MultiThreadedHop
 		refreshSizeInformation();
 	}
 
+	@Override
+	public int getArity() {
+		return -1;
+	}
+
 	public ConvOp getOp()
 	{
 		return op;

--- a/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
+++ b/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
@@ -61,8 +61,7 @@ public class ConvolutionOp extends Hop  implements MultiThreadedHop
 
 	@Override
 	public void checkArity() throws HopsException {
-		int sz = _input.size();
-		HopsException.check(sz >= 1, this, "should have at least one input but has %d inputs", sz);
+		HopsException.check(_input.size() >= 1, this, "should have at least one input but has %d inputs", _input.size());
 	}
 
 	public ConvOp getOp()

--- a/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
+++ b/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
@@ -60,8 +60,9 @@ public class ConvolutionOp extends Hop  implements MultiThreadedHop
 	}
 
 	@Override
-	public int getArity() {
-		return -1;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		HopsException.check(sz >= 1, this, "should have at least one input but has %d inputs", sz);
 	}
 
 	public ConvOp getOp()

--- a/src/main/java/org/apache/sysml/hops/DataGenOp.java
+++ b/src/main/java/org/apache/sysml/hops/DataGenOp.java
@@ -113,7 +113,12 @@ public class DataGenOp extends Hop implements MultiThreadedHop
 		//compute unknown dims and nnz
 		refreshSizeInformation();
 	}
-	
+
+	@Override
+	public int getArity() {
+		return -1;
+	}
+
 	@Override
 	public String getOpString() {
 		return "dg(" + _op.toString().toLowerCase() +")";

--- a/src/main/java/org/apache/sysml/hops/DataGenOp.java
+++ b/src/main/java/org/apache/sysml/hops/DataGenOp.java
@@ -38,6 +38,10 @@ import org.apache.sysml.parser.Expression.ValueType;
 import org.apache.sysml.parser.Statement;
 import org.apache.sysml.runtime.controlprogram.parfor.ProgramConverter;
 
+/**
+ * A DataGenOp can be rand (or matrix constructor), sequence, and sample -
+ * these operators have different parameters and use a map of parameter type to hop position.
+ */
 public class DataGenOp extends Hop implements MultiThreadedHop
 {
 	
@@ -115,8 +119,10 @@ public class DataGenOp extends Hop implements MultiThreadedHop
 	}
 
 	@Override
-	public int getArity() {
-		return -1;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		int pz = _paramIndexMap.size();
+		HopsException.check(sz == pz, this, "has %d inputs but %d parameters", sz, pz);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysml/hops/DataOp.java
+++ b/src/main/java/org/apache/sysml/hops/DataOp.java
@@ -182,7 +182,12 @@ public class DataOp extends Hop
 		if (dop == DataOpTypes.TRANSIENTWRITE)
 			setInputFormatType(FileFormatTypes.BINARY);
 	}
-	
+
+	@Override
+	public int getArity() {
+		return -1;
+	}
+
 	public DataOpTypes getDataOpType()
 	{
 		return _dataop;

--- a/src/main/java/org/apache/sysml/hops/DataOp.java
+++ b/src/main/java/org/apache/sysml/hops/DataOp.java
@@ -195,15 +195,15 @@ public class DataOp extends Hop
 		case PERSISTENTREAD:
 		case TRANSIENTREAD:
 			HopsException.check(sz == pz, this,
-					"in %s mode has %d inputs and %d parameters",
-					_dataop, sz, pz);
+					"in %s operator type has %d inputs and %d parameters",
+					_dataop.name(), sz, pz);
 			break;
 		case PERSISTENTWRITE:
 		case TRANSIENTWRITE:
 		case FUNCTIONOUTPUT:
 			HopsException.check(sz == pz + 1, this,
-					"in %s mode has %d inputs and %d parameters (expect 1 more input for write mode)",
-					_dataop, sz, pz);
+					"in %s operator type has %d inputs and %d parameters (expect 1 more input for write operator type)",
+					_dataop.name(), sz, pz);
 			break;
 		}
 	}

--- a/src/main/java/org/apache/sysml/hops/FunctionOp.java
+++ b/src/main/java/org/apache/sysml/hops/FunctionOp.java
@@ -79,7 +79,12 @@ public class FunctionOp extends Hop
 			in.getParent().add(this);
 		}
 	}
-	
+
+	@Override
+	public int getArity() {
+		return -1;
+	}
+
 	public String getFunctionNamespace()
 	{
 		return _fnamespace;

--- a/src/main/java/org/apache/sysml/hops/FunctionOp.java
+++ b/src/main/java/org/apache/sysml/hops/FunctionOp.java
@@ -80,10 +80,9 @@ public class FunctionOp extends Hop
 		}
 	}
 
+	/** FunctionOps may have any number of inputs. */
 	@Override
-	public int getArity() {
-		return -1;
-	}
+	public void checkArity() throws HopsException {}
 
 	public String getFunctionNamespace()
 	{

--- a/src/main/java/org/apache/sysml/hops/Hop.java
+++ b/src/main/java/org/apache/sysml/hops/Hop.java
@@ -78,8 +78,8 @@ public abstract class Hop
 	protected long _nnz = -1;
 	protected UpdateType _updateType = UpdateType.COPY;
 
-	protected ArrayList<Hop> _parent = new ArrayList<Hop>();
-	protected ArrayList<Hop> _input = new ArrayList<Hop>();
+	protected ArrayList<Hop> _parent = new ArrayList<>();
+	protected ArrayList<Hop> _input = new ArrayList<>(getArity() == -1 ? 5 : getArity());
 
 	protected ExecType _etype = null; //currently used exec type
 	protected ExecType _etypeForced = null; //exec type forced via platform or external optimizer
@@ -135,6 +135,12 @@ public abstract class Hop
 	public long getHopID() {
 		return _ID;
 	}
+
+	/**
+	 * Each Hop has an expected number of inputs.
+	 * Use -1 if this Hop has an unknown number of inputs, as in {@link MultipleOp}.
+	 */
+	public abstract int getArity();
 	
 	public ExecType getExecType()
 	{

--- a/src/main/java/org/apache/sysml/hops/Hop.java
+++ b/src/main/java/org/apache/sysml/hops/Hop.java
@@ -78,8 +78,8 @@ public abstract class Hop
 	protected long _nnz = -1;
 	protected UpdateType _updateType = UpdateType.COPY;
 
-	protected ArrayList<Hop> _parent = new ArrayList<>();
-	protected ArrayList<Hop> _input = new ArrayList<>(getArity() == -1 ? 5 : getArity());
+	protected ArrayList<Hop> _parent = new ArrayList<>(5);
+	protected ArrayList<Hop> _input = new ArrayList<>(5);
 
 	protected ExecType _etype = null; //currently used exec type
 	protected ExecType _etypeForced = null; //exec type forced via platform or external optimizer
@@ -137,10 +137,16 @@ public abstract class Hop
 	}
 
 	/**
-	 * Each Hop has an expected number of inputs.
-	 * Use -1 if this Hop has an unknown number of inputs, as in {@link MultipleOp}.
+	 * Check whether this Hop has a correct number of inputs.
+	 *
+	 * (Some Hops can have a variable number of inputs, such as DataOp, DataGenOp, ParameterizedBuiltinOp,
+	 * ReorgOp, TernaryOp, QuaternaryOp, MultipleOp, ConvolutionOp, and SpoofFusedOp.)
+	 *
+	 * Parameterized Hops (such as DataOp) can check that the number of parameters matches the number of inputs.
+	 *
+	 * @throws HopsException if this Hop has an illegal number of inputs (a kind of Illegal State)
 	 */
-	public abstract int getArity();
+	public abstract void checkArity() throws HopsException;
 	
 	public ExecType getExecType()
 	{

--- a/src/main/java/org/apache/sysml/hops/Hop.java
+++ b/src/main/java/org/apache/sysml/hops/Hop.java
@@ -78,8 +78,8 @@ public abstract class Hop
 	protected long _nnz = -1;
 	protected UpdateType _updateType = UpdateType.COPY;
 
-	protected ArrayList<Hop> _parent = new ArrayList<>(5);
-	protected ArrayList<Hop> _input = new ArrayList<>(5);
+	protected ArrayList<Hop> _parent = new ArrayList<>();
+	protected ArrayList<Hop> _input = new ArrayList<>();
 
 	protected ExecType _etype = null; //currently used exec type
 	protected ExecType _etypeForced = null; //exec type forced via platform or external optimizer

--- a/src/main/java/org/apache/sysml/hops/HopsException.java
+++ b/src/main/java/org/apache/sysml/hops/HopsException.java
@@ -45,4 +45,8 @@ public class HopsException extends DMLException
         super(message, cause);
     }
 
+    public static void check(boolean condition, String message, Object... objects) throws HopsException {
+        if (!condition)
+            throw new HopsException(String.format(message, objects));
+    }
 }

--- a/src/main/java/org/apache/sysml/hops/HopsException.java
+++ b/src/main/java/org/apache/sysml/hops/HopsException.java
@@ -45,8 +45,14 @@ public class HopsException extends DMLException
         super(message, cause);
     }
 
+    /** If the condition fails, print the message formatted with objects. */
     public static void check(boolean condition, String message, Object... objects) throws HopsException {
         if (!condition)
             throw new HopsException(String.format(message, objects));
+    }
+    /** If the condition fails, print the Op and its Id, along with the message formatted with objects. */
+    public static void check(boolean condition, Hop hop, String message, Object... objects) throws HopsException {
+        if (!condition)
+            throw new HopsException(String.format(hop.getOpString()+" id="+hop.getHopID()+" "+message, objects));
     }
 }

--- a/src/main/java/org/apache/sysml/hops/HopsException.java
+++ b/src/main/java/org/apache/sysml/hops/HopsException.java
@@ -45,12 +45,25 @@ public class HopsException extends DMLException
         super(message, cause);
     }
 
-    /** If the condition fails, print the message formatted with objects. */
+    /**
+     * If the condition fails, print the message formatted with objects.
+     * @param condition Condition to test
+     * @param message Message to print if the condition fails
+     * @param objects Objects to print with the message, as per String.format
+     * @throws HopsException Thrown if condition is false
+     */
     public static void check(boolean condition, String message, Object... objects) throws HopsException {
         if (!condition)
             throw new HopsException(String.format(message, objects));
     }
-    /** If the condition fails, print the Op and its Id, along with the message formatted with objects. */
+    /**
+     * If the condition fails, print the Op and its Id, along with the message formatted with objects.
+     * @param condition Condition to test
+     * @param hop Hop to print as a cause of the problem, if the condition fails
+     * @param message Message to print if the condition fails
+     * @param objects Objects to print with the message, as per String.format
+     * @throws HopsException Thrown if condition is false
+     */
     public static void check(boolean condition, Hop hop, String message, Object... objects) throws HopsException {
         if (!condition)
             throw new HopsException(String.format(hop.getOpString()+" id="+hop.getHopID()+" "+message, objects));

--- a/src/main/java/org/apache/sysml/hops/IndexingOp.java
+++ b/src/main/java/org/apache/sysml/hops/IndexingOp.java
@@ -74,8 +74,12 @@ public class IndexingOp extends Hop
 		setRowLowerEqualsUpper(passedRowsLEU);
 		setColLowerEqualsUpper(passedColsLEU);
 	}
-	
-	
+
+	@Override
+	public int getArity() {
+		return 5;
+	}
+
 	public boolean isRowLowerEqualsUpper(){
 		return _rowLowerEqualsUpper;
 	}

--- a/src/main/java/org/apache/sysml/hops/IndexingOp.java
+++ b/src/main/java/org/apache/sysml/hops/IndexingOp.java
@@ -76,8 +76,9 @@ public class IndexingOp extends Hop
 	}
 
 	@Override
-	public int getArity() {
-		return 5;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		HopsException.check(sz == 5, this, "should have 5 inputs but has %d inputs", sz);
 	}
 
 	public boolean isRowLowerEqualsUpper(){

--- a/src/main/java/org/apache/sysml/hops/IndexingOp.java
+++ b/src/main/java/org/apache/sysml/hops/IndexingOp.java
@@ -77,8 +77,7 @@ public class IndexingOp extends Hop
 
 	@Override
 	public void checkArity() throws HopsException {
-		int sz = _input.size();
-		HopsException.check(sz == 5, this, "should have 5 inputs but has %d inputs", sz);
+		HopsException.check(_input.size() == 5, this, "should have 5 inputs but has %d inputs", _input.size());
 	}
 
 	public boolean isRowLowerEqualsUpper(){

--- a/src/main/java/org/apache/sysml/hops/LeftIndexingOp.java
+++ b/src/main/java/org/apache/sysml/hops/LeftIndexingOp.java
@@ -77,7 +77,11 @@ public class LeftIndexingOp  extends Hop
 		setColLowerEqualsUpper(passedColsLEU);
 	}
 
-	
+	@Override
+	public int getArity() {
+		return 6;
+	}
+
 	public boolean getRowLowerEqualsUpper(){
 		return _rowLowerEqualsUpper;
 	}

--- a/src/main/java/org/apache/sysml/hops/LeftIndexingOp.java
+++ b/src/main/java/org/apache/sysml/hops/LeftIndexingOp.java
@@ -78,8 +78,9 @@ public class LeftIndexingOp  extends Hop
 	}
 
 	@Override
-	public int getArity() {
-		return 6;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		HopsException.check(sz == 6, this, "should have 6 inputs but has %d inputs", 6);
 	}
 
 	public boolean getRowLowerEqualsUpper(){

--- a/src/main/java/org/apache/sysml/hops/LeftIndexingOp.java
+++ b/src/main/java/org/apache/sysml/hops/LeftIndexingOp.java
@@ -79,8 +79,7 @@ public class LeftIndexingOp  extends Hop
 
 	@Override
 	public void checkArity() throws HopsException {
-		int sz = _input.size();
-		HopsException.check(sz == 6, this, "should have 6 inputs but has %d inputs", 6);
+		HopsException.check(_input.size() == 6, this, "should have 6 inputs but has %d inputs", 6);
 	}
 
 	public boolean getRowLowerEqualsUpper(){

--- a/src/main/java/org/apache/sysml/hops/LiteralOp.java
+++ b/src/main/java/org/apache/sysml/hops/LiteralOp.java
@@ -62,7 +62,11 @@ public class LiteralOp extends Hop
 		this.value_boolean = value;
 	}
 
-	
+	@Override
+	public int getArity() {
+		return 0;
+	}
+
 	@Override
 	public Lop constructLops()
 		throws HopsException, LopsException  

--- a/src/main/java/org/apache/sysml/hops/LiteralOp.java
+++ b/src/main/java/org/apache/sysml/hops/LiteralOp.java
@@ -63,8 +63,8 @@ public class LiteralOp extends Hop
 	}
 
 	@Override
-	public int getArity() {
-		return 0;
+	public void checkArity() throws HopsException {
+		HopsException.check(_input.isEmpty(), this, "should have 0 inputs but has %d inputs", _input.size());
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysml/hops/MultipleOp.java
+++ b/src/main/java/org/apache/sysml/hops/MultipleOp.java
@@ -71,6 +71,11 @@ public class MultipleOp extends Hop {
 		refreshSizeInformation();
 	}
 
+	@Override
+	public int getArity() {
+		return -1;
+	}
+
 	public MultiInputOp getOp() {
 		return multipleOperandOperation;
 	}

--- a/src/main/java/org/apache/sysml/hops/MultipleOp.java
+++ b/src/main/java/org/apache/sysml/hops/MultipleOp.java
@@ -71,10 +71,9 @@ public class MultipleOp extends Hop {
 		refreshSizeInformation();
 	}
 
+	/** MultipleOp may have any number of inputs. */
 	@Override
-	public int getArity() {
-		return -1;
-	}
+	public void checkArity() throws HopsException {}
 
 	public MultiInputOp getOp() {
 		return multipleOperandOperation;

--- a/src/main/java/org/apache/sysml/hops/ParameterizedBuiltinOp.java
+++ b/src/main/java/org/apache/sysml/hops/ParameterizedBuiltinOp.java
@@ -112,6 +112,11 @@ public class ParameterizedBuiltinOp extends Hop implements MultiThreadedHop
 		refreshSizeInformation();
 	}
 
+	@Override
+	public int getArity() {
+		return -1;
+	}
+
 	public HashMap<String, Integer> getParamIndexMap(){
 		return _paramIndexMap;
 	}

--- a/src/main/java/org/apache/sysml/hops/ParameterizedBuiltinOp.java
+++ b/src/main/java/org/apache/sysml/hops/ParameterizedBuiltinOp.java
@@ -113,8 +113,10 @@ public class ParameterizedBuiltinOp extends Hop implements MultiThreadedHop
 	}
 
 	@Override
-	public int getArity() {
-		return -1;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		int pz = _paramIndexMap.size();
+		HopsException.check(sz == pz, this, "has %d inputs but %d parameters", sz, pz);
 	}
 
 	public HashMap<String, Integer> getParamIndexMap(){

--- a/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
@@ -168,7 +168,12 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 		inU.getParent().add(this);
 		inV.getParent().add(this);
 	}
-	
+
+	@Override
+	public int getArity() {
+		return 4;
+	}
+
 	public OpOp4 getOp(){
 		return _op;
 	}

--- a/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
@@ -170,8 +170,9 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 	}
 
 	@Override
-	public int getArity() {
-		return 4;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		HopsException.check(sz == 3 || sz == 4, this, "should have arity 3 or 4 but has arity %d", sz);
 	}
 
 	public OpOp4 getOp(){

--- a/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/QuaternaryOp.java
@@ -171,8 +171,8 @@ public class QuaternaryOp extends Hop implements MultiThreadedHop
 
 	@Override
 	public void checkArity() throws HopsException {
-		int sz = _input.size();
-		HopsException.check(sz == 3 || sz == 4, this, "should have arity 3 or 4 but has arity %d", sz);
+		HopsException.check(_input.size() == 3 || _input.size() == 4, this,
+				"should have arity 3 or 4 but has arity %d", _input.size());
 	}
 
 	public OpOp4 getOp(){

--- a/src/main/java/org/apache/sysml/hops/ReorgOp.java
+++ b/src/main/java/org/apache/sysml/hops/ReorgOp.java
@@ -91,6 +91,11 @@ public class ReorgOp extends Hop implements MultiThreadedHop
 	}
 
 	@Override
+	public int getArity() {
+		return -1;
+	}
+
+	@Override
 	public void setMaxNumThreads( int k ) {
 		_maxNumThreads = k;
 	}

--- a/src/main/java/org/apache/sysml/hops/ReorgOp.java
+++ b/src/main/java/org/apache/sysml/hops/ReorgOp.java
@@ -41,7 +41,7 @@ import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
  *  Reorg (cell) operation: aij
  * 		Properties: 
  * 			Symbol: ', rdiag, rshape, rsort
- * 			1 Operand
+ * 			1 Operand (except sort and reshape take additional arguments)
  * 	
  * 		Semantic: change indices (in mapper or reducer)
  * 
@@ -91,8 +91,21 @@ public class ReorgOp extends Hop implements MultiThreadedHop
 	}
 
 	@Override
-	public int getArity() {
-		return -1;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		switch( op ) {
+		case TRANSPOSE:
+		case DIAG:
+		case REV:
+			HopsException.check(sz == 1, this, "should have arity 1 for op %s but has arity %d", op, sz);
+			break;
+		case RESHAPE:
+		case SORT:
+			HopsException.check(sz == 4, this, "should have arity 4 for op %s but has arity %d", op, sz);
+			break;
+		default:
+			throw new HopsException("Unsupported lops construction for operation type '" + op + "'.");
+		}
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysml/hops/TernaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/TernaryOp.java
@@ -105,7 +105,12 @@ public class TernaryOp extends Hop
 		inp5.getParent().add(this);
 		_dimInputsPresent = true;
 	}
-	
+
+	@Override
+	public int getArity() {
+		return -1;
+	}
+
 	public OpOp3 getOp(){
 		return _op;
 	}

--- a/src/main/java/org/apache/sysml/hops/TernaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/TernaryOp.java
@@ -44,7 +44,7 @@ import org.apache.sysml.parser.Expression.DataType;
 import org.apache.sysml.parser.Expression.ValueType;
 import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
 
-/* Primary use cases for now, are
+/** Primary use cases for now, are
  * 		quantile (<n-1-matrix>, <n-1-matrix>, <literal>):      quantile (A, w, 0.5)
  * 		quantile (<n-1-matrix>, <n-1-matrix>, <scalar>):       quantile (A, w, s)
  * 		interquantile (<n-1-matrix>, <n-1-matrix>, <scalar>):  interquantile (A, w, s)
@@ -55,9 +55,10 @@ import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
  * 	interquantile (A, s)
  * 
  * Note: this hop should be called AggTernaryOp in consistency with AggUnaryOp and AggBinaryOp;
- * however, since there does not exist a real TernaryOp yet - we can leave it as is for now. 
+ * however, since there does not exist a real TernaryOp yet - we can leave it as is for now.
+ *
+ * CTABLE op takes 2 extra inputs with target dimensions for padding and pruning.
  */
-
 public class TernaryOp extends Hop 
 {
 	
@@ -107,8 +108,14 @@ public class TernaryOp extends Hop
 	}
 
 	@Override
-	public int getArity() {
-		return -1;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		if (_dimInputsPresent) {
+			// only CTABLE
+			HopsException.check(sz == 5, this, "should have arity 5 for op %s but has arity %d", _op, sz);
+		} else {
+			HopsException.check(sz == 3, this, "should have arity 3 for op %s but has arity %d", _op, sz);
+		}
 	}
 
 	public OpOp3 getOp(){

--- a/src/main/java/org/apache/sysml/hops/UnaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/UnaryOp.java
@@ -71,6 +71,11 @@ public class UnaryOp extends Hop implements MultiThreadedHop
 		refreshSizeInformation();
 	}
 
+	@Override
+	public int getArity() {
+		return 1;
+	}
+
 	// this is for OpOp1, e.g. A = -B (0-B); and a=!b
 	public OpOp1 getOp() {
 		return _op;

--- a/src/main/java/org/apache/sysml/hops/UnaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/UnaryOp.java
@@ -72,8 +72,9 @@ public class UnaryOp extends Hop implements MultiThreadedHop
 	}
 
 	@Override
-	public int getArity() {
-		return 1;
+	public void checkArity() throws HopsException {
+		int sz = _input.size();
+		HopsException.check(sz == 1, this, "should have arity 1 but has arity %d", sz);
 	}
 
 	// this is for OpOp1, e.g. A = -B (0-B); and a=!b

--- a/src/main/java/org/apache/sysml/hops/UnaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/UnaryOp.java
@@ -73,8 +73,7 @@ public class UnaryOp extends Hop implements MultiThreadedHop
 
 	@Override
 	public void checkArity() throws HopsException {
-		int sz = _input.size();
-		HopsException.check(sz == 1, this, "should have arity 1 but has arity %d", sz);
+		HopsException.check(_input.size() == 1, this, "should have arity 1 but has arity %d", _input.size());
 	}
 
 	// this is for OpOp1, e.g. A = -B (0-B); and a=!b

--- a/src/main/java/org/apache/sysml/hops/codegen/SpoofFusedOp.java
+++ b/src/main/java/org/apache/sysml/hops/codegen/SpoofFusedOp.java
@@ -61,7 +61,12 @@ public class SpoofFusedOp extends Hop implements MultiThreadedHop
 		_distSupported = dist;
 		_dimsType = type;
 	}
-	
+
+	@Override
+	public int getArity() {
+		return -1;
+	}
+
 	@Override
 	public void setMaxNumThreads(int k) {
 		_numThreads = k;

--- a/src/main/java/org/apache/sysml/hops/codegen/SpoofFusedOp.java
+++ b/src/main/java/org/apache/sysml/hops/codegen/SpoofFusedOp.java
@@ -63,9 +63,7 @@ public class SpoofFusedOp extends Hop implements MultiThreadedHop
 	}
 
 	@Override
-	public int getArity() {
-		return -1;
-	}
+	public void checkArity() throws HopsException {}
 
 	@Override
 	public void setMaxNumThreads(int k) {

--- a/src/main/java/org/apache/sysml/hops/rewrite/HopDagValidator.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/HopDagValidator.java
@@ -87,7 +87,7 @@ public class HopDagValidator {
 
 		final boolean seen = !state.seen.add(id);
 		check(seen == hop.isVisited(), hop,
-				"seen previously is %b but hop visited previously is %b", seen, !seen);
+				"seen previously is %b but does not match hop visit status", seen);
 		if (seen) return; // we saw the Hop previously, no need to re-validate
 		
 		//check parent linking

--- a/src/main/java/org/apache/sysml/hops/rewrite/HopDagValidator.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/HopDagValidator.java
@@ -20,9 +20,7 @@
 package org.apache.sysml.hops.rewrite;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -86,41 +84,37 @@ public class HopDagValidator {
 		final long id = hop.getHopID();
 
 		final boolean seen = !state.seen.add(id);
-		check(seen == hop.isVisited(),
-				"Hop seen previously is %b but hop visited previously is %b for hop %d",
-				seen, !seen, id);
+		check(seen == hop.isVisited(), hop,
+				"seen previously is %b but hop visited previously is %b", seen, !seen);
 		if (seen) return; // we saw the Hop previously, no need to re-validate
 		
 		//check parent linking
 		for( Hop parent : hop.getParent() )
-			check(parent.getInput().contains(hop),
-					"Hop id=%d not properly linked to its parent pid=%d %s",
-					id, parent.getHopID(), parent.getClass().getName());
+			check(parent.getInput().contains(hop), hop,
+					"not properly linked to its parent pid=%d %s",
+					parent.getHopID(), parent.getClass().getName());
 
 		final ArrayList<Hop> input = hop.getInput();
-		final int arity = hop.getArity();
 		final Expression.DataType dt = hop.getDataType();
 		final Expression.ValueType vt = hop.getValueType();
 
 		//check child linking
 		for( Hop child : input )
-			check(child.getParent().contains(hop),
-					"Hop id=%d not properly linked to its child cid=%d %s",
-					id, child.getHopID(), child.getClass().getName());
+			check(child.getParent().contains(hop), hop, "not properly linked to its child cid=%d %s",
+					child.getHopID(), child.getClass().getName());
 
 		//check empty children (other variable-length Hops must have at least one child)
 		if( input.isEmpty() )
-			check(hop instanceof DataOp || hop instanceof LiteralOp,
-					"Hop id=%d is not a dataop/literal but has no children", id);
-		// check arity matches number of children
-		if (arity != -1) // for Hops with known, fixed arity
-			check(input.size() == arity,
-					"Hop id=%d has arity %d but has size %d", id, arity, input.size());
+			check(hop instanceof DataOp || hop instanceof LiteralOp, hop,
+					"is not a dataop/literal but has no children");
+
+		// check Hop has a legal arity (number of children)
+		hop.checkArity();
 
 		// check Matrix data type Hops must have Double Value type
 		if (dt == Expression.DataType.MATRIX )
-			check(vt == Expression.ValueType.DOUBLE,
-				"Hop id=%d has Matrix type but Value Type %s is not DOUBLE", id, vt);
+			check(vt == Expression.ValueType.DOUBLE, hop,
+				"has Matrix type but Value Type %s is not DOUBLE", vt);
 
 		//recursively process children
 		for( Hop child : input )

--- a/src/main/java/org/apache/sysml/hops/rewrite/HopDagValidator.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/HopDagValidator.java
@@ -42,6 +42,8 @@ import static org.apache.sysml.hops.HopsException.check;
  */
 public class HopDagValidator {
 	private static final Log LOG = LogFactory.getLog(HopDagValidator.class.getName());
+
+	private HopDagValidator() {}
 	
 	public static void validateHopDag(final ArrayList<Hop> roots) throws HopsException {
 		if( roots == null )

--- a/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
@@ -55,7 +55,7 @@ public class ProgramRewriter
 	
 	//internal local debug level
 	private static final boolean LDEBUG = false; 
-	private static final boolean CHECK = false;
+	private static final boolean CHECK = true;
 	
 	private ArrayList<HopRewriteRule> _dagRuleSet = null;
 	private ArrayList<StatementBlockRewriteRule> _sbRuleSet = null;

--- a/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
@@ -270,7 +270,7 @@ public class ProgramRewriter
 				try {
 					HopDagValidator.validateHopDag(roots);
 				} catch (HopsException e) {
-					LOG.error("Invalid hop after running "+r.getClass().getName(), e);
+					LOG.error("Invalid hop after rewriting by "+r.getClass().getName(), e);
 					throw e;
 				}
 			}
@@ -289,10 +289,14 @@ public class ProgramRewriter
 		{
 			root.resetVisitStatus(); //reset for each rule
 			root = r.rewriteHopDAG(root, state);
-		
+
 			if( CHECK ) {
-				LOG.info("Validation after: "+r.getClass().getName());
-				HopDagValidator.validateHopDag(root);
+				try {
+					HopDagValidator.validateHopDag(root);
+				} catch (HopsException e) {
+					LOG.error("Invalid hop after rewriting by "+r.getClass().getName(), e);
+					throw e;
+				}
 			}
 		}
 		

--- a/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
@@ -266,9 +266,13 @@ public class ProgramRewriter
 			Hop.resetVisitStatus( roots ); //reset for each rule
 			roots = r.rewriteHopDAGs(roots, state);
 		
-			if( CHECK ) {		
-				LOG.info("Validation after: "+r.getClass().getName());
-				HopDagValidator.validateHopDag(roots);
+			if( CHECK ) {
+				try {
+					HopDagValidator.validateHopDag(roots);
+				} catch (HopsException e) {
+					LOG.error("Invalid hop after running "+r.getClass().getName(), e);
+					throw e;
+				}
 			}
 		}
 		

--- a/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
@@ -55,7 +55,7 @@ public class ProgramRewriter
 	
 	//internal local debug level
 	private static final boolean LDEBUG = false; 
-	private static final boolean CHECK = true;
+	private static final boolean CHECK = false;
 	
 	private ArrayList<HopRewriteRule> _dagRuleSet = null;
 	private ArrayList<StatementBlockRewriteRule> _sbRuleSet = null;
@@ -260,22 +260,20 @@ public class ProgramRewriter
 	
 	public ArrayList<Hop> rewriteHopDAGs(ArrayList<Hop> roots, ProgramRewriteStatus state) 
 		throws HopsException
-	{	
+	{
 		for( HopRewriteRule r : _dagRuleSet )
 		{
 			Hop.resetVisitStatus( roots ); //reset for each rule
 			roots = r.rewriteHopDAGs(roots, state);
 		
-			if( CHECK ) {
+			if( CHECK )
 				try {
 					HopDagValidator.validateHopDag(roots);
 				} catch (HopsException e) {
-					LOG.error("Invalid hop after rewriting by "+r.getClass().getName(), e);
+					LOG.error("Invalid hop after rewriting by " + r.getClass().getName(), e);
 					throw e;
 				}
-			}
 		}
-		
 		return roots;
 	}
 	
@@ -283,23 +281,21 @@ public class ProgramRewriter
 		throws HopsException
 	{	
 		if( root == null )
-			return root;
+			return null;
 		
 		for( HopRewriteRule r : _dagRuleSet )
 		{
 			root.resetVisitStatus(); //reset for each rule
 			root = r.rewriteHopDAG(root, state);
 
-			if( CHECK ) {
+			if( CHECK )
 				try {
 					HopDagValidator.validateHopDag(root);
 				} catch (HopsException e) {
-					LOG.error("Invalid hop after rewriting by "+r.getClass().getName(), e);
+					LOG.error("Invalid hop after rewriting by " + r.getClass().getName(), e);
 					throw e;
 				}
-			}
 		}
-		
 		return root;
 	}
 	


### PR DESCRIPTION
This PR adds additional checks to the Hop Dag Validator.

* Check that each Hop has the correct number of inputs. Adds a `checkArity()` method to Hop and implements it in every Hop.
* Matrix data type Hops must have a Double value type
* Visit flag must be properly reset via `Hop.resetVisitStatus()`. Uses an external Set to track which Hops have been seen and compares this to the visit flag of each Hop.
* Add related Javadoc 

There is a CHECK flag in `ProgramRewriter` that enables the validator after applying rewrites. It is currently set to true.

There are several tests that fail with this validator in place. We should create additional issues for the problems that the validator uncovers.