### PR TITLE
[MINOR] Fix case of externalFunction classname message

### DIFF
--- a/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/dml/DmlSyntacticValidator.java
@@ -852,13 +852,14 @@ public class DmlSyntacticValidator extends CommonSyntacticValidator implements D
 				return;
 			}
 			otherParams.put(paramName, val);
-			if(paramName.equals("classname")) {
+			if (paramName.equals(ExternalFunctionStatement.CLASS_NAME)) {
 				atleastOneClassName = true;
 			}
 		}
 		functionStmt.setOtherParams(otherParams);
-		if(!atleastOneClassName) {
-			notifyErrorListeners("the parameter \'className\' needs to be passed for externalFunction", ctx.start);
+		if (!atleastOneClassName) {
+			notifyErrorListeners("The \'" + ExternalFunctionStatement.CLASS_NAME
+					+ "\' argument needs to be passed to the externalFunction 'implemented in' clause.", ctx.start);
 			return;
 		}
 


### PR DESCRIPTION
Use constant for 'classname' in externalFunction error message, since
the previous 'className' in the error message does not work.