### PR TITLE
[SYSTEMML-1831] Improve the efficiency of matrix subsetting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1455,6 +1455,11 @@
 			<version>1.9.5</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-xml_2.11</artifactId>
+            <version>1.0.6</version>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/scripts/nn/examples/mnist_lenet_distrib_sgd.dml
+++ b/scripts/nn/examples/mnist_lenet_distrib_sgd.dml
@@ -134,7 +134,7 @@ train = function(matrix[double] X, matrix[double] Y,
       db4_agg = matrix(0, rows=parallel_batches, cols=nrow(b4)*ncol(b4))
 
       # Run graph on each mini-batch in this group in parallel (ideally on multiple GPUs)
-      parfor (j in 1:parallel_batches) {
+      parfor (j in 1:parallel_batches, mode=REMOTE_SPARK, opt=CONSTRAINED, resultmerge=REMOTE_SPARK) {
         # Get a mini-batch in this group
         beg = ((j-1) * batch_size) %% nrow(X_group_batch) + 1
         end = min(nrow(X_group_batch), beg + batch_size - 1)

--- a/scripts/nn/examples/mnist_lenet_distrib_sgd_optimize.dml
+++ b/scripts/nn/examples/mnist_lenet_distrib_sgd_optimize.dml
@@ -1,0 +1,404 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+/*
+ * MNIST LeNet Example
+ */
+# Imports
+source("nn/layers/affine.dml") as affine
+source("nn/layers/conv2d_builtin.dml") as conv2d
+source("nn/layers/cross_entropy_loss.dml") as cross_entropy_loss
+source("nn/layers/dropout.dml") as dropout
+source("nn/layers/l2_reg.dml") as l2_reg
+source("nn/layers/max_pool2d_builtin.dml") as max_pool2d
+source("nn/layers/relu.dml") as relu
+source("nn/layers/softmax.dml") as softmax
+source("nn/optim/sgd_nesterov.dml") as sgd_nesterov
+
+train = function(matrix[double] X, matrix[double] Y,
+                 matrix[double] X_val, matrix[double] Y_val,
+                 int C, int Hin, int Win, int batch_size,
+                 int parallel_batches, int epochs)
+    return (matrix[double] W1, matrix[double] b1,
+            matrix[double] W2, matrix[double] b2,
+            matrix[double] W3, matrix[double] b3,
+            matrix[double] W4, matrix[double] b4) {
+  /*
+   * Trains a convolutional net using the "LeNet" architecture using
+   * distributed synchronous SGD.
+   *
+   * The input matrix, X, has N examples, each represented as a 3D
+   * volume unrolled into a single vector.  The targets, Y, have K
+   * classes, and are one-hot encoded.
+   *
+   * Inputs:
+   *  - X: Input data matrix, of shape (N, C*Hin*Win).
+   *  - Y: Target matrix, of shape (N, K).
+   *  - X_val: Input validation data matrix, of shape (N, C*Hin*Win).
+   *  - Y_val: Target validation matrix, of shape (N, K).
+   *  - C: Number of input channels (dimensionality of input depth).
+   *  - Hin: Input height.
+   *  - Win: Input width.
+   *  - batch_size: Number of examples in each batch.
+   *  - parallel_batches: Number of batches to run in parallel.
+   *  - epochs: Total number of full training loops over the full data set.
+   *
+   * Outputs:
+   *  - W1: 1st layer weights (parameters) matrix, of shape (F1, C*Hf*Wf).
+   *  - b1: 1st layer biases vector, of shape (F1, 1).
+   *  - W2: 2nd layer weights (parameters) matrix, of shape (F2, F1*Hf*Wf).
+   *  - b2: 2nd layer biases vector, of shape (F2, 1).
+   *  - W3: 3rd layer weights (parameters) matrix, of shape (F2*(Hin/4)*(Win/4), N3).
+   *  - b3: 3rd layer biases vector, of shape (1, N3).
+   *  - W4: 4th layer weights (parameters) matrix, of shape (N3, K).
+   *  - b4: 4th layer biases vector, of shape (1, K).
+   */
+  N = nrow(X)
+  K = ncol(Y)
+
+  # Create network:
+  # conv1 -> relu1 -> pool1 -> conv2 -> relu2 -> pool2 -> affine3 -> relu3 -> affine4 -> softmax
+  Hf = 5  # filter height
+  Wf = 5  # filter width
+  stride = 1
+  pad = 2  # For same dimensions, (Hf - stride) / 2
+
+  F1 = 32  # num conv filters in conv1
+  F2 = 64  # num conv filters in conv2
+  N3 = 512  # num nodes in affine3
+  # Note: affine4 has K nodes, which is equal to the number of target dimensions (num classes)
+
+  [W1, b1] = conv2d::init(F1, C, Hf, Wf)  # inputs: (N, C*Hin*Win)
+  [W2, b2] = conv2d::init(F2, F1, Hf, Wf)  # inputs: (N, F1*(Hin/2)*(Win/2))
+  [W3, b3] = affine::init(F2*(Hin/2/2)*(Win/2/2), N3)  # inputs: (N, F2*(Hin/2/2)*(Win/2/2))
+  [W4, b4] = affine::init(N3, K)  # inputs: (N, N3)
+  W4 = W4 / sqrt(2)  # different initialization, since being fed into softmax, instead of relu
+
+  # Initialize SGD w/ Nesterov momentum optimizer
+  lr = 0.01  # learning rate
+  mu = 0.9  #0.5  # momentum
+  decay = 0.95  # learning rate decay constant
+  vW1 = sgd_nesterov::init(W1); vb1 = sgd_nesterov::init(b1)
+  vW2 = sgd_nesterov::init(W2); vb2 = sgd_nesterov::init(b2)
+  vW3 = sgd_nesterov::init(W3); vb3 = sgd_nesterov::init(b3)
+  vW4 = sgd_nesterov::init(W4); vb4 = sgd_nesterov::init(b4)
+
+  # Regularization
+  lambda = 5e-04
+
+  # Optimize
+  print("Starting optimization")
+  group_batch_size = parallel_batches*batch_size
+  groups = as.integer(ceil(N/group_batch_size))
+  print("Total Epochs: "+epochs+", Batch size: "+batch_size+
+        ", Degree of parallelism: "+parallel_batches+", Group batch size: "+group_batch_size+
+        ", Num groups: "+groups)
+  # Loop over the dataset multiple times
+  for (e in 1:epochs) {
+    # Grab groups of mini-batches
+    for (g in 1:groups) {
+      # Get next group of mini-batches
+      # NOTE: At the end of the dataset, the last mini-batch in this group could be smaller than
+      # the other groups.
+      group_beg = ((g-1) * group_batch_size) %% N + 1
+      group_end = min(N, group_beg + group_batch_size - 1)
+      nrow_group = group_end - group_beg + 1
+
+      # Data structure to store gradients computed in parallel
+      dW1_agg = matrix(0, rows=parallel_batches, cols=nrow(W1)*ncol(W1))
+      dW2_agg = matrix(0, rows=parallel_batches, cols=nrow(W2)*ncol(W2))
+      dW3_agg = matrix(0, rows=parallel_batches, cols=nrow(W3)*ncol(W3))
+      dW4_agg = matrix(0, rows=parallel_batches, cols=nrow(W4)*ncol(W4))
+      db1_agg = matrix(0, rows=parallel_batches, cols=nrow(b1)*ncol(b1))
+      db2_agg = matrix(0, rows=parallel_batches, cols=nrow(b2)*ncol(b2))
+      db3_agg = matrix(0, rows=parallel_batches, cols=nrow(b3)*ncol(b3))
+      db4_agg = matrix(0, rows=parallel_batches, cols=nrow(b4)*ncol(b4))
+
+      # Run graph on each mini-batch in this group in parallel (ideally on multiple GPUs)
+      # mode=REMOTE_SPARK, opt=CONSTRAINED
+      parfor (j in 1:parallel_batches, mode=REMOTE_SPARK, opt=CONSTRAINED, resultmerge=REMOTE_SPARK) {
+        # Get a mini-batch in this group
+        batch_beg = group_beg + ((j-1) * batch_size) %% nrow_group
+        batch_end = min(N, batch_beg + batch_size - 1)
+        nrow_batch = batch_end - batch_beg + 1
+
+        X_batch = X[batch_beg:batch_end,]
+        y_batch = Y[batch_beg:batch_end,]
+
+        # Enable for debugging:
+        #print("Epoch: "+e+"\t Group: "+g+"\t j: "+j+"\t nrow(X_batch): "+nrow(X_batch))
+
+        # Compute forward pass
+        ## layer 1: conv1 -> relu1 -> pool1
+        [outc1, Houtc1, Woutc1] = conv2d::forward(X_batch, W1, b1, C, Hin, Win, Hf, Wf,
+                                                  stride, stride, pad, pad)
+        outr1 = relu::forward(outc1)
+        [outp1, Houtp1, Woutp1] = max_pool2d::forward(outr1, F1, Houtc1, Woutc1, Hf=2, Wf=2,
+                                                      strideh=2, stridew=2, pad=0, pad=0)
+        ## layer 2: conv2 -> relu2 -> pool2
+        [outc2, Houtc2, Woutc2] = conv2d::forward(outp1, W2, b2, F1, Houtp1, Woutp1, Hf, Wf,
+                                                  stride, stride, pad, pad)
+        outr2 = relu::forward(outc2)
+        [outp2, Houtp2, Woutp2] = max_pool2d::forward(outr2, F2, Houtc2, Woutc2, Hf=2, Wf=2,
+                                                      strideh=2, stridew=2, pad=0, pad=0)
+        ## layer 3:  affine3 -> relu3 -> dropout
+        outa3 = affine::forward(outp2, W3, b3)
+        outr3 = relu::forward(outa3)
+        [outd3, maskd3] = dropout::forward(outr3, 0.5, -1)
+        ## layer 4:  affine4 -> softmax
+        outa4 = affine::forward(outd3, W4, b4)
+        probs = softmax::forward(outa4)
+
+        # Compute data backward pass
+        ## loss:
+        dprobs = cross_entropy_loss::backward(probs, y_batch)
+        ## layer 4:  affine4 -> softmax
+        douta4 = softmax::backward(dprobs, outa4)
+        [doutd3, dW4, db4] = affine::backward(douta4, outr3, W4, b4)
+        ## layer 3:  affine3 -> relu3 -> dropout
+        doutr3 = dropout::backward(doutd3, outr3, 0.5, maskd3)
+        douta3 = relu::backward(doutr3, outa3)
+        [doutp2, dW3, db3] = affine::backward(douta3, outp2, W3, b3)
+        ## layer 2: conv2 -> relu2 -> pool2
+        doutr2 = max_pool2d::backward(doutp2, Houtp2, Woutp2, outr2, F2, Houtc2, Woutc2, Hf=2, Wf=2,
+                                      strideh=2, stridew=2, pad=0, pad=0)
+        doutc2 = relu::backward(doutr2, outc2)
+        [doutp1, dW2, db2] = conv2d::backward(doutc2, Houtc2, Woutc2, outp1, W2, b2, F1,
+                                              Houtp1, Woutp1, Hf, Wf, stride, stride, pad, pad)
+        ## layer 1: conv1 -> relu1 -> pool1
+        doutr1 = max_pool2d::backward(doutp1, Houtp1, Woutp1, outr1, F1, Houtc1, Woutc1, Hf=2, Wf=2,
+                                      strideh=2, stridew=2, pad=0, pad=0)
+        doutc1 = relu::backward(doutr1, outc1)
+        [dX_batch, dW1, db1] = conv2d::backward(doutc1, Houtc1, Woutc1, X_batch, W1, b1, C,
+                                                Hin, Win, Hf, Wf, stride, stride, pad, pad)
+
+        # Compute regularization backward pass
+        dW1_reg = l2_reg::backward(W1, lambda)
+        dW2_reg = l2_reg::backward(W2, lambda)
+        dW3_reg = l2_reg::backward(W3, lambda)
+        dW4_reg = l2_reg::backward(W4, lambda)
+        dW1 = dW1 + dW1_reg
+        dW2 = dW2 + dW2_reg
+        dW3 = dW3 + dW3_reg
+        dW4 = dW4 + dW4_reg
+
+        # Flatten and store gradients for this parallel execution
+        # Note: We multiply by a weighting to allow for proper gradient averaging during the
+        # aggregation even with uneven batch sizes.
+        weighting = nrow_batch / nrow_group
+        dW1_agg[j,] = matrix(dW1, rows=1, cols=nrow(W1)*ncol(W1)) * weighting
+        dW2_agg[j,] = matrix(dW2, rows=1, cols=nrow(W2)*ncol(W2)) * weighting
+        dW3_agg[j,] = matrix(dW3, rows=1, cols=nrow(W3)*ncol(W3)) * weighting
+        dW4_agg[j,] = matrix(dW4, rows=1, cols=nrow(W4)*ncol(W4)) * weighting
+        db1_agg[j,] = matrix(db1, rows=1, cols=nrow(b1)*ncol(b1)) * weighting
+        db2_agg[j,] = matrix(db2, rows=1, cols=nrow(b2)*ncol(b2)) * weighting
+        db3_agg[j,] = matrix(db3, rows=1, cols=nrow(b3)*ncol(b3)) * weighting
+        db4_agg[j,] = matrix(db4, rows=1, cols=nrow(b4)*ncol(b4)) * weighting
+      }
+
+      # Aggregate gradients
+      # Note: The gradients are already pre-multiplied by a weight so that addition here
+      # results in gradient averaging even with different possible mini-batch sizes. I.e.,
+      # the final mini-batch at the end of the dataset could be smaller than the other mini-batches.
+      dW1 = matrix(colSums(dW1_agg), rows=nrow(W1), cols=ncol(W1))
+      dW2 = matrix(colSums(dW2_agg), rows=nrow(W2), cols=ncol(W2))
+      dW3 = matrix(colSums(dW3_agg), rows=nrow(W3), cols=ncol(W3))
+      dW4 = matrix(colSums(dW4_agg), rows=nrow(W4), cols=ncol(W4))
+      db1 = matrix(colSums(db1_agg), rows=nrow(b1), cols=ncol(b1))
+      db2 = matrix(colSums(db2_agg), rows=nrow(b2), cols=ncol(b2))
+      db3 = matrix(colSums(db3_agg), rows=nrow(b3), cols=ncol(b3))
+      db4 = matrix(colSums(db4_agg), rows=nrow(b4), cols=ncol(b4))
+
+      # Optimize with SGD w/ Nesterov momentum
+      [W1, vW1] = sgd_nesterov::update(W1, dW1, lr, mu, vW1)
+      [W2, vW2] = sgd_nesterov::update(W2, dW2, lr, mu, vW2)
+      [W3, vW3] = sgd_nesterov::update(W3, dW3, lr, mu, vW3)
+      [W4, vW4] = sgd_nesterov::update(W4, dW4, lr, mu, vW4)
+      [b1, vb1] = sgd_nesterov::update(b1, db1, lr, mu, vb1)
+      [b2, vb2] = sgd_nesterov::update(b2, db2, lr, mu, vb2)
+      [b3, vb3] = sgd_nesterov::update(b3, db3, lr, mu, vb3)
+      [b4, vb4] = sgd_nesterov::update(b4, db4, lr, mu, vb4)
+
+
+      # Compute loss & accuracy for training & validation data every 100 iterations.
+      if (g %% 10 == 0) {
+        # Get a mini-batch in this group
+
+        batch_beg = group_beg + ((j-1) * batch_size) %% nrow_group
+        batch_end = min(N, batch_beg + batch_size - 1)
+        nrow_batch = batch_end - batch_beg + 1
+
+        X_batch = X[batch_beg:batch_end,]
+        y_batch = Y[batch_beg:batch_end,]
+
+
+        # Compute training loss & accuracy using final
+        probs = predict(X_batch, C, Hin, Win, W1, b1, W2, b2, W3, b3, W4, b4)
+        loss_data = cross_entropy_loss::forward(probs, y_batch)
+        loss_reg_W1 = l2_reg::forward(W1, lambda)
+        loss_reg_W2 = l2_reg::forward(W2, lambda)
+        loss_reg_W3 = l2_reg::forward(W3, lambda)
+        loss_reg_W4 = l2_reg::forward(W4, lambda)
+        loss = loss_data + loss_reg_W1 + loss_reg_W2 + loss_reg_W3 + loss_reg_W4
+        accuracy = mean(rowIndexMax(probs) == rowIndexMax(y_batch))
+
+        # Compute validation loss & accuracy
+        probs_val = predict(X_val, C, Hin, Win, W1, b1, W2, b2, W3, b3, W4, b4)
+        loss_val = cross_entropy_loss::forward(probs_val, Y_val)
+        accuracy_val = mean(rowIndexMax(probs_val) == rowIndexMax(Y_val))
+
+        # Output results
+        print("Epoch: " + e + ", Group: " + g + ", Train Loss: " + loss + ", Train Accuracy: "
+              + accuracy + ", Val Loss: " + loss_val + ", Val Accuracy: " + accuracy_val)
+      }
+    }
+    # Anneal momentum towards 0.999
+    #mu = mu + (0.999 - mu)/(1+epochs-e)
+    # Decay learning rate
+    lr = lr * decay
+  }
+}
+
+predict = function(matrix[double] X, int C, int Hin, int Win,
+                   matrix[double] W1, matrix[double] b1,
+                   matrix[double] W2, matrix[double] b2,
+                   matrix[double] W3, matrix[double] b3,
+                   matrix[double] W4, matrix[double] b4)
+    return (matrix[double] probs) {
+  /*
+   * Computes the class probability predictions of a convolutional
+   * net using the "LeNet" architecture.
+   *
+   * The input matrix, X, has N examples, each represented as a 3D
+   * volume unrolled into a single vector.
+   *
+   * Inputs:
+   *  - X: Input data matrix, of shape (N, C*Hin*Win).
+   *  - C: Number of input channels (dimensionality of input depth).
+   *  - Hin: Input height.
+   *  - Win: Input width.
+   *  - W1: 1st layer weights (parameters) matrix, of shape (F1, C*Hf*Wf).
+   *  - b1: 1st layer biases vector, of shape (F1, 1).
+   *  - W2: 2nd layer weights (parameters) matrix, of shape (F2, F1*Hf*Wf).
+   *  - b2: 2nd layer biases vector, of shape (F2, 1).
+   *  - W3: 3rd layer weights (parameters) matrix, of shape (F2*(Hin/4)*(Win/4), N3).
+   *  - b3: 3rd layer biases vector, of shape (1, N3).
+   *  - W4: 4th layer weights (parameters) matrix, of shape (N3, K).
+   *  - b4: 4th layer biases vector, of shape (1, K).
+   *
+   * Outputs:
+   *  - probs: Class probabilities, of shape (N, K).
+   */
+  N = nrow(X)
+
+  # Network:
+  # conv1 -> relu1 -> pool1 -> conv2 -> relu2 -> pool2 -> affine3 -> relu3 -> affine4 -> softmax
+  Hf = 5  # filter height
+  Wf = 5  # filter width
+  stride = 1
+  pad = 2  # For same dimensions, (Hf - stride) / 2
+
+  F1 = nrow(W1)  # num conv filters in conv1
+  F2 = nrow(W2)  # num conv filters in conv2
+  N3 = ncol(W3)  # num nodes in affine3
+  K = ncol(W4)  # num nodes in affine4, equal to number of target dimensions (num classes)
+
+  # Compute predictions over mini-batches
+  probs = matrix(0, rows=N, cols=K)
+  batch_size = 64
+  iters = ceil(N / batch_size)
+  parfor(i in 1:iters, check=0) {  # complains about `probs` as an inter-loop dependency
+    # Get next batch
+    beg = ((i-1) * batch_size) %% N + 1
+    end = min(N, beg + batch_size - 1)
+    X_batch = X[beg:end,]
+
+    # Compute forward pass
+    ## layer 1: conv1 -> relu1 -> pool1
+    [outc1, Houtc1, Woutc1] = conv2d::forward(X_batch, W1, b1, C, Hin, Win, Hf, Wf, stride, stride,
+                                              pad, pad)
+    outr1 = relu::forward(outc1)
+    [outp1, Houtp1, Woutp1] = max_pool2d::forward(outr1, F1, Houtc1, Woutc1, Hf=2, Wf=2,
+                                                  strideh=2, stridew=2, pad=0, pad=0)
+    ## layer 2: conv2 -> relu2 -> pool2
+    [outc2, Houtc2, Woutc2] = conv2d::forward(outp1, W2, b2, F1, Houtp1, Woutp1, Hf, Wf,
+                                              stride, stride, pad, pad)
+    outr2 = relu::forward(outc2)
+    [outp2, Houtp2, Woutp2] = max_pool2d::forward(outr2, F2, Houtc2, Woutc2, Hf=2, Wf=2,
+                                                  strideh=2, stridew=2, pad=0, pad=0)
+    ## layer 3:  affine3 -> relu3
+    outa3 = affine::forward(outp2, W3, b3)
+    outr3 = relu::forward(outa3)
+    ## layer 4:  affine4 -> softmax
+    outa4 = affine::forward(outr3, W4, b4)
+    probs_batch = softmax::forward(outa4)
+
+    # Store predictions
+    probs[beg:end,] = probs_batch
+  }
+}
+
+eval = function(matrix[double] probs, matrix[double] Y)
+    return (double loss, double accuracy) {
+  /*
+   * Evaluates a convolutional net using the "LeNet" architecture.
+   *
+   * The probs matrix contains the class probability predictions
+   * of K classes over N examples.  The targets, Y, have K classes,
+   * and are one-hot encoded.
+   *
+   * Inputs:
+   *  - probs: Class probabilities, of shape (N, K).
+   *  - Y: Target matrix, of shape (N, K).
+   *
+   * Outputs:
+   *  - loss: Scalar loss, of shape (1).
+   *  - accuracy: Scalar accuracy, of shape (1).
+   */
+  # Compute loss & accuracy
+  loss = cross_entropy_loss::forward(probs, Y)
+  correct_pred = rowIndexMax(probs) == rowIndexMax(Y)
+  accuracy = mean(correct_pred)
+}
+
+generate_dummy_data = function(int N, int C, int Hin, int Win, int K)
+    return (matrix[double] X, matrix[double] Y) {
+  /*
+   * Generate a dummy dataset.
+   *
+   * Outputs:
+   *  - X: Input data matrix, of shape (N, D).
+   *  - Y: Target matrix, of shape (N, K).
+   *  - C: Number of input channels (dimensionality of input depth).
+   *  - Hin: Input height.
+   *  - Win: Input width.
+   */
+  # Generate dummy input data
+  #N = 1024  # num examples
+  #C = 1  # num input channels
+  #Hin = 28  # input height
+  #Win = 28  # input width
+  #K = 10  # num target classes
+  X = rand(rows=N, cols=C*Hin*Win, pdf="normal")
+  classes = round(rand(rows=N, cols=1, min=1, max=K, pdf="uniform"))
+  Y = table(seq(1, N), classes, N, K)  # one-hot encoding
+}
+

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/caching/CacheableData.java
@@ -497,6 +497,8 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
               //get object from cache
               if( _data == null )
                 getCache();
+
+              if ( _data != null)
                 _data = (T) _data.sliceOperations((int) ixrange.rowStart, (int) ixrange.rowEnd, (int) ixrange.colStart, (int) ixrange.colEnd, _data);
 
               //call acquireHostRead if gpuHandle is set as well as is allocated

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/caching/CacheableData.java
@@ -495,11 +495,13 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
                 throw new CacheException ("MatrixObject not available to read.");
 
               //get object from cache
-              if( _data == null )
+              if( _data == null ) {
                 getCache();
+                if ( _data != null)
+                  _data = (T) _data.sliceOperations((int) ixrange.rowStart, (int) ixrange.rowEnd, (int) ixrange.colStart, (int) ixrange.colEnd, null);
+              }
 
-              if ( _data != null)
-                _data = (T) _data.sliceOperations((int) ixrange.rowStart, (int) ixrange.rowEnd, (int) ixrange.colStart, (int) ixrange.colEnd, _data);
+
 
               //call acquireHostRead if gpuHandle is set as well as is allocated
               //TODO: update the GPU part

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
@@ -54,6 +54,7 @@ import org.apache.sysml.runtime.matrix.MetaData;
 import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.Pair;
+import org.apache.sysml.runtime.util.IndexRange;
 import org.apache.sysml.runtime.util.MapReduceTool;
 import org.apache.sysml.utils.GPUStatistics;
 
@@ -252,6 +253,28 @@ public class ExecutionContext {
 		}
 		return mb;
 	}
+
+        /**
+         * Subset and pins a matrix variable into memory, update the finegrained statistics and returns the internal matrix block.
+         *
+         * @param varName variable name
+         * @param opcode  extended opcode
+         * @param ixrange index range
+         * @return matrix block
+         * @throws DMLRuntimeException if DMLRuntimeException occurs
+         */
+        public MatrixBlock subsetMatrixInput(String varName, String opcode, IndexRange ixrange) throws DMLRuntimeException {
+          long t1 = opcode != null && DMLScript.STATISTICS && DMLScript.FINEGRAINED_STATISTICS ? System.nanoTime() : 0;
+          MatrixBlock mb = subsetMatrixInput(varName, ixrange);
+          if(opcode != null && DMLScript.STATISTICS && DMLScript.FINEGRAINED_STATISTICS) {
+            long t2 = System.nanoTime();
+            if(mb.isInSparseFormat())
+              GPUStatistics.maintainCPMiscTimes(opcode, CPInstruction.MISC_TIMER_GET_SPARSE_MB, t2-t1);
+            else
+              GPUStatistics.maintainCPMiscTimes(opcode, CPInstruction.MISC_TIMER_GET_DENSE_MB, t2-t1);
+          }
+          return mb;
+        }
 	
 	/**
 	 * Pins a matrix variable into memory and returns the internal matrix block.
@@ -266,6 +289,21 @@ public class ExecutionContext {
 		MatrixObject mo = getMatrixObject(varName);
 		return mo.acquireRead();
 	}
+
+        /**
+         * Subset and pins a matrix variable into memory and returns the internal matrix block.
+         *
+         * @param varName variable name
+         * @param ixrange index range
+         * @return matrix block
+         * @throws DMLRuntimeException if DMLRuntimeException occurs
+         */
+        private MatrixBlock subsetMatrixInput(String varName, IndexRange ixrange)
+            throws DMLRuntimeException
+        {
+          MatrixObject mo = getMatrixObject(varName);
+          return mo.acquireSubsetRead(ixrange);
+        }
 	
 	public void setMetaData(String varName, long nrows, long ncols) 
 		throws DMLRuntimeException  

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
@@ -64,10 +64,6 @@ public final class MatrixIndexingCPInstruction extends IndexingCPInstruction
 				//MatrixBlock matBlock = ec.getMatrixInput(input1.getName(), getExtendedOpcode());
 				//resultBlock = matBlock.sliceOperations(ixrange, new MatrixBlock());
                                 resultBlock = ec.subsetMatrixInput(input1.getName(), getExtendedOpcode(), ixrange);
-
-				
-				//unpin rhs input
-				ec.releaseMatrixInput(input1.getName(), getExtendedOpcode());
 				
 				//ensure correct sparse/dense output representation
 				//(memory guarded by release of input)

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
@@ -62,7 +62,9 @@ public final class MatrixIndexingCPInstruction extends IndexingCPInstruction
 			{
 				//execute right indexing operation
 				MatrixBlock matBlock = ec.getMatrixInput(input1.getName(), getExtendedOpcode());
-				resultBlock = matBlock.sliceOperations(ixrange, new MatrixBlock());	
+				//resultBlock = matBlock.sliceOperations(ixrange, new MatrixBlock());
+                                resultBlock = ec.subsetMatrixInput(input1.getName(), getExtendedOpcode(), ixrange);
+
 				
 				//unpin rhs input
 				ec.releaseMatrixInput(input1.getName(), getExtendedOpcode());

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
@@ -61,7 +61,7 @@ public final class MatrixIndexingCPInstruction extends IndexingCPInstruction
 			else //via slicing the in-memory matrix
 			{
 				//execute right indexing operation
-				MatrixBlock matBlock = ec.getMatrixInput(input1.getName(), getExtendedOpcode());
+				//MatrixBlock matBlock = ec.getMatrixInput(input1.getName(), getExtendedOpcode());
 				//resultBlock = matBlock.sliceOperations(ixrange, new MatrixBlock());
                                 resultBlock = ec.subsetMatrixInput(input1.getName(), getExtendedOpcode(), ixrange);
 

--- a/src/main/java/org/apache/sysml/runtime/io/MatrixReader.java
+++ b/src/main/java/org/apache/sysml/runtime/io/MatrixReader.java
@@ -36,6 +36,7 @@ import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.SparseBlock;
 import org.apache.sysml.runtime.matrix.data.SparseBlockMCSR;
+import org.apache.sysml.runtime.util.IndexRange;
 import org.apache.sysml.runtime.util.MapReduceTool;
 
 /**
@@ -55,6 +56,12 @@ public abstract class MatrixReader
 
 	public abstract MatrixBlock readMatrixFromInputStream( InputStream is, long rlen, long clen, int brlen, int bclen, long estnnz )
 			throws IOException, DMLRuntimeException;
+
+        public MatrixBlock readSubsetMatrixFromHDFS(String fname, long rlen, long clen, int brlen, int bclen, long estnnz, IndexRange ixRange)
+            throws IOException, DMLRuntimeException {
+          MatrixBlock ret = readMatrixFromHDFS(fname, rlen, clen, brlen, bclen, estnnz);
+          return ret.sliceOperations(ixRange, ret);
+        }
 	
 	/**
 	 * NOTE: mallocDense controls if the output matrix blocks is fully allocated, this can be redundant

--- a/src/main/java/org/apache/sysml/runtime/io/MatrixReader.java
+++ b/src/main/java/org/apache/sysml/runtime/io/MatrixReader.java
@@ -60,7 +60,7 @@ public abstract class MatrixReader
         public MatrixBlock readSubsetMatrixFromHDFS(String fname, long rlen, long clen, int brlen, int bclen, long estnnz, IndexRange ixRange)
             throws IOException, DMLRuntimeException {
           MatrixBlock ret = readMatrixFromHDFS(fname, rlen, clen, brlen, bclen, estnnz);
-          return ret.sliceOperations(ixRange, ret);
+          return ret.sliceOperations(ixRange, new MatrixBlock());
         }
 	
 	/**

--- a/src/main/java/org/apache/sysml/runtime/io/ReaderSubsetBinaryBlackParallel.java
+++ b/src/main/java/org/apache/sysml/runtime/io/ReaderSubsetBinaryBlackParallel.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Future;
 
 
 public class ReaderSubsetBinaryBlackParallel extends ReaderBinaryBlock {
-        protected static final Log LOG = LogFactory.getLog(ReaderSubBinaryBlackParallel.class.getName());
+        protected static final Log LOG = LogFactory.getLog(ReaderSubsetBinaryBlackParallel.class.getName());
 
         private static int _numThreads = 1;
 

--- a/src/main/java/org/apache/sysml/runtime/io/ReaderSubsetBinaryBlackParallel.java
+++ b/src/main/java/org/apache/sysml/runtime/io/ReaderSubsetBinaryBlackParallel.java
@@ -1,0 +1,225 @@
+package org.apache.sysml.runtime.io;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.sysml.conf.ConfigurationManager;
+import org.apache.sysml.hops.OptimizerUtils;
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.runtime.matrix.data.MatrixBlock;
+import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
+import org.apache.sysml.runtime.matrix.data.SparseBlock;
+import org.apache.sysml.runtime.matrix.data.SparseBlockMCSR;
+import org.apache.sysml.runtime.matrix.mapred.MRJobConfiguration;
+import org.apache.sysml.runtime.util.IndexRange;
+import org.apache.sysml.udf.Matrix;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+
+/**
+ * Created by Fei Hu on 8/8/17.
+ */
+public class ReaderSubsetBinaryBlackParallel extends ReaderBinaryBlock {
+        protected static final Log LOG = LogFactory.getLog(ReaderSubBinaryBlackParallel.class.getName());
+
+        private static int _numThreads = 1;
+
+        public ReaderSubsetBinaryBlackParallel(boolean localFS) {
+              super(localFS);
+              _numThreads = OptimizerUtils.getParallelBinaryReadParallelism();
+        }
+
+        @Override
+        public MatrixBlock readSubsetMatrixFromHDFS(String fname, long rlen, long clen, int brlen, int bclen,
+                                                 long estnnz, IndexRange ixRange)
+              throws IOException, DMLRuntimeException {
+              //allocate output matrix block (incl block allocation for parallel)
+              long rlen_ret = ixRange.rowEnd - ixRange.rowStart + 1; //Math.min((ixRange.rowEnd/brlen - ixRange.rowStart/brlen + 1) * brlen, rlen);
+              long clen_ret = ixRange.colEnd - ixRange.colStart + 1; //Math.min((ixRange.colEnd/bclen - ixRange.colStart/bclen + 1) * bclen, clen);
+              MatrixBlock ret = createOutputMatrixBlock(rlen_ret, clen_ret, brlen, bclen, estnnz, true, true);
+
+              //prepare file access
+              JobConf job = new JobConf(ConfigurationManager.getCachedJobConf());
+              Path path = new Path((_localFS ? "file:///" : "") + fname);
+              FileSystem fs = IOUtilFunctions.getFileSystem(path, job);
+
+              //check existence and non-empty file
+              checkValidInputFile(fs, path);
+
+              //core read
+              readSubBinaryBlockMatrixFromHDFS(path, job, fs, ret, rlen, clen, brlen, bclen, ixRange);
+
+              //finally check if change of sparse/dense block representation required
+              if (!AGGREGATE_BLOCK_NNZ)
+                ret.recomputeNonZeros();
+              ret.examSparsity();
+
+              return ret;
+        }
+
+        private static void readSubBinaryBlockMatrixFromHDFS(Path path, JobConf job, FileSystem fs,
+                                                             MatrixBlock dest, long rlen, long clen,
+                                                             int brlen, int bclen, IndexRange ixRange)
+            throws IOException, DMLRuntimeException {
+              //set up preferred custom serialization framework for binary block format
+              if (MRJobConfiguration.USE_BINARYBLOCK_SERIALIZATION)
+                MRJobConfiguration.addBinaryBlockSerializationFramework(job);
+
+              try {
+                //create read tasks for all files
+                ExecutorService pool = Executors.newFixedThreadPool(_numThreads);
+                ArrayList<ReaderSubsetBinaryBlackParallel.ReadFileTask>
+                    tasks = new ArrayList<ReaderSubsetBinaryBlackParallel.ReadFileTask>();
+                for (Path lpath : IOUtilFunctions.getSequenceFilePaths(fs, path)) {
+                  ReaderSubsetBinaryBlackParallel.ReadFileTask t = new ReaderSubsetBinaryBlackParallel.ReadFileTask(lpath, job, fs, dest, rlen, clen, brlen,
+                                                                    bclen, ixRange);
+                  tasks.add(t);
+                }
+
+                //wait until all tasks have been executed
+                List<Future<Object>> rt = pool.invokeAll(tasks);
+
+                //check for exceptions and aggregate nnz
+                long lnnz = 0;
+                for (Future<Object> task : rt)
+                  lnnz += (Long) task.get();
+
+                //post-processing
+                dest.setNonZeros(lnnz);
+                if (dest.isInSparseFormat() && clen > bclen)
+                  sortSparseRowsParallel(dest, rlen, _numThreads, pool);
+
+                pool.shutdown();
+              } catch (Exception e) {
+                throw new IOException("Failed parallel sub-read of binary block input.", e);
+              }
+        }
+
+        private static class ReadFileTask implements Callable<Object> {
+
+        private Path _path = null;
+        private JobConf _job = null;
+        private FileSystem _fs = null;
+        private MatrixBlock _dest = null;
+        private long _rlen = -1;
+        private long _clen = -1;
+        private int _brlen = -1;
+        private int _bclen = -1;
+        private IndexRange _ixRange = null;
+
+        public ReadFileTask(Path path, JobConf job, FileSystem fs, MatrixBlock dest, long rlen,
+                            long clen, int brlen, int bclen, IndexRange ixRange) {
+              _path = path;
+              _fs = fs;
+              _job = job;
+              _dest = dest;
+              _rlen = rlen;
+              _clen = clen;
+              _brlen = brlen;
+              _bclen = bclen;
+              _ixRange = ixRange;
+        }
+
+        @Override
+        @SuppressWarnings({"deprecation"})
+        public Object call() throws Exception {
+          boolean sparse = _dest.isInSparseFormat();
+          MatrixIndexes key = new MatrixIndexes();
+          MatrixBlock value = new MatrixBlock();
+          long lnnz = 0; //aggregate block nnz
+
+          //directly read from sequence files (individual partfiles)
+          SequenceFile.Reader reader = new SequenceFile.Reader(_fs, _path, _job);
+
+          try {
+            System.out.println("****** SubMatrix Path is " + this._path.toString() + String
+                .format(" row length %d; column length %d ", _rlen, _clen));
+            //note: next(key, value) does not yet exploit the given serialization classes, record reader does but is generally slower.
+            while (reader.next(key)) {
+              int row_offset = (int) (key.getRowIndex() - 1) * _brlen;
+              int col_offset = (int) (key.getColumnIndex() - 1) * _bclen;
+              int row_end = (int) Math.min(row_offset + _brlen - 1, _rlen);
+              int col_end = (int) Math.min(col_offset + _bclen - 1, _clen);
+
+              int min_row = (int) Math.max(row_offset, _ixRange.rowStart);
+              int min_col = (int) Math.max(col_offset, _ixRange.colStart);
+              int max_row = (int) Math.min(row_end, _ixRange.rowEnd);
+              int max_col = (int) Math.min(col_end, _ixRange.colEnd);
+
+              boolean isOverlapped = !((min_row > max_row) || (min_col > max_col));
+
+              if (!isOverlapped) {
+                LOG.trace("Filter out the MatricBlock " + key.toString());
+                continue;
+              }
+
+              reader.getCurrentValue(value);
+              int rows = value.getNumRows();
+              int cols = value.getNumColumns();
+
+              int row_offset_ret = (int) (min_row - _ixRange.rowStart);
+              int col_offset_ret = (int) (min_col - _ixRange.colStart);
+              int row_end_ret = (int) (max_row - _ixRange.rowStart);
+              int col_end_ret = (int) (max_col - _ixRange.colStart);
+
+              MatrixBlock sub_value = value.sliceOperations(min_row - row_offset, max_row - row_offset, min_col - col_offset, max_col - col_offset, new MatrixBlock());
+
+              //bound check per block
+              if (row_offset + rows < 0 || row_offset + rows > _rlen || col_offset + cols < 0
+                  || col_offset + cols > _clen) {
+                throw new IOException(
+                    "Matrix block [" + (row_offset + 1) + ":" + (row_offset + rows) + "," + (col_offset
+                                                                                             + 1) + ":"
+                    + (col_offset + cols) + "] " +
+                    "out of overall matrix range [1:" + _rlen + ",1:" + _clen + "].");
+              }
+
+              //copy block to result
+              if (sparse) {
+                //note: append requires final sort
+                if (cols < _clen) {
+                  //sparse requires lock, when matrix is wider than one block
+                  //(fine-grained locking of block rows instead of the entire matrix)
+                  //NOTE: fine-grained locking depends on MCSR SparseRow objects
+                  SparseBlock sblock = _dest.getSparseBlock();
+                  if (sblock instanceof SparseBlockMCSR
+                      && sblock.get(row_offset_ret) != null) {
+                    synchronized (sblock.get(row_offset_ret)) {
+                      _dest.appendToSparse(sub_value, row_offset_ret, col_offset_ret);
+                    }
+                  } else {
+                    synchronized (_dest) {
+                      _dest.appendToSparse(sub_value, row_offset_ret, col_offset_ret);
+                    }
+                  }
+                } else { //quickpath (no synchronization)
+                  _dest.appendToSparse(sub_value, row_offset_ret, col_offset_ret);
+                }
+              } else {
+                LOG.trace(String.format("Add the sub-matrixblock where row_offset_ret = %d, rows = %d, col_offset_ret = %d, cols = %d", row_offset, rows, col_offset_ret, cols));
+                _dest.copy(row_offset_ret, row_end_ret,
+                           col_offset_ret, col_end_ret, sub_value, false);
+              }
+              //aggregate nnz
+              lnnz += value.getNonZeros();
+            }
+          } catch (ArrayIndexOutOfBoundsException e) {
+            throw e;
+          } finally {
+            IOUtilFunctions.closeSilently(reader);
+          }
+
+          return lnnz;
+        }
+      }
+}

--- a/src/main/java/org/apache/sysml/runtime/io/ReaderSubsetBinaryBlackParallel.java
+++ b/src/main/java/org/apache/sysml/runtime/io/ReaderSubsetBinaryBlackParallel.java
@@ -26,9 +26,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 
-/**
- * Created by Fei Hu on 8/8/17.
- */
 public class ReaderSubsetBinaryBlackParallel extends ReaderBinaryBlock {
         protected static final Log LOG = LogFactory.getLog(ReaderSubBinaryBlackParallel.class.getName());
 

--- a/src/main/java/org/apache/sysml/runtime/util/DataConverter.java
+++ b/src/main/java/org/apache/sysml/runtime/util/DataConverter.java
@@ -265,7 +265,7 @@ public class DataConverter
           MatrixBlock ret = null;
           try {
             MatrixReader reader = MatrixReaderFactory.createSubMatrixReader(prop);
-            ret = reader.readSubMatrixFromHDFS(prop.path, prop.rlen, prop.clen, prop.brlen, prop.bclen, estnnz, ixRange);
+            ret = reader.readSubsetMatrixFromHDFS(prop.path, prop.rlen, prop.clen, prop.brlen, prop.bclen, estnnz, ixRange);
           }
           catch(DMLRuntimeException rex)
           {

--- a/src/main/java/org/apache/sysml/runtime/util/DataConverter.java
+++ b/src/main/java/org/apache/sysml/runtime/util/DataConverter.java
@@ -167,6 +167,25 @@ public class DataConverter
 		//prop.printMe();
 		return readMatrixFromHDFS(prop);
 	}
+
+        public static MatrixBlock subsetMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen,
+                                                    int brlen, int bclen, double expectedSparsity, FileFormatProperties formatProperties, IndexRange ixrange)
+            throws IOException
+        {
+          ReadProperties prop = new ReadProperties();
+
+          prop.path = dir;
+          prop.inputInfo = inputinfo;
+          prop.rlen = rlen;
+          prop.clen = clen;
+          prop.brlen = brlen;
+          prop.bclen = bclen;
+          prop.expectedSparsity = expectedSparsity;
+          prop.formatProperties = formatProperties;
+
+          //prop.printMe();
+          return subMatrixFromHDFS(prop, ixrange);
+        }
 	
 	/**
 	 * Core method for reading matrices in format textcell, matrixmarket, binarycell, or binaryblock 
@@ -212,6 +231,51 @@ public class DataConverter
 				
 		return ret;
 	}
+
+        /**
+         * Core method for subsetting matrices in format textcell, matrixmarket, binarycell, or binaryblock
+         * from HDFS into main memory. For expected dense matrices we directly copy value- or block-at-a-time
+         * into the target matrix. In contrast, for sparse matrices, we append (column-value)-pairs and do a
+         * final sort if required in order to prevent large reorg overheads and increased memory consumption
+         * in case of unordered inputs.
+         *
+         * DENSE MxN input:
+         *  * best/average/worst: O(M*N)
+         * SPARSE MxN input
+         *  * best (ordered, or binary block w/ clen&lt;=bclen): O(M*N)
+         *  * average (unordered): O(M*N*log(N))
+         *  * worst (descending order per row): O(M * N^2)
+         *
+         * NOTE: providing an exact estimate of 'expected sparsity' can prevent a full copy of the result
+         * matrix block (required for changing sparse-&gt;dense, or vice versa)
+         *
+         * @param prop read properties
+         * @return matrix block
+         * @throws IOException if IOException occurs
+         */
+        public static MatrixBlock subMatrixFromHDFS(ReadProperties prop, IndexRange ixRange)
+            throws IOException
+        {
+          //Timing time = new Timing(true);
+
+          long estnnz = (prop.expectedSparsity <= 0 || prop.rlen <= 0 || prop.clen <= 0) ?
+                        -1 : (long)(prop.expectedSparsity*prop.rlen*prop.clen);
+
+          //core matrix reading
+          MatrixBlock ret = null;
+          try {
+            MatrixReader reader = MatrixReaderFactory.createSubMatrixReader(prop);
+            ret = reader.readSubMatrixFromHDFS(prop.path, prop.rlen, prop.clen, prop.brlen, prop.bclen, estnnz, ixRange);
+          }
+          catch(DMLRuntimeException rex)
+          {
+            throw new IOException(rex);
+          }
+
+          //System.out.println("read matrix ("+prop.rlen+","+prop.clen+","+ret.getNonZeros()+") in "+time.stop());
+
+          return ret;
+        }
 
 	
 	//////////////

--- a/src/main/scala/org/apache/sysml/examples/MNIST_Distrib_Sgd.scala
+++ b/src/main/scala/org/apache/sysml/examples/MNIST_Distrib_Sgd.scala
@@ -3,7 +3,7 @@ package org.apache.sysml.examples
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.sysml.api.mlcontext.ScriptFactory.dml
 import org.apache.sysml.api.mlcontext._
-import org.apache.sysml.scripts.nn.examples.{Mnist_lenet_distrib_sgd, Mnist_lenet_distrib_sgd_optimize}
+import org.apache.sysml.scripts.nn.examples.Mnist_lenet_distrib_sgd
 
 object MNIST_Distrib_Sgd {
 
@@ -66,7 +66,7 @@ object MNIST_Distrib_Sgd {
 
     org.apache.sysml.api.DMLScript.rtplatform = org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM.HYBRID_SPARK
 
-    val clf = new Mnist_lenet_distrib_sgd_optimize()
+    val clf = new Mnist_lenet_distrib_sgd()
 
     val N = 3200
     val Nval = 32
@@ -84,16 +84,15 @@ object MNIST_Distrib_Sgd {
     val X_val_file = "scratch_space/X_val_input"
     val Y_val_file = "scratch_space/Y_val_input"
 
-    createMNISTDummyData(X_file, Y_file, X_val_file, Y_val_file, N, Nval, Ntest, C, Hin, Win, K)
+    //createMNISTDummyData(X_file, Y_file, X_val_file, Y_val_file, N, Nval, Ntest, C, Hin, Win, K)
 
     val X = readMatrix(X_file, ml)
     val Y = readMatrix(Y_file, ml)
     val X_val = readMatrix(X_val_file, ml)
     val Y_val = readMatrix(Y_val_file, ml)
 
-    X.toMatrixObject
-
-    println(X.getMatrixMetadata)
+    //X.toMatrixObject
+    //println(X.getMatrixMetadata)
 
     val params = clf.train(X, Y, X_val, Y_val, C, Hin, Win, batchSize, paralellBatches, epochs)
     println(params.toString)

--- a/src/main/scala/org/apache/sysml/examples/MNIST_Distrib_Sgd.scala
+++ b/src/main/scala/org/apache/sysml/examples/MNIST_Distrib_Sgd.scala
@@ -3,7 +3,7 @@ package org.apache.sysml.examples
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.sysml.api.mlcontext.ScriptFactory.dml
 import org.apache.sysml.api.mlcontext._
-import org.apache.sysml.scripts.nn.examples.Mnist_lenet_distrib_sgd
+import org.apache.sysml.scripts.nn.examples.{Mnist_lenet_distrib_sgd, Mnist_lenet_distrib_sgd_optimize}
 
 object MNIST_Distrib_Sgd {
 
@@ -35,15 +35,7 @@ object MNIST_Distrib_Sgd {
     writeMatrix(dummyVal.Y, Y_val_file)
   }
 
-  def setSparkConf(): SparkConf = {
-    val conf = new SparkConf().setAppName("SystemML-MNIST-Distrib").setMaster("local[4]").set("spark.driver.memory", "2g")
-    /*conf.set("spark.driver.memory", "2g")
-    conf.set("spark.executor.memory", "2g")*/
-
-    /*val memSize = 20 * 1024 * 1024 * 1024L
-    conf.set("spark.testing.memory", memSize.toString)*/
-    conf
-  }
+  def setSparkConf(): SparkConf = new SparkConf().setAppName("SystemML-MNIST-Distrib").setMaster("local[4]").set("spark.driver.memory", "2g")
 
   def configMLContext(ml: MLContext): Unit = {
     ml.setStatistics(true)
@@ -66,7 +58,7 @@ object MNIST_Distrib_Sgd {
 
     org.apache.sysml.api.DMLScript.rtplatform = org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM.HYBRID_SPARK
 
-    val clf = new Mnist_lenet_distrib_sgd()
+    val clf = new Mnist_lenet_distrib_sgd_optimize()
 
     val N = 3200
     val Nval = 32
@@ -90,9 +82,6 @@ object MNIST_Distrib_Sgd {
     val Y = readMatrix(Y_file, ml)
     val X_val = readMatrix(X_val_file, ml)
     val Y_val = readMatrix(Y_val_file, ml)
-
-    //X.toMatrixObject
-    //println(X.getMatrixMetadata)
 
     val params = clf.train(X, Y, X_val, Y_val, C, Hin, Win, batchSize, paralellBatches, epochs)
     println(params.toString)

--- a/src/main/scala/org/apache/sysml/examples/MNIST_Distrib_Sgd.scala
+++ b/src/main/scala/org/apache/sysml/examples/MNIST_Distrib_Sgd.scala
@@ -3,7 +3,7 @@ package org.apache.sysml.examples
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.sysml.api.mlcontext.ScriptFactory.dml
 import org.apache.sysml.api.mlcontext._
-import org.apache.sysml.scripts.nn.examples.{Mnist_lenet_distrib_sgd, Mnist_lenet_distrib_sgd_optimize}
+import org.apache.sysml.scripts.nn.examples.Mnist_lenet_distrib_sgd
 
 object MNIST_Distrib_Sgd {
 
@@ -58,7 +58,7 @@ object MNIST_Distrib_Sgd {
 
     org.apache.sysml.api.DMLScript.rtplatform = org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM.HYBRID_SPARK
 
-    val clf = new Mnist_lenet_distrib_sgd_optimize()
+    val clf = new Mnist_lenet_distrib_sgd()
 
     val N = 3200
     val Nval = 32

--- a/src/main/scala/org/apache/sysml/examples/MNIST_Distrib_Sgd.scala
+++ b/src/main/scala/org/apache/sysml/examples/MNIST_Distrib_Sgd.scala
@@ -1,0 +1,102 @@
+package org.apache.sysml.examples
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.sysml.api.mlcontext.ScriptFactory.dml
+import org.apache.sysml.api.mlcontext._
+import org.apache.sysml.scripts.nn.examples.{Mnist_lenet_distrib_sgd, Mnist_lenet_distrib_sgd_optimize}
+
+object MNIST_Distrib_Sgd {
+
+  def writeMatrix(matrix: Matrix, file: String): Unit = {
+    matrix.toMatrixObject.exportData(file, null)
+  }
+
+  def readMatrix(file: String, ml: MLContext): Matrix = {
+    val s =
+      """
+        x = read(file)
+      """
+
+    val scr = dml(s).in(Map("file" -> file)).out("x")
+    val res = ml.execute(scr)
+    res.getMatrix("x")
+  }
+
+  def createMNISTDummyData(X_file: String, Y_file: String, X_val_file: String, Y_val_file: String,
+                           N: Int, Nval: Int, Ntest: Int, C: Int, Hin: Int, Win: Int, K: Int): Unit = {
+
+    val clf = new Mnist_lenet_distrib_sgd()
+    val dummy = clf.generate_dummy_data(N, C, Hin, Win, K)
+    writeMatrix(dummy.X, X_file)
+    writeMatrix(dummy.Y, Y_file)
+
+    val dummyVal = clf.generate_dummy_data(Nval, C, Hin, Win, K)
+    writeMatrix(dummyVal.X, X_val_file)
+    writeMatrix(dummyVal.Y, Y_val_file)
+  }
+
+  def setSparkConf(): SparkConf = {
+    val conf = new SparkConf().setAppName("SystemML-MNIST-Distrib").setMaster("local[4]").set("spark.driver.memory", "2g")
+    /*conf.set("spark.driver.memory", "2g")
+    conf.set("spark.executor.memory", "2g")*/
+
+    /*val memSize = 20 * 1024 * 1024 * 1024L
+    conf.set("spark.testing.memory", memSize.toString)*/
+    conf
+  }
+
+  def configMLContext(ml: MLContext): Unit = {
+    ml.setStatistics(true)
+    ml.setStatisticsMaxHeavyHitters(10000)
+    ml.setConfigProperty("systemml.stats.finegrained", "true")
+    ml.setExplain(true)
+    ml.setExplainLevel(MLContext.ExplainLevel.RECOMPILE_RUNTIME)
+  }
+
+  /**
+    *
+    * @param args
+    */
+  def main(args: Array[String]): Unit = {
+    val sc = new SparkContext(setSparkConf())
+    //sc.setLogLevel("TRACE")
+
+    val ml = new MLContext(sc)
+    //configMLContext(ml)
+
+    org.apache.sysml.api.DMLScript.rtplatform = org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM.HYBRID_SPARK
+
+    val clf = new Mnist_lenet_distrib_sgd_optimize()
+
+    val N = 3200
+    val Nval = 32
+    val Ntest = 32
+    val C = 3
+    val Hin = 28
+    val Win = 28
+    val K = 10
+    val batchSize = 2
+    val paralellBatches = 2
+    val epochs = 1
+
+    val X_file = "scratch_space/X_input"
+    val Y_file = "scratch_space/Y_input"
+    val X_val_file = "scratch_space/X_val_input"
+    val Y_val_file = "scratch_space/Y_val_input"
+
+    createMNISTDummyData(X_file, Y_file, X_val_file, Y_val_file, N, Nval, Ntest, C, Hin, Win, K)
+
+    val X = readMatrix(X_file, ml)
+    val Y = readMatrix(Y_file, ml)
+    val X_val = readMatrix(X_val_file, ml)
+    val Y_val = readMatrix(Y_val_file, ml)
+
+    X.toMatrixObject
+
+    println(X.getMatrixMetadata)
+
+    val params = clf.train(X, Y, X_val, Y_val, C, Hin, Win, batchSize, paralellBatches, epochs)
+    println(params.toString)
+  }
+
+}


### PR DESCRIPTION
For the `rangeReIndex` operation, it needs to read the whole input matrix into memory first and then do the subsetting in the memory. It is not efficient because it needs to read a lot of unnecessary data, and even will be out of memory if the size of input matrix exceeds the available memory.

This PR optimizes the data pipeline of matrix subsetting. It reads the keys in the Hadoop sequence file, and identify the keys overlapped with the input range index. Then the values specified by the identified keys will be read.