### PR TITLE
[SYSTEMML-1742] Fix label map while training from Caffe2DML

### DIFF
--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -392,13 +392,17 @@ class BaseSystemMLClassifier(BaseSystemMLEstimator):
         """
         if self.model != None:
             self.model.save(self.sc._jsc, outputDir, format, sep)
-            if self.le is not None:
+
+            labelMapping = None
+            if hasattr(self, 'le') and self.le is not None:
                 labelMapping = dict(enumerate(list(self.le.classes_), 1))
-            else:
+            elif hasattr(self, 'labelMap') and self.labelMap is not None:
                 labelMapping = self.labelMap
-            lStr = [ [ int(k), str(labelMapping[k]) ] for k in labelMapping ]
-            df = self.sparkSession.createDataFrame(lStr)
-            df.write.csv(outputDir + sep + 'labels.txt', mode='overwrite', header=False)
+
+            if labelMapping is not None:
+                lStr = [ [ int(k), str(labelMapping[k]) ] for k in labelMapping ]
+                df = self.sparkSession.createDataFrame(lStr)
+                df.write.csv(outputDir + sep + 'labels.txt', mode='overwrite', header=False)
         else:
             raise Exception('Cannot save as you need to train the model first using fit')
         return self


### PR DESCRIPTION
Class attribute 'le' is not initialized when fit() method on object is invoked. 

Similarly labelMap is not initialized if labels.txt not in the weight directory.

Fix is to avoid accessing invalid class attributes.


@niketanpansare Can you please review this?