### PR TITLE
[SYSTEMML-1844] Attach python artifact for install and deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1129,6 +1129,30 @@
 							</execution>
 						</executions>
 					</plugin>
+					<!-- Attach python artifact so it can be installed and deployed. -->
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>build-helper-maven-plugin</artifactId>
+						<version>1.8</version>
+						<executions>
+							<execution>
+								<id>attach-python-artifact</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>attach-artifact</goal>
+								</goals>
+								<configuration>
+									<artifacts>
+										<artifact>
+											<file>${basedir}/target/${project.artifactId}-${project.version}-python.tgz</file>
+											<type>tgz</type>
+											<classifier>python</classifier>
+										</artifact>
+									</artifacts>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
Attach the python artifact to project using build-helper-maven-plugin's
attach-artifact goal. This allows the python artifact to be installed
into the local maven repository and deployed to the snapshot repository
using the distribution profile.