### PR TITLE
[SYSTEMML-1796] Improved formatting of fine-grained statistics for SystemML

### DIFF
--- a/conf/SystemML-config.xml.template
+++ b/conf/SystemML-config.xml.template
@@ -80,4 +80,7 @@
 
     <!-- sets the GPUs to use per process, -1 for all GPUs, a specific GPU number (5), a range (eg: 0-2) or a comma separated list (eg: 0,2,4)-->
     <systemml.gpu.availableGPUs>-1</systemml.gpu.availableGPUs>
+    
+    <!-- maximum wrap length for instruction and miscellaneous timer column of statistics -->
+   <systemml.stats.maxWrapLength>30</systemml.stats.maxWrapLength>
 </root>

--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -158,8 +158,9 @@ public class DMLScript
 
 	public static RUNTIME_PLATFORM  rtplatform          = DMLOptions.defaultOptions.execMode;    // the execution mode
 	public static boolean           STATISTICS          = DMLOptions.defaultOptions.stats;       // whether to print statistics
-	public static boolean           FINEGRAINED_STATISTICS  = DMLOptions.defaultOptions.stats;       // whether to print statistics
+	public static boolean           FINEGRAINED_STATISTICS  = false;   						     // whether to print fine-grained statistics
 	public static int               STATISTICS_COUNT    = DMLOptions.defaultOptions.statsCount;  // statistics maximum heavy hitter count
+	public static int               STATISTICS_MAX_WRAP_LEN = 30;                                // statistics maximum wrap length
 	public static boolean           ENABLE_DEBUG_MODE   = DMLOptions.defaultOptions.debug;       // debug mode
 	public static ExplainType       EXPLAIN             = DMLOptions.defaultOptions.explainType; // explain type
 	public static String            DML_FILE_PATH_ANTLR_PARSER = DMLOptions.defaultOptions.filePath; // filename of dml/pydml script

--- a/src/main/java/org/apache/sysml/api/ScriptExecutorUtils.java
+++ b/src/main/java/org/apache/sysml/api/ScriptExecutorUtils.java
@@ -78,6 +78,7 @@ public class ScriptExecutorUtils {
 		GPUStatistics.DISPLAY_STATISTICS = dmlconf.getBooleanValue(DMLConfig.EXTRA_GPU_STATS);
 		LibMatrixDNN.DISPLAY_STATISTICS = dmlconf.getBooleanValue(DMLConfig.EXTRA_DNN_STATS);
 		DMLScript.FINEGRAINED_STATISTICS = dmlconf.getBooleanValue(DMLConfig.EXTRA_FINEGRAINED_STATS);
+		DMLScript.STATISTICS_MAX_WRAP_LEN = dmlconf.getIntValue(DMLConfig.STATS_MAX_WRAP_LEN);
 
 		Statistics.startRunTimer();
 		try {

--- a/src/main/java/org/apache/sysml/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysml/conf/DMLConfig.java
@@ -22,7 +22,6 @@ package org.apache.sysml.conf;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
@@ -78,6 +77,7 @@ public class DMLConfig
 	public static final String CODEGEN_PLANCACHE    = "codegen.plancache"; //boolean
 	public static final String CODEGEN_LITERALS     = "codegen.literals"; //1..heuristic, 2..always
 	public static final String EXTRA_FINEGRAINED_STATS = "systemml.stats.finegrained"; //boolean
+	public static final String STATS_MAX_WRAP_LEN = "systemml.stats.maxWrapLength"; //int
 	public static final String EXTRA_GPU_STATS      = "systemml.stats.extraGPU"; //boolean
 	public static final String EXTRA_DNN_STATS      = "systemml.stats.extraDNN"; //boolean
 	public static final String AVAILABLE_GPUS       = "systemml.gpu.availableGPUs"; // String to specify which GPUs to use (a range, all GPUs, comma separated list or a specific GPU)
@@ -123,6 +123,7 @@ public class DMLConfig
 		_defaultVals.put(CODEGEN_LITERALS,       "1" );
 		_defaultVals.put(NATIVE_BLAS,            "none" );
 		_defaultVals.put(EXTRA_FINEGRAINED_STATS,"false" );
+		_defaultVals.put(STATS_MAX_WRAP_LEN,"30" );
 		_defaultVals.put(EXTRA_GPU_STATS,        "false" );
 		_defaultVals.put(EXTRA_DNN_STATS,        "false" );
 
@@ -408,7 +409,7 @@ public class DMLConfig
 				YARN_APPMASTER, YARN_APPMASTERMEM, YARN_MAPREDUCEMEM, 
 				CP_PARALLEL_OPS, CP_PARALLEL_IO, NATIVE_BLAS,
 				COMPRESSED_LINALG, CODEGEN, CODEGEN_LITERALS, CODEGEN_PLANCACHE,
-				EXTRA_GPU_STATS, EXTRA_DNN_STATS, EXTRA_FINEGRAINED_STATS,
+				EXTRA_GPU_STATS, EXTRA_DNN_STATS, EXTRA_FINEGRAINED_STATS, STATS_MAX_WRAP_LEN,
 				AVAILABLE_GPUS
 		}; 
 		


### PR DESCRIPTION
- The user can update systemml.stats.maxWrapLength configuration to
change the maximum wrap length of instruction and misc timers
- Here are some examples:

```
Heavy hitter instructions:
  #  Instruction                    Time(s)  Count  Misc Timers
  1  write [PCA.dml 110:8-110:14]     7.740      1
  2  eigen [PCA.dml 85:1-85:1]        7.191      1 rlswr[0.000s,2], rlsev[0.000s,0], a
                                                                         qmd[0.001s,2]
  3  write [92:12-92:25]              0.686      1
  4  ba+* [PCA.dml 110:8-110:14]      0.511      1 rlswr[0.000s,1], rlsev[0.000s,0], a
                                                   qmd[0.000s,1], aqrd[0.000s,2], rlsi
                                                                            [0.000s,2]
  5  tsmm [PCA.dml 81:5-81:16]        0.372      1 rlswr[0.000s,1], rlsev[0.000s,0], r
                                                   lsi[0.000s,1], aqrd[0.000s,1], aqmd
                                                                            [0.000s,1]
  6  uacmean [PCA.dml 66:5-66:5]      0.361      1 rlswr[0.000s,1], rlsev[0.000s,0], a
                                                   qmd[0.000s,1], rlsi[0.000s,1], aqrd
                                                                            [0.204s,1]
  7  ba+* [92:12-92:25]               0.155      1 rlswr[0.000s,1], aqmd[0.000s,1], aq
                                                   rs[0.000s,1], aqrd[0.000s,1], rlsev
                                                            [0.000s,0], rlsi[0.000s,2]
  8  uacsqk+ [PCA.dml 70:23-70:23]    0.147      1 rlswr[0.000s,1], rlsev[0.000s,0], a
                                                   qmd[0.000s,1], aqrd[0.000s,1], rlsi
                                                                            [0.000s,1]


Heavy hitter instructions:
  #  Instruction  Time(s)  Count  Misc Timers
  1  write [PCA    7.751      1
     .dml 110:8
     -110:14]
  2  eigen [PCA    7.031      1 rlswr[0.00
     .dml 85:1-                 0s,2], rls
     85:1]                      ev[0.000s,
                                0], aqmd[0
                                  .000s,2]
  3  write [92:    0.687      1
     12-92:25]
  4  ba+* [PCA.    0.527      1 rlswr[0.00
     dml 110:8-                 0s,1], aqm
     110:14]                    d[0.000s,1
                                ], aqrd[0.
                                000s,2], r
                                lsev[0.000
                                s,0], rlsi
                                [0.001s,2]
  5  tsmm [PCA.    0.401      1 rlswr[0.00
     dml 81:5-8                 0s,1], rls
     1:16]                      ev[0.000s,
                                0], rlsi[0
                                .000s,1],
                                aqrd[0.000
                                s,1], aqmd
                                [0.000s,1]


Heavy hitter instructions:
  #  Instruction  Time(s)  Count
  1  write         8.371      4
  2  eigen         7.239      1
  3  ba+*          0.663      3
  4  tsmm          0.340      2
  5  uacmean       0.309      2
  6  uacsqk+       0.146      1
  7  /             0.107      5
  8  -             0.067      3
  9  uack+         0.043      1
 10  -*            0.025      2
 11  ctableexpa    0.007      1
     nd

```

@mboehm7 can you please review this PR ?