### PR TITLE
[SYSTEMML-1774] Bugfix for illegal arguments in ConvolutionUtils

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/util/ConvolutionUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/util/ConvolutionUtils.java
@@ -92,7 +92,7 @@ public class ConvolutionUtils {
 						int prevDestIndex = 0;
 						for(int j = apos; j < apos+alen; j++) {
 							// Multiplication by zero. Assumption: aix is sorted.
-							Arrays.fill(dest, cix+prevDestIndex, aix[j], 0);
+							Arrays.fill(dest, cix+prevDestIndex, cix+aix[j], 0);
 							prevDestIndex = aix[j]+1;
 							dest[ cix+aix[j] ] *= avals[j];
 						}


### PR DESCRIPTION
When using `Arrays.fill()` in `ConvolutionUtils.#binaryOperationInPlace` to fill the values of the 1-dimension destination array by `fromIndex` and `toIndex`, the column index `cix` of the sparse matrix block need to be added into `fromIndex` and `endIndex` first, but it is missed at `line 95` for `toIndex`.