### PR TITLE
[SYSTEMML-1821] Improve the training process in mnist_lenet_distrib_sgd.dml

### DIFF
--- a/scripts/nn/examples/mnist_lenet_distrib_sgd.dml
+++ b/scripts/nn/examples/mnist_lenet_distrib_sgd.dml
@@ -120,8 +120,8 @@ train = function(matrix[double] X, matrix[double] Y,
       # the other groups.
       group_beg = ((g-1) * group_batch_size) %% N + 1
       group_end = min(N, group_beg + group_batch_size - 1)
-      X_group_batch = X[group_beg:group_end,]
-      y_group_batch = Y[group_beg:group_end,]
+      row_group = group_beg - group_beg + 1
+     
 
       # Data structure to store gradients computed in parallel
       dW1_agg = matrix(0, rows=parallel_batches, cols=nrow(W1)*ncol(W1))
@@ -134,12 +134,15 @@ train = function(matrix[double] X, matrix[double] Y,
       db4_agg = matrix(0, rows=parallel_batches, cols=nrow(b4)*ncol(b4))
 
       # Run graph on each mini-batch in this group in parallel (ideally on multiple GPUs)
-      parfor (j in 1:parallel_batches) {
+      # mode=REMOTE_SPARK, opt=CONSTRAINED
+      parfor (j in 1:parallel_batches, mode=REMOTE_SPARK, opt=CONSTRAINED, resultmerge=REMOTE_SPARK) {
         # Get a mini-batch in this group
-        beg = ((j-1) * batch_size) %% nrow(X_group_batch) + 1
-        end = min(nrow(X_group_batch), beg + batch_size - 1)
-        X_batch = X_group_batch[beg:end,]
-        y_batch = y_group_batch[beg:end,]
+        batch_beg = group_beg + ((j-1) * batch_size) %% (group_end - group_beg + 1) + 1
+        batch_end = min(N, batch_beg + batch_size - 1)
+        row_batch = batch_end - batch_beg + 1
+
+        X_batch = X[batch_beg:batch_end,]
+        y_batch = Y[batch_beg:batch_end,]
 
         # Enable for debugging:
         #print("Epoch: "+e+"\t Group: "+g+"\t j: "+j+"\t nrow(X_batch): "+nrow(X_batch))
@@ -201,7 +204,7 @@ train = function(matrix[double] X, matrix[double] Y,
         # Flatten and store gradients for this parallel execution
         # Note: We multiply by a weighting to allow for proper gradient averaging during the
         # aggregation even with uneven batch sizes.
-        weighting = nrow(X_batch) / nrow(X_group_batch)
+        weighting = row_batch / row_group
         dW1_agg[j,] = matrix(dW1, rows=1, cols=nrow(W1)*ncol(W1)) * weighting
         dW2_agg[j,] = matrix(dW2, rows=1, cols=nrow(W2)*ncol(W2)) * weighting
         dW3_agg[j,] = matrix(dW3, rows=1, cols=nrow(W3)*ncol(W3)) * weighting
@@ -235,13 +238,17 @@ train = function(matrix[double] X, matrix[double] Y,
       [b3, vb3] = sgd_nesterov::update(b3, db3, lr, mu, vb3)
       [b4, vb4] = sgd_nesterov::update(b4, db4, lr, mu, vb4)
 
+
       # Compute loss & accuracy for training & validation data every 100 iterations.
       if (g %% 10 == 0) {
         # Get a mini-batch in this group
-        beg = ((j-1) * batch_size) %% nrow(X_group_batch) + 1
-        end = min(nrow(X_group_batch), beg + batch_size - 1)
-        X_batch = X_group_batch[beg:end,]
-        y_batch = y_group_batch[beg:end,]
+        batch_beg = group_beg + ((j-1) * batch_size) %% (group_end - group_beg + 1) + 1
+        batch_end = min(N, batch_beg + batch_size - 1)
+        row_batch = batch_end - batch_beg + 1
+
+        X_batch = X[batch_beg:batch_end,]
+        y_batch = Y[batch_beg:batch_end,]
+
 
         # Compute training loss & accuracy using final
         probs = predict(X_batch, C, Hin, Win, W1, b1, W2, b2, W3, b3, W4, b4)

--- a/scripts/nn/examples/mnist_lenet_distrib_sgd.dml
+++ b/scripts/nn/examples/mnist_lenet_distrib_sgd.dml
@@ -137,7 +137,7 @@ train = function(matrix[double] X, matrix[double] Y,
       # mode=REMOTE_SPARK, opt=CONSTRAINED
       parfor (j in 1:parallel_batches, mode=REMOTE_SPARK, opt=CONSTRAINED, resultmerge=REMOTE_SPARK) {
         # Get a mini-batch in this group
-        batch_beg = group_beg + ((j-1) * batch_size) %% (group_end - group_beg + 1) + 1
+        batch_beg = group_beg + ((j-1) * batch_size) %% row_group + 1
         batch_end = min(N, batch_beg + batch_size - 1)
         row_batch = batch_end - batch_beg + 1
 
@@ -242,7 +242,7 @@ train = function(matrix[double] X, matrix[double] Y,
       # Compute loss & accuracy for training & validation data every 100 iterations.
       if (g %% 10 == 0) {
         # Get a mini-batch in this group
-        batch_beg = group_beg + ((j-1) * batch_size) %% (group_end - group_beg + 1) + 1
+        batch_beg = group_beg + ((j-1) * batch_size) %% row_group + 1
         batch_end = min(N, batch_beg + batch_size - 1)
         row_batch = batch_end - batch_beg + 1
 

--- a/scripts/nn/examples/mnist_lenet_distrib_sgd.dml
+++ b/scripts/nn/examples/mnist_lenet_distrib_sgd.dml
@@ -120,8 +120,7 @@ train = function(matrix[double] X, matrix[double] Y,
       # the other groups.
       group_beg = ((g-1) * group_batch_size) %% N + 1
       group_end = min(N, group_beg + group_batch_size - 1)
-      row_group = group_beg - group_beg + 1
-     
+      nrow_group = group_end - group_beg + 1
 
       # Data structure to store gradients computed in parallel
       dW1_agg = matrix(0, rows=parallel_batches, cols=nrow(W1)*ncol(W1))
@@ -137,9 +136,9 @@ train = function(matrix[double] X, matrix[double] Y,
       # mode=REMOTE_SPARK, opt=CONSTRAINED
       parfor (j in 1:parallel_batches, mode=REMOTE_SPARK, opt=CONSTRAINED, resultmerge=REMOTE_SPARK) {
         # Get a mini-batch in this group
-        batch_beg = group_beg + ((j-1) * batch_size) %% row_group + 1
+        batch_beg = group_beg + ((j-1) * batch_size) %% nrow_group
         batch_end = min(N, batch_beg + batch_size - 1)
-        row_batch = batch_end - batch_beg + 1
+        nrow_batch = batch_end - batch_beg + 1
 
         X_batch = X[batch_beg:batch_end,]
         y_batch = Y[batch_beg:batch_end,]
@@ -204,7 +203,7 @@ train = function(matrix[double] X, matrix[double] Y,
         # Flatten and store gradients for this parallel execution
         # Note: We multiply by a weighting to allow for proper gradient averaging during the
         # aggregation even with uneven batch sizes.
-        weighting = row_batch / row_group
+        weighting = nrow_batch / nrow_group
         dW1_agg[j,] = matrix(dW1, rows=1, cols=nrow(W1)*ncol(W1)) * weighting
         dW2_agg[j,] = matrix(dW2, rows=1, cols=nrow(W2)*ncol(W2)) * weighting
         dW3_agg[j,] = matrix(dW3, rows=1, cols=nrow(W3)*ncol(W3)) * weighting
@@ -242,9 +241,10 @@ train = function(matrix[double] X, matrix[double] Y,
       # Compute loss & accuracy for training & validation data every 100 iterations.
       if (g %% 10 == 0) {
         # Get a mini-batch in this group
-        batch_beg = group_beg + ((j-1) * batch_size) %% row_group + 1
+
+        batch_beg = group_beg + ((j-1) * batch_size) %% nrow_group
         batch_end = min(N, batch_beg + batch_size - 1)
-        row_batch = batch_end - batch_beg + 1
+        nrow_batch = batch_end - batch_beg + 1
 
         X_batch = X[batch_beg:batch_end,]
         y_batch = Y[batch_beg:batch_end,]

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ParForProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ParForProgramBlock.java
@@ -105,6 +105,7 @@ import org.apache.sysml.runtime.instructions.cp.VariableCPInstruction;
 import org.apache.sysml.runtime.io.IOUtilFunctions;
 import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
 import org.apache.sysml.runtime.matrix.data.OutputInfo;
+import org.apache.sysml.runtime.util.MapReduceTool;
 import org.apache.sysml.runtime.util.UtilFunctions;
 import org.apache.sysml.utils.Statistics;
 import org.apache.sysml.yarn.ropt.YarnClusterAnalyzer;
@@ -1326,7 +1327,7 @@ public class ParForProgramBlock extends ForProgramBlock
 			for (String key : ec.getVariables().keySet() ) {
 				if( varsRead.containsVariable(key) && !blacklist.contains(key) ) {
 					Data d = ec.getVariable(key);
-					if( d.getDataType() == DataType.MATRIX )
+					if( d.getDataType() == DataType.MATRIX && !MapReduceTool.existsFileOnHDFS(((MatrixObject)d).getFileName()))
 						((MatrixObject)d).exportData(_replicationExport);
 				}
 			}


### PR DESCRIPTION
We optimize `mnist_lenet_distrib_sgd.dml` by removing the unnecessary intermediate matrixes. However, there comes an error `org.apache.hadoop.mapred.FileAlreadyExistsException` with it when running the distributed training of MNIST_LeNet example. The revisions in 'org.apache.sysml.runtime.controlprogram.ParForProgramBlock#exportMatricesToHDFS' can solve the error, but may not the best solution.