### PR TITLE
[SYSTEMML-1663] Enable elementwise multiplication tests

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/RewriteElementwiseMultChainOptimizationTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/RewriteElementwiseMultChainOptimizationTest.java
@@ -61,7 +61,6 @@ public class RewriteElementwiseMultChainOptimizationTest extends AutomatedTestBa
 		testRewriteMatrixMultChainOp(TEST_NAME1, false, ExecType.SPARK);
 	}
 	
-	/* TODO enable together with RewriteElementwiseMultChainOptimization
 	@Test
 	public void testMatrixMultChainOptRewritesCP() {
 		testRewriteMatrixMultChainOp(TEST_NAME1, true, ExecType.CP);
@@ -71,7 +70,6 @@ public class RewriteElementwiseMultChainOptimizationTest extends AutomatedTestBa
 	public void testMatrixMultChainOptRewritesSP() {
 		testRewriteMatrixMultChainOp(TEST_NAME1, true, ExecType.SPARK);
 	}
-	*/
 
 	private void testRewriteMatrixMultChainOp(String testname, boolean rewrites, ExecType et)
 	{	


### PR DESCRIPTION
These tests were meant to be enabled with the completion of SYSTEMML-1663. This patch uncomments them.