### PR TITLE
[MINOR] Refactoring - boolean constructors, returns, semicolons

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLResults.java
@@ -1980,7 +1980,7 @@ public class MLResults {
 	private <T> T outputValue(String outputName) {
 		Data data = getData(outputName);
 		if (data instanceof BooleanObject) {
-			return (T) new Boolean(((BooleanObject) data).getBooleanValue());
+			return (T) Boolean.valueOf(((BooleanObject) data).getBooleanValue());
 		} else if (data instanceof DoubleObject) {
 			return (T) new Double(((DoubleObject) data).getDoubleValue());
 		} else if (data instanceof IntObject) {

--- a/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
@@ -1217,7 +1217,6 @@ public class BuiltinFunctionExpression extends DataIdentifier
 					raiseValidateError("Unsupported function "+op, false, LanguageErrorCodes.INVALID_PARAMETERS);
 			}
 		}
-		return;
 	}
 	
 	private void setBinaryOutputProperties(DataIdentifier output) 

--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -159,8 +159,6 @@ public class DMLTranslator
 				constVars = sb.getConstOut();
 			}	
 		}
-		
-		return;
 	}
 
 	public void liveVariableAnalysis(DMLProgram dmlp) throws LanguageException {
@@ -224,8 +222,6 @@ public class DMLTranslator
 				currentLiveOut = sb.analyze(currentLiveOut);
 			}
 		}
-		return;
-
 	}
 
 	/**

--- a/src/main/java/org/apache/sysml/parser/DataExpression.java
+++ b/src/main/java/org/apache/sysml/parser/DataExpression.java
@@ -1671,7 +1671,6 @@ public class DataExpression extends DataIdentifier
 		default:
 			raiseValidateError("Unsupported Data expression"+ this.getOpCode(), false, LanguageErrorCodes.INVALID_PARAMETERS); //always unconditional
 		}
-		return;
 	}
 
 	private void performConstantPropagationRand( HashMap<String, ConstIdentifier> currConstVars )

--- a/src/main/java/org/apache/sysml/parser/FunctionCallIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/FunctionCallIdentifier.java
@@ -163,8 +163,6 @@ public class FunctionCallIdentifier extends DataIdentifier
 		for(int i=0; i < fstmt.getOutputParams().size(); i++) {
 			_outputs[i] = new DataIdentifier(fstmt.getOutputParams().get(i));
 		}
-		
-		return;
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysml/parser/ParameterizedBuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysml/parser/ParameterizedBuiltinFunctionExpression.java
@@ -244,7 +244,6 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 				raiseValidateError("Unsupported parameterized function "+ getOpCode(), 
 						false, LanguageErrorCodes.UNSUPPORTED_EXPRESSION);
 		}
-		return;
 	}
 
 	@Override
@@ -277,8 +276,6 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 			default: //always unconditional (because unsupported operation)
 				raiseValidateError("Unsupported parameterized function "+ getOpCode(), false, LanguageErrorCodes.INVALID_PARAMETERS);
 		}
-		
-		return;
 	}
 	
 	// example: A = transformapply(target=X, meta=M, spec=s)
@@ -645,7 +642,6 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 		output.setDataType(DataType.SCALAR);
 		output.setValueType(ValueType.DOUBLE);
 		output.setDimensions(0, 0);
-		return;
 	}
 	
 	private void validateCastAsString(DataIdentifier output, boolean conditional) 

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
@@ -1427,7 +1427,7 @@ public class ProgramConverter
 		throws DMLRuntimeException
 	{
 		ArrayList<ProgramBlock> pbs = new ArrayList<ProgramBlock>();
-		String tmpdata = in.substring(PARFOR_PBS_BEGIN.length(),in.length()-PARFOR_PBS_END.length()); ;
+		String tmpdata = in.substring(PARFOR_PBS_BEGIN.length(),in.length()-PARFOR_PBS_END.length());
 		HierarchyAwareStringTokenizer st = new HierarchyAwareStringTokenizer(tmpdata, ELEMENT_DELIM);
 		
 		while( st.hasMoreTokens() )

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/VariableCPInstruction.java
@@ -492,7 +492,7 @@ public class VariableCPInstruction extends CPInstruction
 				String fname = getInput2().getName();
 				
 				// check if unique filename needs to be generated
-				boolean overrideFileName = ((BooleanObject) ec.getScalarInput(getInput3().getName(), getInput3().getValueType(), true)).getBooleanValue();; //!(input1.getName().startsWith("p")); //    
+				boolean overrideFileName = ((BooleanObject) ec.getScalarInput(getInput3().getName(), getInput3().getValueType(), true)).getBooleanValue();
 				if ( overrideFileName ) {
 					fname = fname + "_" + _uniqueVarID.getNextID();
 				}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/MatrixBlock.java
@@ -2979,7 +2979,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 						for(int c=0; c<clen; c++)
 						{
 							buffer._sum=this.quickGetValue(r, c);
-							buffer._correction=cor.quickGetValue(r, 0);;
+							buffer._correction=cor.quickGetValue(r, 0);
 							buffer=(KahanObject) aggOp.increOp.fn.execute(buffer, newWithCor.quickGetValue(r, c), newWithCor.quickGetValue(r, c+1));
 							quickSetValue(r, c, buffer._sum);
 							cor.quickSetValue(r, 0, buffer._correction);

--- a/src/test/java/org/apache/sysml/test/integration/functions/frame/FrameCopyTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/frame/FrameCopyTest.java
@@ -137,7 +137,7 @@ public class FrameCopyTest extends AutomatedTestBase
 		for( int j=0; j<lschema.length; j++ )	{
 			switch( lschema[j] ) {
 				case STRING:  frame.set(updateRow,  j,  "String:"+ frame.get(updateRow, j)); break;
-				case BOOLEAN: frame.set(updateRow,  j, ((Boolean)frame.get(updateRow, j))?(new Boolean(false)):(new Boolean(true))); break;
+				case BOOLEAN: frame.set(updateRow,  j, ((Boolean)frame.get(updateRow, j))?Boolean.FALSE:Boolean.TRUE); break;
 				case INT:     frame.set(updateRow,  j, (Long)frame.get(updateRow, j) * 2 + 5); break;
 				case DOUBLE:  frame.set(updateRow,  j, (Double)frame.get(updateRow, j) * 2 + 7); break;
 				default: throw new RuntimeException("Unsupported value type: "+lschema[j]);

--- a/src/test/java/org/apache/sysml/test/integration/functions/indexing/IndexRangeBlockAlignmentTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/indexing/IndexRangeBlockAlignmentTest.java
@@ -38,49 +38,49 @@ public class IndexRangeBlockAlignmentTest extends AutomatedTestBase
 	
 	@Test
 	public void testRowBlockFirstColumn() {
-		Assert.assertEquals(new Boolean(true), 
-			OptimizerUtils.isIndexingRangeBlockAligned(2001, 4000, 1, 1736, BRLEN, BCLEN));
+		Assert.assertEquals(Boolean.TRUE,
+				OptimizerUtils.isIndexingRangeBlockAligned(2001, 4000, 1, 1736, BRLEN, BCLEN));
 	}
 	
 	@Test
 	public void testRowBlockColBlock() {
-		Assert.assertEquals(new Boolean(true), 
-			OptimizerUtils.isIndexingRangeBlockAligned(2001, 4000, 7001, 9000, BRLEN, BCLEN));
+		Assert.assertEquals(Boolean.TRUE,
+				OptimizerUtils.isIndexingRangeBlockAligned(2001, 4000, 7001, 9000, BRLEN, BCLEN));
 	}
 
 	@Test
 	public void testSingleRowBlockFirstColumn() {
-		Assert.assertEquals(new Boolean(true), 
-			OptimizerUtils.isIndexingRangeBlockAligned(2500, 2600, 1, 1736, BRLEN, BCLEN));
+		Assert.assertEquals(Boolean.TRUE,
+				OptimizerUtils.isIndexingRangeBlockAligned(2500, 2600, 1, 1736, BRLEN, BCLEN));
 	}
 	
 	@Test
 	public void testSingleRowBlockColBlock() {
-		Assert.assertEquals(new Boolean(true), 
-			OptimizerUtils.isIndexingRangeBlockAligned(2500, 2600, 7001, 9000, BRLEN, BCLEN));
+		Assert.assertEquals(Boolean.TRUE,
+				OptimizerUtils.isIndexingRangeBlockAligned(2500, 2600, 7001, 9000, BRLEN, BCLEN));
 	}
 	
 	@Test
 	public void testRowBlockFirstColumnNeg() {
-		Assert.assertEquals(new Boolean(false), 
-			OptimizerUtils.isIndexingRangeBlockAligned(2501, 4500, 1, 1736, BRLEN, BCLEN));
+		Assert.assertEquals(Boolean.FALSE,
+				OptimizerUtils.isIndexingRangeBlockAligned(2501, 4500, 1, 1736, BRLEN, BCLEN));
 	}
 	
 	@Test
 	public void testRowBlockColBlockNeg() {
-		Assert.assertEquals(new Boolean(false), 
-			OptimizerUtils.isIndexingRangeBlockAligned(2501, 4500, 7001, 9000, BRLEN, BCLEN));
+		Assert.assertEquals(Boolean.FALSE,
+				OptimizerUtils.isIndexingRangeBlockAligned(2501, 4500, 7001, 9000, BRLEN, BCLEN));
 	}
 
 	@Test
 	public void testSingleRowBlockFirstColumnNeg() {
-		Assert.assertEquals(new Boolean(false), 
-			OptimizerUtils.isIndexingRangeBlockAligned(2500, 3001, 1, 1736, BRLEN, BCLEN));
+		Assert.assertEquals(Boolean.FALSE,
+				OptimizerUtils.isIndexingRangeBlockAligned(2500, 3001, 1, 1736, BRLEN, BCLEN));
 	}
 	
 	@Test
 	public void testSingleRowBlockColBlockNeg() {
-		Assert.assertEquals(new Boolean(false), 
-			OptimizerUtils.isIndexingRangeBlockAligned(2500, 3001, 7001, 9000, BRLEN, BCLEN));
+		Assert.assertEquals(Boolean.FALSE,
+				OptimizerUtils.isIndexingRangeBlockAligned(2500, 3001, 7001, 9000, BRLEN, BCLEN));
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/RewriteCTableToRExpandTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/RewriteCTableToRExpandTest.java
@@ -124,7 +124,7 @@ public class RewriteCTableToRExpandTest extends AutomatedTestBase
 		checkDMLMetaDataFile("R", new MatrixCharacteristics(rrows, rcols, 1, 1));
 		
 		//check for applied rewrite
-		Assert.assertEquals(new Boolean(testname.equals(TEST_NAME1)||testname.equals(TEST_NAME2)), 
-				new Boolean(heavyHittersContainsSubString("rexpand")));
+		Assert.assertEquals(Boolean.valueOf(testname.equals(TEST_NAME1) || testname.equals(TEST_NAME2)),
+				Boolean.valueOf(heavyHittersContainsSubString("rexpand")));
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/ternary/TernaryAggregateTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/ternary/TernaryAggregateTest.java
@@ -254,8 +254,8 @@ public class TernaryAggregateTest extends AutomatedTestBase
 			if( rewrites && et != ExecType.MR ) {
 				String opcode = ((et == ExecType.SPARK) ? Instruction.SP_INST_PREFIX : "") + 
 					(((testname.equals(TEST_NAME1) || vectors ) ? "tak+*" : "tack+*"));
-				Assert.assertEquals(new Boolean(true), new Boolean(
-					Statistics.getCPHeavyHitterOpCodes().contains(opcode)));
+				Assert.assertEquals(Boolean.TRUE,
+						Boolean.valueOf(Statistics.getCPHeavyHitterOpCodes().contains(opcode)));
 			}
 		}
 		finally {


### PR DESCRIPTION
1) Boolean constructor creates new Boolean instances, so follow best
practice of using Boolean.TRUE, Boolean.FALSE, and Boolean.valueOf()
rather than the Boolean constructor. See Boolean constructor javadocs
for more information.
2) Remove unnecessary return statements
3) Remove extraneous semicolons