### PR TITLE
[MINOR] [SYSTEMML-445] GPU bugfix for metadata checking

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
@@ -284,55 +284,97 @@ public class ExecutionContext {
 				((MatrixFormatMetaData)oldMetaData).getOutputInfo(),
 				((MatrixFormatMetaData)oldMetaData).getInputInfo()));
 	}
+	
+	/**
+	 * Compares two potential dimensions d1 and d2 and return the one which is not -1.
+	 * This method is useful when the dimensions are not known at compile time, but are known at runtime.
+	 *  
+	 * @param d1 dimension1
+	 * @param d2 dimension1
+	 * @return valid d1 or d2
+	 * @throws DMLRuntimeException if error occurs
+	 */
+	private long validateDimensions(long d1, long d2) throws DMLRuntimeException {
+		if(d1 >= 0 && d2 >= 0 && d1 != d2) {
+			throw new DMLRuntimeException("Incorrect dimensions:" + d1 + " != " + d2);
+		}
+		return Math.max(d1, d2);
+	}
 
 	/**
 	 * Allocates a dense matrix on the GPU (for output)
 	 * @param varName	name of the output matrix (known by this {@link ExecutionContext})
+	 * @param numRows number of rows of matrix object
+	 * @param numCols number of columns of matrix object
 	 * @return a pair containing the wrapping {@link MatrixObject} and a boolean indicating whether a cuda memory allocation took place (as opposed to the space already being allocated)
 	 * @throws DMLRuntimeException
 	 */
-	public Pair<MatrixObject, Boolean> getDenseMatrixOutputForGPUInstruction(String varName)
+	public Pair<MatrixObject, Boolean> getDenseMatrixOutputForGPUInstruction(String varName, long numRows, long numCols)
 		throws DMLRuntimeException 
 	{	
-		MatrixObject mo = allocateGPUMatrixObject(varName);
+		MatrixObject mo = allocateGPUMatrixObject(varName, numRows, numCols);
 		boolean allocated = mo.getGPUObject(getGPUContext(0)).acquireDeviceModifyDense();
 		mo.getMatrixCharacteristics().setNonZeros(-1);
 		return new Pair<MatrixObject, Boolean>(mo, allocated);
 	}
 
-    /**
+	/**
      * Allocates a sparse matrix in CSR format on the GPU.
      * Assumes that mat.getNumRows() returns a valid number
      * 
      * @param varName variable name
+     * @param numRows number of rows of matrix object
+	 * @param numCols number of columns of matrix object
      * @param nnz number of non zeroes
      * @return matrix object
      * @throws DMLRuntimeException if DMLRuntimeException occurs
      */
-    public Pair<MatrixObject, Boolean> getSparseMatrixOutputForGPUInstruction(String varName, long nnz)
+    public Pair<MatrixObject, Boolean> getSparseMatrixOutputForGPUInstruction(String varName, long numRows, long numCols, long nnz)
         throws DMLRuntimeException
     {
-        MatrixObject mo = allocateGPUMatrixObject(varName);
+    	MatrixObject mo = allocateGPUMatrixObject(varName, numRows, numCols);
         mo.getMatrixCharacteristics().setNonZeros(nnz);
 				boolean allocated = mo.getGPUObject(getGPUContext(0)).acquireDeviceModifySparse();
         return new Pair<MatrixObject, Boolean>(mo, allocated);
     } 
 
-	/**
+    /**
 	 * Allocates the {@link GPUObject} for a given LOPS Variable (eg. _mVar3)
 	 * @param varName variable name
+	 * @param numRows number of rows of matrix object
+	 * @param numCols number of columns of matrix object
 	 * @return matrix object
 	 * @throws DMLRuntimeException if DMLRuntimeException occurs
 	 */
-	public MatrixObject allocateGPUMatrixObject(String varName) throws DMLRuntimeException {
+	public MatrixObject allocateGPUMatrixObject(String varName, long numRows, long numCols) throws DMLRuntimeException {
 		MatrixObject mo = getMatrixObject(varName);
+		long dim1 = -1; long dim2 = -1;
+		DMLRuntimeException e = null;
+		try {
+			dim1 = validateDimensions(mo.getNumRows(), numRows);
+		} catch(DMLRuntimeException e1) {
+			e = e1;
+		}
+		try {
+			dim2 = validateDimensions(mo.getNumColumns(), numCols);
+		} catch(DMLRuntimeException e1) {
+			e = e1;
+		}
+		if(e != null) {
+			throw new DMLRuntimeException("Incorrect dimensions given to allocateGPUMatrixObject: [" + numRows + "," + numCols + "], "
+					+ "[" + mo.getNumRows() + "," + mo.getNumColumns() + "]", e);
+		}
+		if(dim1 != mo.getNumRows() || dim2 != mo.getNumColumns()) {
+			// Set unknown dimensions
+			mo.getMatrixCharacteristics().setDimension(dim1, dim2);
+		}
 		if( mo.getGPUObject(getGPUContext(0)) == null ) {
 			GPUObject newGObj = getGPUContext(0).createGPUObject(mo);
-			// The lock is added here for an output block
-			// so that any block currently in use is not deallocated by eviction on the GPU
-			newGObj.addLock();
 			mo.setGPUObject(getGPUContext(0), newGObj);
 		}
+		// The lock is added here for an output block
+		// so that any block currently in use is not deallocated by eviction on the GPU
+		mo.getGPUObject(getGPUContext(0)).addLock();
 		return mo;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
@@ -182,9 +182,8 @@ public class ConvolutionGPUInstruction extends GPUInstruction
 		GPUStatistics.incrementNoOfExecutedGPUInst();
 		MatrixObject input = getMatrixInputForGPUInstruction(ec, _input1.getName());
 		MatrixObject bias = getMatrixInputForGPUInstruction(ec, _input2.getName());
+		MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName(), input.getNumRows(), input.getNumColumns());
 		
-		ec.setMetaData(_output.getName(), input.getNumRows(), input.getNumColumns());
-		MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName());
 		if(instOpcode.equalsIgnoreCase("bias_add"))
 			LibMatrixCUDA.biasAdd(ec.getGPUContext(0), getExtendedOpcode(), input, bias, out);
 		else if(instOpcode.equalsIgnoreCase("bias_multiply"))
@@ -195,13 +194,14 @@ public class ConvolutionGPUInstruction extends GPUInstruction
 		ec.releaseMatrixOutputForGPUInstruction(_output.getName());
 	}
 
+	// (X > 0) * dout
 	public void processReLUBackwardInstruction(ExecutionContext ec) throws DMLRuntimeException {
 		GPUStatistics.incrementNoOfExecutedGPUInst();
 		MatrixObject input = getMatrixInputForGPUInstruction(ec, _input1.getName());
 		MatrixObject dout = getMatrixInputForGPUInstruction(ec, _input2.getName());
 		
-		MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName());
-		ec.setMetaData(_output.getName(), input.getNumRows(), input.getNumColumns());
+		MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName(), input.getNumRows(), input.getNumColumns());
+		
 		LibMatrixCUDA.reluBackward(ec.getGPUContext(0), getExtendedOpcode(), input, dout, out);
 		// release inputs/outputs
 		ec.releaseMatrixInputForGPUInstruction(_input1.getName());
@@ -251,8 +251,8 @@ public class ConvolutionGPUInstruction extends GPUInstruction
 			if(filter.getNumRows() != K || filter.getNumColumns() != C*R*S) 
 				throw new DMLRuntimeException("Incorrect dimensions for filter in conv2d");
 			
-			ec.setMetaData(_output.getName(), N, K * P * Q);
-			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName());
+			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName(), N, K * P * Q);
+			
 			LibMatrixCUDA.conv2d(ec.getGPUContext(0), getExtendedOpcode(), image, filter, out, N, C, H, W,
 					K, R, S, pad_h, pad_w, stride_h, stride_w, P, Q);
 		}
@@ -266,8 +266,8 @@ public class ConvolutionGPUInstruction extends GPUInstruction
 			if(filter.getNumRows() != K || filter.getNumColumns() != C*R*S) 
 				throw new DMLRuntimeException("Incorrect dimensions for filter in conv2d");
 			
-			ec.setMetaData(_output.getName(), N, K * P * Q);
-			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName());
+			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName(), N, K * P * Q);
+			
 			LibMatrixCUDA.conv2dBiasAdd(ec.getGPUContext(0), getExtendedOpcode(), image, bias, filter, out, N, C, H, W,
 						K, R, S, pad_h, pad_w, stride_h, stride_w, P, Q);
 		}
@@ -281,8 +281,8 @@ public class ConvolutionGPUInstruction extends GPUInstruction
 				throw new DMLRuntimeException("Incorrect dimensions for dout in conv2d_backward_filter: " + 
 						dout.getNumRows() + " != " +  N + " || " + dout.getNumColumns() + " != " + K*P*Q);
 			
-			ec.setMetaData(_output.getName(), K, C * R * S);
-			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName());
+			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName(), K, C * R * S);
+			
 			LibMatrixCUDA.conv2dBackwardFilter(ec.getGPUContext(0), getExtendedOpcode(), image, dout, out, N, C, H, W,
 					K, R, S, pad_h, pad_w, stride_h, stride_w, P, Q);
 			// TODO: For now always copy the device data to host
@@ -298,8 +298,8 @@ public class ConvolutionGPUInstruction extends GPUInstruction
 				throw new DMLRuntimeException("Incorrect dimensions for dout in conv2d_backward_data: " + 
 						dout.getNumRows() + " != " +  N + " || " + dout.getNumColumns() + " != " + K*P*Q);
 			
-			ec.setMetaData(_output.getName(), N, C * H * W);
-			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName());
+			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName(), N, C * H * W);
+			
 			LibMatrixCUDA.conv2dBackwardData(ec.getGPUContext(0), getExtendedOpcode(), filter, dout, out, N, C, H, W,
 					K, R, S, pad_h, pad_w, stride_h, stride_w, P, Q);
 		}
@@ -310,8 +310,8 @@ public class ConvolutionGPUInstruction extends GPUInstruction
 				throw new DMLRuntimeException("Incorrect dimensions for image in maxpooling: " + 
 						image.getNumRows() + " != " +  N + " || " + image.getNumColumns() + " != " + C*H*W);
 			
-			ec.setMetaData(_output.getName(), N, C * P * Q);
-			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName());
+			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName(), N, C * P * Q);
+			
 			if(instOpcode.equalsIgnoreCase("maxpooling"))
 				LibMatrixCUDA.maxpooling(ec.getGPUContext(0), getExtendedOpcode(), image, out, N, C, H, W,
 					K, R, S, pad_h, pad_w, stride_h, stride_w, P, Q);
@@ -326,8 +326,8 @@ public class ConvolutionGPUInstruction extends GPUInstruction
 				throw new DMLRuntimeException("Incorrect dimensions for image in maxpooling_backward: " + 
 						image.getNumRows() + " != " +  N + " || " + image.getNumColumns() + " != " + K*P*Q);
 			
-			ec.setMetaData(_output.getName(), N, C * H * W);
-			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName());
+			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName(), N, C * H * W);
+			
 			LibMatrixCUDA.maxpoolingBackward(ec.getGPUContext(0), getExtendedOpcode(), image, dout, out, N, C, H, W,
 					K, R, S, pad_h, pad_w, stride_h, stride_w, P, Q);
 		}

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
@@ -208,12 +208,14 @@ public abstract class GPUInstruction extends Instruction
 	 * Also records performance information into {@link Statistics}
 	 * @param ec		active {@link ExecutionContext}
 	 * @param name	name of input matrix (that the {@link ExecutionContext} is aware of)
+	 * @param numRows number of rows of matrix object
+	 * @param numCols number of columns of matrix object
 	 * @return	the matrix object
 	 * @throws DMLRuntimeException	if an error occurs
 	 */
-	protected MatrixObject getDenseMatrixOutputForGPUInstruction(ExecutionContext ec, String name) throws DMLRuntimeException {
+	protected MatrixObject getDenseMatrixOutputForGPUInstruction(ExecutionContext ec, String name, long numRows, long numCols) throws DMLRuntimeException {
 		long t0 = System.nanoTime();
-		Pair<MatrixObject, Boolean> mb = ec.getDenseMatrixOutputForGPUInstruction(name);
+		Pair<MatrixObject, Boolean> mb = ec.getDenseMatrixOutputForGPUInstruction(name, numRows, numCols);
 		if (mb.getValue()) GPUStatistics.maintainCPMiscTimes(getExtendedOpcode(), GPUInstruction.MISC_TIMER_ALLOCATE_DENSE_OUTPUT, System.nanoTime() - t0);
 		return mb.getKey();
 	}


### PR DESCRIPTION
This PR contains two fixes:
- First fix ensures that the method allocating output matrix (for eg:
getSparseMatrixOutputForGPUInstruction,
getDenseMatrixOutputForGPUInstruction) has correct dimension by forcing
the caller methods to specify the expected dimensions. If the expected
dimensions don't match to the ones in the symbol table, it throws a
DMLRuntimeException.
- The second fix ensures that long to int conversions in LibMatrixCUDA is guarded.

@nakul02 can you please review this PR ?