### PR TITLE
[SYSTEMML-1704] Add commons-io to bin and standalone-jar artifacts

### DIFF
--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -102,6 +102,7 @@
 				<include>*:commons-collections*</include>
 				<include>*:commons-configuration*</include>
 				<include>*:commons-httpclient*</include>
+				<include>*:commons-io*</include>
 				<include>*:commons-lang</include>
 				<include>*:commons-logging*</include>
 				<include>*:commons-math3*</include>

--- a/src/assembly/bin/LICENSE
+++ b/src/assembly/bin/LICENSE
@@ -208,6 +208,7 @@ commons-cli-1.2.jar
 commons-collections-3.2.1.jar
 commons-configuration-1.6.jar
 commons-httpclient-3.1.jar
+commons-io-2.4.jar
 commons-lang-2.6.jar
 commons-logging-1.1.3.jar
 commons-math3-3.4.1.jar

--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -79,6 +79,7 @@
 				<include>*:commons-collections*</include>
 				<include>*:commons-configuration*</include>
 				<include>*:commons-httpclient*</include>
+				<include>*:commons-io*</include>
 				<include>*:commons-lang</include>
 				<include>*:commons-logging*</include>
 				<include>*:commons-math3*</include>

--- a/src/assembly/standalone-jar/LICENSE
+++ b/src/assembly/standalone-jar/LICENSE
@@ -209,6 +209,7 @@ commons-cli:commons-cli:1.2
 commons-collections:commons-collections:3.2.1
 commons-configuration:commons-configuration:1.6
 commons-httpclient:commons-httpclient:3.1
+commons-io:commons-io:2.4
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.3
 log4j:log4j:1.2.15


### PR DESCRIPTION
The commons-io library can be required for certain actions, such as
writing matrices and metadata to the file system, so add commons-io
to the bin and standalone-jar artifacts.