### PR TITLE
[MINOR] Add Python artifact README.txt

### DIFF
--- a/src/main/python/MANIFEST.in
+++ b/src/main/python/MANIFEST.in
@@ -20,4 +20,5 @@
 #-------------------------------------------------------------
 include LICENSE
 include NOTICE
+include README.txt
 recursive-include systemml/systemml-java *

--- a/src/main/python/README.txt
+++ b/src/main/python/README.txt
@@ -1,0 +1,27 @@
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+Apache SystemML
+
+Website: http://systemml.apache.org/
+GitHub: https://github.com/apache/systemml
+Mailing List: dev@systemml.apache.org
+Issue Tracker: https://issues.apache.org/jira/browse/SYSTEMML
+Download: http://systemml.apache.org/download.html
+
+For more information about using SystemML with Python, please see:
+Beginner's Guide for Python Users: http://apache.github.io/systemml/beginners-guide-python.html
+Reference Guide for Python Users: http://apache.github.io/systemml/python-reference.html


### PR DESCRIPTION
Create README.txt file for Python artifact. This removes the Python
README warning when the Python artifact is built.