### PR TITLE
[Minor] Minor bug fix in org.apache.sysml.hops.ipa.FunctionCallSizeInfo#toString()

### DIFF
--- a/src/main/java/org/apache/sysml/hops/ipa/FunctionCallSizeInfo.java
+++ b/src/main/java/org/apache/sysml/hops/ipa/FunctionCallSizeInfo.java
@@ -303,7 +303,7 @@ public class FunctionCallSizeInfo
 			sb.append(getFunctionCallCount(fkey));
 			if( !_fcandSafeNNZ.get(fkey).isEmpty() ) {
 				sb.append("\n----");
-				sb.append(Arrays.toString(_fcandSafeNNZ.get(fkey).toArray(new Long[0])));
+				sb.append(Arrays.toString(_fcandSafeNNZ.get(fkey).toArray(new Integer[0])));
 			}
 			sb.append("\n");
 		}


### PR DESCRIPTION
Integer can not be converted to Long. This bug can be reproduced by setting the LogLevel to be `DEBUG` and running the MNIST example.