### PR TITLE
[SYSTEMML-1813] Breast cancer preprocessing simplification and cleanup

### DIFF
--- a/projects/breast_cancer/MachineLearning-Keras-ResNet50.ipynb
+++ b/projects/breast_cancer/MachineLearning-Keras-ResNet50.ipynb
@@ -10,7 +10,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
@@ -54,7 +56,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# os.environ['CUDA_VISIBLE_DEVICES'] = \"\"\n",
@@ -100,7 +104,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def get_run_dir(path, new_run):\n",
@@ -178,7 +184,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "K.image_data_format()"
@@ -187,7 +195,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "train_save_dir = \"images/{stage}/{p}\".format(stage=train_dir, p=p)\n",
@@ -198,7 +208,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Create train & val image generators\n",
@@ -243,6 +255,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -280,7 +293,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "class_counts = np.bincount(train_generator_orig.classes)\n",
@@ -320,7 +335,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def plot(gen):\n",
@@ -482,6 +499,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -501,6 +519,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -522,6 +541,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -551,6 +571,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -589,7 +610,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(model.summary())"
@@ -609,7 +632,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "initial_epoch = epochs\n",
@@ -631,7 +656,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "raw_metrics = model.evaluate_generator(val_generator, steps=val_batches) #,\n",
@@ -656,7 +683,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "filename = \"{acc:.5}_acc_{loss:.5}_loss_model.hdf5\".format(**metrics)\n",
@@ -709,7 +738,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/projects/breast_cancer/Preprocessing-Save-JPEGs.ipynb
+++ b/projects/breast_cancer/Preprocessing-Save-JPEGs.ipynb
@@ -602,7 +602,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/projects/breast_cancer/preprocess.py
+++ b/projects/breast_cancer/preprocess.py
@@ -29,9 +29,11 @@ import os
 import shutil
 
 import numpy as np
-
-from breastcancer.preprocessing import preprocess, save, train_val_split
+import pandas as pd
+from sklearn.model_selection import train_test_split
 from pyspark.sql import SparkSession
+
+from breastcancer.preprocessing import add_row_indices, get_labels_df, preprocess, save
 
 
 # Create new SparkSession
@@ -56,93 +58,58 @@ spark.sparkContext.addPyFile(zipname)
 # procedure of the paper.  Look into simply selecting tiles of the
 # desired size to begin with.
 
-# Get list of image numbers, minus the broken ones.
-broken = {2, 45, 91, 112, 242, 256, 280, 313, 329, 467}
-slide_nums = sorted(set(range(1,501)) - broken)
-
 # Settings
-training = True
+# TODO: Convert this to a set of parsed command line arguments
 tile_size = 256
 sample_size = 256
 grayscale = False
 num_partitions = 20000
-add_row_indices = True
+training = True
+row_indices = False
 train_frac = 0.8
-split_seed = 24
-folder = "data"  # Linux-filesystem directory to read raw data
+sample_frac=0.01
+seed = 42
+folder = "data"  # Linux-filesystem directory to read raw WSI data
 save_folder = "data"  # Hadoop-supported directory in which to save DataFrames
-df_path = os.path.join(save_folder, "samples_{}_{}{}.parquet".format(
-    "labels" if training else "testing", sample_size, "_grayscale" if grayscale else ""))
 train_df_path = os.path.join(save_folder, "train_{}{}.parquet".format(sample_size,
     "_grayscale" if grayscale else ""))
 val_df_path = os.path.join(save_folder, "val_{}{}.parquet".format(sample_size,
     "_grayscale" if grayscale else ""))
+train_sample_path = os.path.join(save_folder, "train_{}_sample_{}{}.parquet".format(sample_frac,
+    sample_size, "_grayscale" if grayscale else ""))
+val_sample_path = os.path.join(save_folder, "val_{}_sample_{}{}.parquet".format(sample_frac,
+    sample_size, "_grayscale" if grayscale else ""))
 
-# Process all slides.
-df = preprocess(spark, slide_nums, tile_size=tile_size, sample_size=sample_size,
-                grayscale=grayscale, training=training, num_partitions=num_partitions,
-                folder=folder)
+# Get labels
+labels_df = get_labels_df(folder)
 
-# Save DataFrame of samples.
-save(df, df_path, sample_size, grayscale)
+# Split into train and validation sets based on slide number, stratified by class
+train, val = train_test_split(labels_df, train_size=train_frac, stratify=labels_df['tumor_score'],
+                              random_state=seed)
 
-# Load full DataFrame from disk.
-df = spark.read.load(df_path)
+# Process train & val slides
+train_df = preprocess(spark, train.index, tile_size=tile_size, sample_size=sample_size,
+                      grayscale=grayscale, num_partitions=num_partitions, folder=folder)
+val_df = preprocess(spark, val.index, tile_size=tile_size, sample_size=sample_size,
+                    grayscale=grayscale, num_partitions=num_partitions, folder=folder)
 
-# Split into train and validation DataFrames based On slide number
-train, val = train_val_split(spark, df, slide_nums, folder, train_frac, add_row_indices,
-                             seed=split_seed)
+if row_indices:
+  # Add row indices
+  train_df = add_row_indices(train_df)
+  val_df = add_row_indices(val_df)
 
-# Save train and validation DataFrames.
-save(train, train_df_path, sample_size, grayscale)
-save(val, val_df_path, sample_size, grayscale)
+# Save train & val DataFrames
+save(train_df, train_df_path, sample_size, grayscale)
+save(val_df, val_df_path, sample_size, grayscale)
 
+if sample_frac > 0:
+  # Sample Data
+  train_df = spark.read.load(train_df_path)
+  val_df = spark.read.load(val_df_path)
+  train_sample = sample(train_df, sample_frac, seed)
+  val_sample = sample(val_df, sample_frac, seed)
 
-# ---
-#
-# Sample Data
-## TODO: Wrap this in a function with appropriate default arguments
-
-# Load train and validation DataFrames from disk.
-train = spark.read.load(train_df_path)
-val = spark.read.load(val_df_path)
-
-# Take a stratified sample.
-p=0.01
-train_sample = train.drop("__INDEX").sampleBy("tumor_score", fractions={1: p, 2: p, 3: p}, seed=42)
-val_sample = val.drop("__INDEX").sampleBy("tumor_score", fractions={1: p, 2: p, 3: p}, seed=42)
-
-# Reassign row indices.
-# TODO: Wrap this in a function with appropriate default arguments.
-train_sample = (
-  train_sample.rdd
-              .zipWithIndex()
-              .map(lambda r: (r[1] + 1, *r[0]))
-              .toDF(['__INDEX', 'slide_num', 'tumor_score', 'molecular_score', 'sample']))
-train_sample = train_sample.select(train_sample["__INDEX"].astype("int"),
-                                   train_sample.slide_num.astype("int"),
-                                   train_sample.tumor_score.astype("int"),
-                                   train_sample.molecular_score,
-                                   train_sample["sample"])
-
-val_sample = (
-  val_sample.rdd
-            .zipWithIndex()
-            .map(lambda r: (r[1] + 1, *r[0]))
-            .toDF(['__INDEX', 'slide_num', 'tumor_score', 'molecular_score', 'sample']))
-val_sample = val_sample.select(val_sample["__INDEX"].astype("int"),
-                               val_sample.slide_num.astype("int"),
-                               val_sample.tumor_score.astype("int"),
-                               val_sample.molecular_score,
-                               val_sample["sample"])
-
-# Save train and validation DataFrames.
-tr_sample_filename = "train_{}_sample_{}{}.parquet".format(p, sample_size,
-    "_grayscale" if grayscale else "")
-val_sample_filename = "val_{}_sample_{}{}.parquet".format(p, sample_size,
-    "_grayscale" if grayscale else "")
-train_sample_path = os.path.join(save_folder, tr_sample_filename)
-val_sample_path = os.path.join(save_folder, val_sample_filename)
-save(train_sample, train_sample_path, sample_size, grayscale)
-save(val_sample, val_sample_path, sample_size, grayscale)
+  # Save sampled DataFrames.
+  save(train_sample, train_sample_path, sample_size, grayscale)
+  save(val_sample, val_sample_path, sample_size, grayscale)
 


### PR DESCRIPTION
In anticipation of near-future algorithmic improvements to the
preprocessing to improve model training, this simplifies and cleans up
the preprocessing code as follows.

- Previously, we were processing all slides into one large saved
DataFrame, and then splitting that DataFrame into train and validation
DataFrames.  This commit simplifies this by splitting the slide numbers
into train and validation sets, and then processing those slides
separately.  This effectively skips the creation of the large DataFrame,
and removes the need to split that large DataFrame into train/val ones,
which should provide a large performance benefit.  The DataFrame `union`
method can be used to combine two DataFrames row-wise.
- Previously, we maintained a list of "broken" slides that were manually
removed.  This commit removes that manual list, and instead adds a
try/except filtering step to automatically remove problematic slides.
- This commit moves ad-hoc sampling code into a new `sample` function.
- This commit moves code to add row indices to a DataFrame into a new
`add_row_indices` function.

The benefit is that near-future algorithmic improvements to the
preprocessing code will be much easier to incorporate.