### PR TITLE
[MINOR] Fix javadoc warning

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUContext.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUContext.java
@@ -65,8 +65,8 @@ import jcuda.runtime.JCuda;
 import jcuda.runtime.cudaDeviceProp;
 
 /**
- * Represents a context per GPU accessible through the same JVM
- * Each context holds cublas, cusparse, cudnn... handles which are separate for each GPU
+ * Represents a context per GPU accessible through the same JVM.
+ * Each context holds cublas, cusparse, cudnn... handles which are separate for each GPU.
  */
 public class GPUContext {
 
@@ -187,12 +187,22 @@ public class GPUContext {
 		}
 	}
 
+	/**
+	 * Returns which device is currently being used.
+	 * 
+	 * @return the current device for the calling host thread
+	 */
 	public static int cudaGetDevice() {
 		int[] device = new int[1];
 		JCuda.cudaGetDevice(device);
 		return device[0];
 	}
 
+	/**
+	 * Returns which device is assigned to this GPUContext instance.
+	 * 
+	 * @return active device assigned to this GPUContext instance
+	 */
 	public int getDeviceNum() {
 		return deviceNum;
 	}
@@ -201,8 +211,10 @@ public class GPUContext {
 	 * Sets the device for the calling thread.
 	 * This method must be called after
 	 * {@link org.apache.sysml.runtime.controlprogram.context.ExecutionContext#getGPUContext(int)}
-	 * If in a multi-threaded env like parfor, this method must be called when in the
-	 * appropriate thread
+	 * If in a multi-threaded environment like parfor, this method must be called when in the
+	 * appropriate thread.
+	 * 
+	 * @throws DMLRuntimeException if DMLRuntimeException occurs
 	 */
 	public void initializeThread() throws DMLRuntimeException {
 		cudaSetDevice(deviceNum);
@@ -295,7 +307,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Does lazy cudaFree calls
+	 * Does lazy cudaFree calls.
 	 *
 	 * @param toFree {@link Pointer} instance to be freed
 	 */
@@ -304,7 +316,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * does lazy/eager cudaFree calls
+	 * Does lazy/eager cudaFree calls.
 	 *
 	 * @param toFree {@link Pointer} instance to be freed
 	 * @param eager  true if to be done eagerly
@@ -314,7 +326,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Does lazy cudaFree calls
+	 * Does lazy cudaFree calls.
 	 *
 	 * @param instructionName name of the instruction for which to record per instruction free time, null if do not want to record
 	 * @param toFree          {@link Pointer} instance to be freed
@@ -324,7 +336,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Does cudaFree calls, lazily
+	 * Does cudaFree calls, lazily.
 	 *
 	 * @param instructionName name of the instruction for which to record per instruction free time, null if do not want to record
 	 * @param toFree          {@link Pointer} instance to be freed
@@ -366,7 +378,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Thin wrapper over {@link GPUContext#evict(long)}
+	 * Thin wrapper over {@link GPUContext#evict(long)}.
 	 *
 	 * @param size size to check
 	 * @throws DMLRuntimeException if DMLRuntimeException occurs
@@ -376,7 +388,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Thin wrapper over {@link GPUContext#evict(long)}
+	 * Thin wrapper over {@link GPUContext#evict(long)}.
 	 *
 	 * @param instructionName instructionName name of the instruction for which performance measurements are made
 	 * @param size            size to check
@@ -389,7 +401,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Convenience wrapper over {@link GPUContext#evict(String, long)}
+	 * Convenience wrapper over {@link GPUContext#evict(String, long)}.
 	 *
 	 * @param GPUSize Desired size to be freed up on the GPU
 	 * @throws DMLRuntimeException If no blocks to free up or if not enough blocks with zero locks on them.
@@ -492,7 +504,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Whether the GPU associated with this {@link GPUContext} has recorded the usage of a certain block
+	 * Whether the GPU associated with this {@link GPUContext} has recorded the usage of a certain block.
 	 *
 	 * @param o the block
 	 * @return true if present, false otherwise
@@ -520,7 +532,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Gets the available memory on GPU that SystemML can use
+	 * Gets the available memory on GPU that SystemML can use.
 	 *
 	 * @return the available memory in bytes
 	 */
@@ -532,7 +544,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Makes sure that GPU that SystemML is trying to use has the minimum compute capability needed
+	 * Makes sure that GPU that SystemML is trying to use has the minimum compute capability needed.
 	 *
 	 * @throws DMLRuntimeException if the compute capability is less than what is required
 	 */
@@ -560,12 +572,18 @@ public class GPUContext {
 		}
 	}
 
+	/**
+	 * Instantiates a new {@link GPUObject} initialized with the given {@link org.apache.sysml.runtime.controlprogram.caching.MatrixObject MatrixObject}.
+	 * 
+	 * @param mo a {@link org.apache.sysml.runtime.controlprogram.caching.MatrixObject MatrixObject} that represents a matrix
+	 * @return a new {@link GPUObject} instance
+	 */
 	public GPUObject createGPUObject(MatrixObject mo) {
 		return new GPUObject(this, mo);
 	}
 
 	/**
-	 * Gets the device properties for the active GPU (set with cudaSetDevice())
+	 * Gets the device properties for the active GPU (set with cudaSetDevice()).
 	 *
 	 * @return the device properties
 	 * @throws DMLRuntimeException ?
@@ -575,7 +593,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Gets the maximum number of threads per block for "active" GPU
+	 * Gets the maximum number of threads per block for "active" GPU.
 	 *
 	 * @return the maximum number of threads per block
 	 * @throws DMLRuntimeException ?
@@ -586,7 +604,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Gets the maximum number of blocks supported by the active cuda device
+	 * Gets the maximum number of blocks supported by the active cuda device.
 	 *
 	 * @return the maximum number of blocks supported
 	 * @throws DMLRuntimeException ?
@@ -597,7 +615,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Gets the shared memory per block supported by the active cuda device
+	 * Gets the shared memory per block supported by the active cuda device.
 	 *
 	 * @return the shared memory per block
 	 * @throws DMLRuntimeException ?
@@ -608,7 +626,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Gets the warp size supported by the active cuda device
+	 * Gets the warp size supported by the active cuda device.
 	 *
 	 * @return the warp size
 	 * @throws DMLRuntimeException ?
@@ -618,32 +636,62 @@ public class GPUContext {
 		return deviceProp.warpSize;
 	}
 
+	/**
+	 * Returns the cudnnHandle for Deep Neural Network operations on the GPU.
+	 * 
+	 * @return cudnnHandle for current thread
+	 */
 	public cudnnHandle getCudnnHandle() {
 		return cudnnHandle.get();
 	}
 
+	/**
+	 * Returns cublasHandle for BLAS operations on the GPU.
+	 * 
+	 * @return cublasHandle for current thread
+	 */
 	public cublasHandle getCublasHandle() {
 		return cublasHandle.get();
 	}
 
+	/**
+	 * Returns cusparseHandle for certain sparse BLAS operations on the GPU.
+	 * 
+	 * @return cusparseHandle for current thread
+	 */
 	public cusparseHandle getCusparseHandle() {
 		return cusparseHandle.get();
 	}
 
+	/**
+	 * Returns cusolverDnHandle for invoking solve() function on dense matrices on the GPU.
+	 * 
+	 * @return cusolverDnHandle for current thread
+	 */
 	public cusolverDnHandle getCusolverDnHandle() {
 		return cusolverDnHandle.get();
 	}
 
+	/**
+	 * Returns cusolverSpHandle for invoking solve() function on sparse matrices on the GPU.
+	 * 
+	 * @return cusolverSpHandle for current thread
+	 */
 	public cusolverSpHandle getCusolverSpHandle() {
 		return cusolverSpHandle.get();
 	}
 
+	/**
+	 * Returns utility class used to launch custom CUDA kernel, specific to the active GPU for this GPUContext.
+	 * 
+	 * @return {@link JCudaKernels} for current thread
+	 */
 	public JCudaKernels getKernels() {
 		return kernels.get();
 	}
 
 	/**
-	 * Destroys this GPUContext object
+	 * Destroys this GPUContext object.
 	 *
 	 * @throws DMLRuntimeException if error
 	 */
@@ -658,8 +706,8 @@ public class GPUContext {
 	}
 
 	/**
-	 * Clears all memory used by this {@link GPUContext}
-	 * Be careful to ensure that no memory is currently being used in the temporary memory before invoking this
+	 * Clears all memory used by this {@link GPUContext}.
+	 * Be careful to ensure that no memory is currently being used in the temporary memory before invoking this.
 	 * If memory is being used between MLContext invocations, they are pointed to by a {@link GPUObject} instance
 	 * which would be part of the {@link MatrixObject}. The cleanup of that {@link MatrixObject} instance will
 	 * cause the memory associated with that block on the GPU to be freed up.
@@ -681,7 +729,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Clears up the memory used to optimize cudaMalloc/cudaFree calls
+	 * Clears up the memory used to optimize cudaMalloc/cudaFree calls.
 	 */
 	public void clearTemporaryMemory() {
 		// To record the cuda block sizes needed by allocatedGPUObjects, others are cleared up.
@@ -724,7 +772,7 @@ public class GPUContext {
 	}
 
 	/**
-	 * Eviction policies for {@link GPUContext#evict(long)}
+	 * Eviction policies for {@link GPUContext#evict(long)}.
 	 */
 	public enum EvictionPolicy {
 		LRU, LFU, MIN_EVICT


### PR DESCRIPTION
Add `@throws DMLRuntimeException` to javadoc comment to remove build warning during javadoc generation.  Also included javadoc comments for other public methods for consistency following pattern used in MLContext.