### PR TITLE
[MINOR] Fix ternary test to read proper files.

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/functions/ternary/TernaryAggregateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/ternary/TernaryAggregateTest.java
@@ -164,22 +164,22 @@ public class TernaryAggregateTest extends AutomatedTestBase
 	
 	@Test
 	public void testTernaryAggregateRCDenseVectorCPNoRewrite() {
-		runTernaryAggregateTest(TEST_NAME2, false, true, false, ExecType.CP);
+		runTernaryAggregateTest(TEST_NAME1, false, true, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testTernaryAggregateRCSparseVectorCPNoRewrite() {
-		runTernaryAggregateTest(TEST_NAME2, true, true, false, ExecType.CP);
+		runTernaryAggregateTest(TEST_NAME1, true, true, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testTernaryAggregateRCDenseMatrixCPNoRewrite() {
-		runTernaryAggregateTest(TEST_NAME2, false, false, false, ExecType.CP);
+		runTernaryAggregateTest(TEST_NAME1, false, false, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testTernaryAggregateRCSparseMatrixCPNoRewrite() {
-		runTernaryAggregateTest(TEST_NAME2, true, false, false, ExecType.CP);
+		runTernaryAggregateTest(TEST_NAME1, true, false, false, ExecType.CP);
 	}
 	
 	@Test


### PR DESCRIPTION
Some tests in TernaryAggregateTest refer to the wrong input program.
This fixes them to the correct one.