### PR TITLE
[SYSTEMML-1764] Fix cbind value in AppendGAlignedSP constructor

### DIFF
--- a/src/main/java/org/apache/sysml/lops/AppendGAlignedSP.java
+++ b/src/main/java/org/apache/sysml/lops/AppendGAlignedSP.java
@@ -36,7 +36,7 @@ public class AppendGAlignedSP extends Lop
 		super(Lop.Type.Append, dt, vt);		
 		init(input1, input2, input3, dt, vt);
 		
-		_cbind = true;
+		_cbind = cbind;
 	}
 	
 	public void init(Lop input1, Lop input2, Lop input3, DataType dt, ValueType vt) 


### PR DESCRIPTION
Set the _cbind field to the value of the cbind parameter in the AppendGAlignedSP
constructor.