### PR TITLE
[SYSTEMML-1762] Improve the matrix reshape function for the Spark mode

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixReorg.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixReorg.java
@@ -1588,7 +1588,14 @@ public class LibMatrixReorg
 					computeResultBlockIndex(ixtmp, ai, aj, rows1, cols1, rows2, cols2, brlen2, bclen2, rowwise);
 					MatrixBlock out = rix.get(ixtmp);
 					computeInBlockIndex(ixtmp, ai, aj, rows1, cols1, rows2, cols2, brlen2, bclen2, rowwise);
-					out.appendValue((int)ixtmp.getRowIndex(),(int)ixtmp.getColumnIndex(), avals[j]);
+
+                                        if (out == null) {
+                                          System.out.println("********** OUT is NULL-------------");
+                                        } else {
+                                          out.appendValue((int)ixtmp.getRowIndex(),(int)ixtmp.getColumnIndex(), avals[j]);
+                                        }
+
+                                        //out.appendValue((int)ixtmp.getRowIndex(),(int)ixtmp.getColumnIndex(), avals[j]);
 				}
 			}
 		}


### PR DESCRIPTION
When running the [distributed MNIST LeNet example](https://github.com/apache/systemml/blob/master/scripts/nn/examples/mnist_lenet_distrib_sgd.dml), it works well in the hybrid mode. But in the Spark mode, there are some errors about `java.lang.NullPointerException` and `java.lang.ArrayIndexOutOfBoundsException` when reshaping the matrix.

More details can be found at [JIRA-SYSTEMML-1762](https://issues.apache.org/jira/browse/SYSTEMML-1762).