### PR TITLE
[SYSTEMML-1858] Allow parsed text in validation errors

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -534,39 +534,27 @@ public class MLContext {
 				if (datatype.compareToIgnoreCase("frame") != 0) {
 					MatrixObject mo = getMatrixObject(target);
 					if (mo != null) {
-						int blp = source.getBeginLine();
-						int bcp = source.getBeginColumn();
-						int elp = source.getEndLine();
-						int ecp = source.getEndColumn();
-						exp.addVarParam(DataExpression.READROWPARAM,
-								new IntIdentifier(mo.getNumRows(), source.getFilename(), blp, bcp, elp, ecp));
-						exp.addVarParam(DataExpression.READCOLPARAM,
-								new IntIdentifier(mo.getNumColumns(), source.getFilename(), blp, bcp, elp, ecp));
-						exp.addVarParam(DataExpression.READNUMNONZEROPARAM,
-								new IntIdentifier(mo.getNnz(), source.getFilename(), blp, bcp, elp, ecp));
-						exp.addVarParam(DataExpression.DATATYPEPARAM,
-								new StringIdentifier("matrix", source.getFilename(), blp, bcp, elp, ecp));
-						exp.addVarParam(DataExpression.VALUETYPEPARAM,
-								new StringIdentifier("double", source.getFilename(), blp, bcp, elp, ecp));
+						exp.addVarParam(DataExpression.READROWPARAM, new IntIdentifier(mo.getNumRows(), source));
+						exp.addVarParam(DataExpression.READCOLPARAM, new IntIdentifier(mo.getNumColumns(), source));
+						exp.addVarParam(DataExpression.READNUMNONZEROPARAM, new IntIdentifier(mo.getNnz(), source));
+						exp.addVarParam(DataExpression.DATATYPEPARAM, new StringIdentifier("matrix", source));
+						exp.addVarParam(DataExpression.VALUETYPEPARAM, new StringIdentifier("double", source));
 
 						if (mo.getMetaData() instanceof MatrixFormatMetaData) {
 							MatrixFormatMetaData metaData = (MatrixFormatMetaData) mo.getMetaData();
 							if (metaData.getOutputInfo() == OutputInfo.CSVOutputInfo) {
 								exp.addVarParam(DataExpression.FORMAT_TYPE,
-										new StringIdentifier(DataExpression.FORMAT_TYPE_VALUE_CSV, source.getFilename(),
-												blp, bcp, elp, ecp));
+										new StringIdentifier(DataExpression.FORMAT_TYPE_VALUE_CSV, source));
 							} else if (metaData.getOutputInfo() == OutputInfo.TextCellOutputInfo) {
 								exp.addVarParam(DataExpression.FORMAT_TYPE,
-										new StringIdentifier(DataExpression.FORMAT_TYPE_VALUE_TEXT,
-												source.getFilename(), blp, bcp, elp, ecp));
+										new StringIdentifier(DataExpression.FORMAT_TYPE_VALUE_TEXT, source));
 							} else if (metaData.getOutputInfo() == OutputInfo.BinaryBlockOutputInfo) {
-								exp.addVarParam(DataExpression.ROWBLOCKCOUNTPARAM, new IntIdentifier(
-										mo.getNumRowsPerBlock(), source.getFilename(), blp, bcp, elp, ecp));
-								exp.addVarParam(DataExpression.COLUMNBLOCKCOUNTPARAM, new IntIdentifier(
-										mo.getNumColumnsPerBlock(), source.getFilename(), blp, bcp, elp, ecp));
+								exp.addVarParam(DataExpression.ROWBLOCKCOUNTPARAM,
+										new IntIdentifier(mo.getNumRowsPerBlock(), source));
+								exp.addVarParam(DataExpression.COLUMNBLOCKCOUNTPARAM,
+										new IntIdentifier(mo.getNumColumnsPerBlock(), source));
 								exp.addVarParam(DataExpression.FORMAT_TYPE,
-										new StringIdentifier(DataExpression.FORMAT_TYPE_VALUE_BINARY,
-												source.getFilename(), blp, bcp, elp, ecp));
+										new StringIdentifier(DataExpression.FORMAT_TYPE_VALUE_BINARY, source));
 							} else {
 								throw new MLContextException("Unsupported format through MLContext");
 							}

--- a/src/main/java/org/apache/sysml/hops/Hop.java
+++ b/src/main/java/org/apache/sysml/hops/Hop.java
@@ -42,6 +42,7 @@ import org.apache.sysml.lops.ReBlock;
 import org.apache.sysml.lops.UnaryCP;
 import org.apache.sysml.parser.Expression.DataType;
 import org.apache.sysml.parser.Expression.ValueType;
+import org.apache.sysml.parser.ParseInfo;
 import org.apache.sysml.runtime.controlprogram.LocalVariableMap;
 import org.apache.sysml.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.apache.sysml.runtime.controlprogram.context.SparkExecutionContext;
@@ -52,7 +53,7 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
 
-public abstract class Hop 
+public abstract class Hop implements ParseInfo
 {
 	protected static final Log LOG =  LogFactory.getLog(Hop.class.getName());
 	
@@ -1818,26 +1819,21 @@ public abstract class Hop
 	public int _beginLine, _beginColumn;
 	public int _endLine, _endColumn;
 	public String _filename;
+	public String _text;
 	
 	public void setBeginLine(int passed)    { _beginLine = passed;   }
 	public void setBeginColumn(int passed) 	{ _beginColumn = passed; }
 	public void setEndLine(int passed) 		{ _endLine = passed;   }
 	public void setEndColumn(int passed)	{ _endColumn = passed; }
 	public void setFilename(String passed) { _filename = passed; }
-	
-	public void setAllPositions(String filename, int blp, int bcp, int elp, int ecp){
-		_filename = filename;
-		_beginLine	 = blp; 
-		_beginColumn = bcp; 
-		_endLine 	 = elp;
-		_endColumn 	 = ecp;
-	}
+	public void setText(String text) { _text = text; }
 
 	public int getBeginLine()	{ return _beginLine;   }
 	public int getBeginColumn() { return _beginColumn; }
 	public int getEndLine() 	{ return _endLine;   }
 	public int getEndColumn()	{ return _endColumn; }
 	public String getFilename()	{ return _filename; }
+	public String getText() { return _text; }
 	
 	public String printErrorLocation(){
 		if(_filename != null)
@@ -1855,5 +1851,24 @@ public abstract class Hop
 	{
 		lop.setAllPositions(this.getFilename(), this.getBeginLine(), this.getBeginColumn(), this.getEndLine(), this.getEndColumn());
 	}
-	
+
+	/**
+	 * Set parse information.
+	 *
+	 * @param parseInfo
+	 *            parse information, such as beginning line position, beginning
+	 *            column position, ending line position, ending column position,
+	 *            text, and filename
+	 * @param filename
+	 *            the DML/PYDML filename (if it exists)
+	 */
+	public void setParseInfo(ParseInfo parseInfo) {
+		_beginLine = parseInfo.getBeginLine();
+		_beginColumn = parseInfo.getBeginColumn();
+		_endLine = parseInfo.getEndLine();
+		_endColumn = parseInfo.getEndColumn();
+		_text = parseInfo.getText();
+		_filename = parseInfo.getFilename();
+	}
+
 } // end class

--- a/src/main/java/org/apache/sysml/hops/rewrite/HopRewriteUtils.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/HopRewriteUtils.java
@@ -656,11 +656,11 @@ public class HopRewriteUtils
 		hnew.setOutputBlocksizes(hold.getRowsInBlock(), hold.getColsInBlock());
 		hnew.refreshSizeInformation();
 	}
-	
-	public static void copyLineNumbers( Hop src, Hop dest ) {
-		dest.setAllPositions(src.getFilename(), src.getBeginLine(), src.getBeginColumn(), src.getEndLine(), src.getEndColumn());
+
+	public static void copyLineNumbers(Hop src, Hop dest) {
+		dest.setParseInfo(src);
 	}
-	
+
 	public static void updateHopCharacteristics( Hop hop, long brlen, long bclen, Hop src )
 	{
 		updateHopCharacteristics(hop, brlen, bclen, new MemoTable(), src);

--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteInjectSparkLoopCheckpointing.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteInjectSparkLoopCheckpointing.java
@@ -89,7 +89,7 @@ public class RewriteInjectSparkLoopCheckpointing extends StatementBlockRewriteRu
 			{
 				StatementBlock sb0 = new StatementBlock();
 				sb0.setDMLProg(sb.getDMLProg());
-				sb0.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+				sb0.setParseInfo(sb);
 				ArrayList<Hop> hops = new ArrayList<Hop>();
 				VariableSet livein = new VariableSet();
 				VariableSet liveout = new VariableSet();

--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteSplitDagDataDependentOperators.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteSplitDagDataDependentOperators.java
@@ -97,7 +97,7 @@ public class RewriteSplitDagDataDependentOperators extends StatementBlockRewrite
 				//duplicate sb incl live variable sets
 				StatementBlock sb1 = new StatementBlock();
 				sb1.setDMLProg(sb.getDMLProg());
-				sb1.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+				sb1.setParseInfo(sb);
 				sb1.setLiveIn(new VariableSet());
 				sb1.setLiveOut(new VariableSet());
 				

--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteSplitDagUnknownCSVRead.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteSplitDagUnknownCSVRead.java
@@ -67,7 +67,7 @@ public class RewriteSplitDagUnknownCSVRead extends StatementBlockRewriteRule
 				//duplicate sb incl live variable sets
 				StatementBlock sb1 = new StatementBlock();
 				sb1.setDMLProg(sb.getDMLProg());
-				sb1.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+				sb1.setParseInfo(sb);
 				sb1.setLiveIn(new VariableSet());
 				sb1.setLiveOut(new VariableSet());
 				

--- a/src/main/java/org/apache/sysml/parser/AssignmentStatement.java
+++ b/src/main/java/org/apache/sysml/parser/AssignmentStatement.java
@@ -21,6 +21,7 @@ package org.apache.sysml.parser;
 
 import java.util.ArrayList;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.debug.DMLBreakpointManager;
 
@@ -32,35 +33,39 @@ public class AssignmentStatement extends Statement
 	private Expression _source;
 	 
 	// rewrites statement to support function inlining (creates deep copy)
-	public Statement rewriteStatement(String prefix) throws LanguageException{
-				
+	public Statement rewriteStatement(String prefix) throws LanguageException {
+
 		// rewrite target (deep copy)
-		DataIdentifier newTarget = (DataIdentifier)_targetList.get(0).rewriteExpression(prefix);
-		
+		DataIdentifier newTarget = (DataIdentifier) _targetList.get(0).rewriteExpression(prefix);
+
 		// rewrite source (deep copy)
 		Expression newSource = _source.rewriteExpression(prefix);
-		
+
 		// create rewritten assignment statement (deep copy)
-		AssignmentStatement retVal = new AssignmentStatement(newTarget, newSource,this.getBeginLine(), 
-											this.getBeginColumn(), this.getEndLine(), this.getEndColumn());
-		
+		AssignmentStatement retVal = new AssignmentStatement(newTarget, newSource, this);
+
 		return retVal;
 	}
-	
-	public AssignmentStatement(DataIdentifier t, Expression s, int beginLine, int beginCol, int endLine, int endCol) 
-		throws LanguageException
-	{	
+
+	public AssignmentStatement(DataIdentifier di, Expression exp, ParseInfo parseInfo) {
 		_targetList = new ArrayList<DataIdentifier>();
-		_targetList.add(t);
-		_source = s;
-	
-		setBeginLine(beginLine);
-		setBeginColumn(beginCol);
-		setEndLine(endLine);
-		setEndColumn(endCol);
-		
+		_targetList.add(di);
+		_source = exp;
+		setParseInfo(parseInfo);
 	}
-	
+
+	public AssignmentStatement(ParserRuleContext ctx, DataIdentifier di, Expression exp) throws LanguageException {
+		_targetList = new ArrayList<DataIdentifier>();
+		_targetList.add(di);
+		_source = exp;
+		setCtxValues(ctx);
+	}
+
+	public AssignmentStatement(ParserRuleContext ctx, DataIdentifier di, Expression exp, String filename) throws LanguageException {
+		this(ctx, di, exp);
+		setFilename(filename);
+	}
+
 	public DataIdentifier getTarget(){
 		return _targetList.get(0);
 	}

--- a/src/main/java/org/apache/sysml/parser/BooleanIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/BooleanIdentifier.java
@@ -19,21 +19,39 @@
 
 package org.apache.sysml.parser;
 
-
+import org.antlr.v4.runtime.ParserRuleContext;
 
 public class BooleanIdentifier extends ConstIdentifier 
 {
 	private boolean _val;
-	
-	public BooleanIdentifier(boolean val, String filename, int blp, int bcp, int elp, int ecp){
+
+	public BooleanIdentifier(boolean val) {
 		super();
-		 _val = val;
-		setDimensions(0,0);
-        computeDataType();
-        setValueType(ValueType.BOOLEAN);
-        setAllPositions(filename, blp, bcp, elp, ecp);
+		setInfo(val);
+		setBeginLine(-1);
+		setBeginColumn(-1);
+		setEndLine(-1);
+		setEndColumn(-1);
+		setText(null);
 	}
-	
+
+	public BooleanIdentifier(boolean val, ParseInfo parseInfo) {
+		this(val);
+		setParseInfo(parseInfo);
+	}
+
+	public BooleanIdentifier(ParserRuleContext ctx, boolean val, String filename) {
+		this(val);
+		setCtxValuesAndFilename(ctx, filename);
+	}
+
+	private void setInfo(boolean val) {
+		_val = val;
+		setDimensions(0, 0);
+		computeDataType();
+		setValueType(ValueType.BOOLEAN);
+	}
+
 	public Expression rewriteExpression(String prefix) throws LanguageException{
 		return this;
 	}

--- a/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.sysml.parser.LanguageException.LanguageErrorCodes;
 import org.apache.sysml.runtime.util.ConvolutionUtils;
 import org.apache.sysml.runtime.util.UtilFunctions;
@@ -32,9 +33,9 @@ public class BuiltinFunctionExpression extends DataIdentifier
 	protected Expression[] 	  _args = null;
 	private BuiltinFunctionOp _opcode;
 
-	public BuiltinFunctionExpression(BuiltinFunctionOp bifop, ArrayList<ParameterExpression> args, String fname, int blp, int bcp, int elp, int ecp) {
+	public BuiltinFunctionExpression(ParserRuleContext ctx, BuiltinFunctionOp bifop, ArrayList<ParameterExpression> args, String fname) {
 		_opcode = bifop;
-		setAllPositions(fname, blp, bcp, elp, ecp);
+		setCtxValuesAndFilename(ctx, fname);
 		args = expandConvolutionArguments(args);
 		_args = new Expression[args.size()];
 		for(int i=0; i < args.size(); i++) {
@@ -42,25 +43,31 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		}
 	}
 
-	public BuiltinFunctionExpression(BuiltinFunctionOp bifop, Expression[] args, String fname, int blp, int bcp, int elp, int ecp) {
+	public BuiltinFunctionExpression(BuiltinFunctionOp bifop, Expression[] args, ParseInfo parseInfo) {
+		_opcode = bifop;
+		_args = new Expression[args.length];
+		for (int i = 0; i < args.length; i++) {
+			_args[i] = args[i];
+		}
+		setParseInfo(parseInfo);
+	}
+
+	public BuiltinFunctionExpression(ParserRuleContext ctx, BuiltinFunctionOp bifop, Expression[] args, String fname) {
 		_opcode = bifop;
 		_args = new Expression[args.length];
 		for(int i=0; i < args.length; i++) {
 			_args[i] = args[i];
 		}
-		this.setAllPositions(fname, blp, bcp, elp, ecp);
+		setCtxValuesAndFilename(ctx, fname);
 	}
 
 	public Expression rewriteExpression(String prefix) throws LanguageException {
-
 		Expression[] newArgs = new Expression[_args.length];
-		for(int i=0; i < _args.length; i++) {
+		for (int i = 0; i < _args.length; i++) {
 			newArgs[i] = _args[i].rewriteExpression(prefix);
 		}
-		BuiltinFunctionExpression retVal = new BuiltinFunctionExpression(this._opcode, newArgs, 
-				this.getFilename(), this.getBeginLine(), this.getBeginColumn(), this.getEndLine(), this.getEndColumn());
+		BuiltinFunctionExpression retVal = new BuiltinFunctionExpression(this._opcode, newArgs, this);
 		return retVal;
-	
 	}
 
 	public BuiltinFunctionOp getOpCode() {
@@ -108,7 +115,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		int count = 0;
 		for (DataIdentifier outParam: stmt.getTargetList()){
 			DataIdentifier tmp = new DataIdentifier(outParam);
-			tmp.setAllPositions(this.getFilename(), this.getBeginLine(), this.getBeginColumn(), this.getEndLine(), this.getEndColumn());
+			tmp.setParseInfo(this);
 			_outputs[count++] = tmp;
 		}
 		
@@ -149,11 +156,12 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			
 			long inrows = getFirstExpr().getOutput().getDim1();
 			long incols = getFirstExpr().getOutput().getDim2();
-			
-			if ( inrows != incols ) {
-				raiseValidateError("LU Decomposition can only be done on a square matrix. Input matrix is rectangular (rows=" + inrows + ", cols="+incols+")", conditional);
+
+			if (inrows != incols) {
+				raiseValidateError("LU Decomposition requires a square matrix. Matrix " + getFirstExpr() + " is "
+						+ inrows + "x" + incols + ".", conditional);
 			}
-			
+
 			// Output1 - P
 			luOut1.setDataType(DataType.MATRIX);
 			luOut1.setValueType(ValueType.DOUBLE);
@@ -287,10 +295,8 @@ public class BuiltinFunctionExpression extends DataIdentifier
 				HashSet<String> expand = new HashSet<String>();
 				expand.add("input_shape"); expand.add("pool_size"); expand.add("stride"); expand.add("padding");
 				paramExpression = expandListParams(paramExpression, expand);
-				paramExpression.add(new ParameterExpression("filter_shape1", 
-						new IntIdentifier(1, getFilename(), getBeginLine(), getBeginColumn(), getEndLine(), getEndColumn())));
-				paramExpression.add(new ParameterExpression("filter_shape2", 
-						new IntIdentifier(1, getFilename(), getBeginLine(), getBeginColumn(), getEndLine(), getEndColumn())));
+				paramExpression.add(new ParameterExpression("filter_shape1", new IntIdentifier(1, this)));
+				paramExpression.add(new ParameterExpression("filter_shape2", new IntIdentifier(1, this)));
 				paramExpression = replaceListParams(paramExpression, "pool_size", "filter_shape", 3);
 				if(_opcode == BuiltinFunctionOp.MAX_POOL_BACKWARD)
 					paramExpression = orderConvolutionParams(paramExpression, 2);
@@ -326,7 +332,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		// checkIdentifierParams();
 		String outputName = getTempName();
 		DataIdentifier output = new DataIdentifier(outputName);
-		output.setAllPositions(this.getFilename(), this.getBeginLine(), this.getBeginColumn(), this.getEndLine(), this.getEndColumn());
+		output.setParseInfo(this);
 		
 		Identifier id = this.getFirstExpr().getOutput();
 		output.setProperties(this.getFirstExpr().getOutput());
@@ -646,11 +652,12 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			
 			// First input: is always of type MATRIX
 			checkMatrixParam(getFirstExpr());
-			
-			if ( getSecondExpr() == null )
-				raiseValidateError("Invalid number of arguments to table(): " 
-						+ this.toString(), conditional, LanguageErrorCodes.INVALID_PARAMETERS);
-			
+
+			if (getSecondExpr() == null)
+				raiseValidateError(
+						"Invalid number of arguments to table(). The table() function requires 2, 3, 4, or 5 arguments.",
+						conditional);
+
 			// Second input: can be MATRIX or SCALAR
 			// cases: table(A,B) or table(A,1)
 			if ( getSecondExpr().getOutput().getDataType() == DataType.MATRIX)
@@ -987,9 +994,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 					// default value: 1 if from <= to; -1 if from > to
 					if(getThirdExpr() == null) {
 						expandArguments();
-						_args[2] = new DoubleIdentifier(((from > to) ? -1.0 : 1.0),
-								this.getFilename(), this.getBeginLine(), this.getBeginColumn(), 
-								this.getEndLine(), this.getEndColumn());
+						_args[2] = new DoubleIdentifier(((from > to) ? -1.0 : 1.0), this);
 					}
 					incr = getDoubleValue(getThirdExpr()); 
 					
@@ -1361,28 +1366,30 @@ public class BuiltinFunctionExpression extends DataIdentifier
 	protected void checkNumParameters(int count) //always unconditional
 		throws LanguageException 
 	{
-		if (getFirstExpr() == null){
-			raiseValidateError("Missing parameter for function "+ this.getOpCode(), false, LanguageErrorCodes.INVALID_PARAMETERS);
+		if (getFirstExpr() == null) {
+			raiseValidateError("Missing argument for function " + this.getOpCode(), false,
+					LanguageErrorCodes.INVALID_PARAMETERS);
 		}
-		
-       	if (((count == 1) && (getSecondExpr()!= null || getThirdExpr() != null)) || 
-        		((count == 2) && (getThirdExpr() != null))){ 
-       		raiseValidateError("Invalid number of parameters for function "+ this.getOpCode(), false, LanguageErrorCodes.INVALID_PARAMETERS);
-       	}
-       	else if (((count == 2) && (getSecondExpr() == null)) || 
-		             ((count == 3) && (getSecondExpr() == null || getThirdExpr() == null))){
-       		raiseValidateError( "Missing parameter for function "+this.getOpCode(), false, LanguageErrorCodes.INVALID_PARAMETERS);
-       	}
+
+		if (((count == 1) && (getSecondExpr() != null || getThirdExpr() != null))
+				|| ((count == 2) && (getThirdExpr() != null))) {
+			raiseValidateError("Invalid number of arguments for function " + this.getOpCode().toString().toLowerCase()
+					+ "(). This function only takes 1 or 2 arguments.", false);
+		} else if (((count == 2) && (getSecondExpr() == null))
+				|| ((count == 3) && (getSecondExpr() == null || getThirdExpr() == null))) {
+			raiseValidateError("Missing argument for function " + this.getOpCode(), false,
+					LanguageErrorCodes.INVALID_PARAMETERS);
+		}
 	}
 
-	protected void checkMatrixParam(Expression e) //always unconditional
-		throws LanguageException 
-	{
+	protected void checkMatrixParam(Expression e) throws LanguageException {
 		if (e.getOutput().getDataType() != DataType.MATRIX) {
-			raiseValidateError("Expecting matrix parameter for function "+ this.getOpCode(), false, LanguageErrorCodes.UNSUPPORTED_PARAMETERS);
+			raiseValidateError(
+					"Expecting matrix argument for function " + this.getOpCode().toString().toLowerCase() + "().",
+					false);
 		}
 	}
-	
+
 	protected void checkMatrixFrameParam(Expression e) //always unconditional
 		throws LanguageException 
 	{
@@ -1481,9 +1488,9 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		}
 	}
 
-	public static BuiltinFunctionExpression getBuiltinFunctionExpression(
+	public static BuiltinFunctionExpression getBuiltinFunctionExpression(ParserRuleContext ctx, 
 			String functionName, ArrayList<ParameterExpression> paramExprsPassed,
-			String filename, int blp, int bcp, int elp, int ecp) {
+			String filename) {
 		
 		if (functionName == null || paramExprsPassed == null)
 			return null;
@@ -1667,8 +1674,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		else
 			return null;
 		
-		BuiltinFunctionExpression retVal = new BuiltinFunctionExpression(bifop, paramExprsPassed,
-				filename, blp, bcp, elp, ecp);
+		BuiltinFunctionExpression retVal = new BuiltinFunctionExpression(ctx, bifop, paramExprsPassed, filename);
 	
 		return retVal;
 	} // end method getBuiltinFunctionExpression

--- a/src/main/java/org/apache/sysml/parser/ConditionalPredicate.java
+++ b/src/main/java/org/apache/sysml/parser/ConditionalPredicate.java
@@ -19,7 +19,7 @@
 
 package org.apache.sysml.parser;
 
-public class ConditionalPredicate 
+public class ConditionalPredicate implements ParseInfo
 {
 
 	
@@ -61,17 +61,20 @@ public class ConditionalPredicate
 	private String _filename;
 	private int _beginLine, _beginColumn;
 	private int _endLine, _endColumn;
+	private String _text;
 	
 	public void setFilename(String fname)   { _filename = fname;   }
 	public void setBeginLine(int passed)    { _beginLine = passed;   }
 	public void setBeginColumn(int passed) 	{ _beginColumn = passed; }
 	public void setEndLine(int passed) 		{ _endLine = passed;   }
 	public void setEndColumn(int passed)	{ _endColumn = passed; }
+	public void setText(String text) { _text = text; }
 
 	public String getFilename()	{ return _filename;   }
 	public int getBeginLine()	{ return _beginLine;   }
 	public int getBeginColumn() { return _beginColumn; }
 	public int getEndLine() 	{ return _endLine;   }
 	public int getEndColumn()	{ return _endColumn; }
+	public String getText() { return _text; }
 
 }

--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -548,7 +548,7 @@ public class DMLTranslator
 			retPB.setStatementBlock(sb);
 			
 			// add location information
-			retPB.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+			retPB.setParseInfo(sb);
 		}
 		
 		// process If Statement - add runtime program blocks to program
@@ -615,7 +615,7 @@ public class DMLTranslator
 			retPB.setStatementBlock(sb);
 			
 			// add location information
-			retPB.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+			retPB.setParseInfo(sb);
 		}
 		
 		// process For Statement - add runtime program blocks to program
@@ -693,7 +693,7 @@ public class DMLTranslator
 			retPB.setStatementBlock(sb);
 			
 			// add location information
-			retPB.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+			retPB.setParseInfo(sb);
 		}
 		
 		// process function statement block - add runtime program blocks to program
@@ -775,7 +775,7 @@ public class DMLTranslator
 			retPB = rtpb;
 			
 			// add location information
-			retPB.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+			retPB.setParseInfo(sb);
 		}
 		else {
 	
@@ -806,7 +806,7 @@ public class DMLTranslator
 			retPB.setStatementBlock(sb);
 			
 			// add location information
-			retPB.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+			retPB.setParseInfo(sb);
 		}
 		
 		return retPB;
@@ -1270,7 +1270,7 @@ public class DMLTranslator
 					long actualDim1 = (var instanceof IndexedIdentifier) ? ((IndexedIdentifier)var).getOrigDim1() : var.getDim1();
 					long actualDim2 = (var instanceof IndexedIdentifier) ? ((IndexedIdentifier)var).getOrigDim2() : var.getDim2();
 					DataOp read = new DataOp(var.getName(), var.getDataType(), var.getValueType(), DataOpTypes.TRANSIENTREAD, null, actualDim1, actualDim2, var.getNnz(), var.getRowsInBlock(), var.getColumnsInBlock());
-					read.setAllPositions(var.getFilename(), var.getBeginLine(), var.getBeginColumn(), var.getEndLine(), var.getEndColumn());
+					read.setParseInfo(var);
 					ids.put(varName, read);
 				}
 			}
@@ -1326,8 +1326,7 @@ public class DMLTranslator
 				DataIdentifier target = createTarget();
 				target.setDataType(DataType.SCALAR);
 				target.setValueType(ValueType.STRING);
-				target.setAllPositions(current.getFilename(), current.getBeginLine(), target.getBeginColumn(),
-						current.getEndLine(), current.getEndColumn());
+				target.setParseInfo(current);
 
 				PrintStatement ps = (PrintStatement) current;
 				PRINTTYPE ptype = ps.getType();
@@ -1338,16 +1337,14 @@ public class DMLTranslator
 						Expression source = ps.getExpressions().get(0);
 						Hop ae = processExpression(source, target, ids);
 						Hop printHop = new UnaryOp(target.getName(), target.getDataType(), target.getValueType(), op, ae);
-						printHop.setAllPositions(current.getFilename(), current.getBeginLine(), current.getBeginColumn(), current.getEndLine(),
-								current.getEndColumn());
+						printHop.setParseInfo(current);
 						output.add(printHop);
 					} else if (ptype == PRINTTYPE.STOP) {
 						Hop.OpOp1 op = Hop.OpOp1.STOP;
 						Expression source = ps.getExpressions().get(0);
 						Hop ae = processExpression(source, target, ids);
 						Hop stopHop = new UnaryOp(target.getName(), target.getDataType(), target.getValueType(), op, ae);
-						stopHop.setAllPositions(current.getFilename(), current.getBeginLine(), current.getBeginColumn(), current.getEndLine(),
-								current.getEndColumn());
+						stopHop.setParseInfo(current);
 						output.add(stopHop);
 						sb.setSplitDag(true); //avoid merge
 					} else if (ptype == PRINTTYPE.PRINTF) {
@@ -1392,7 +1389,7 @@ public class DMLTranslator
 						if ((statementId != null) && (statementId.intValue() == i)) {
 							DataOp transientwrite = new DataOp(target.getName(), target.getDataType(), target.getValueType(), ae, DataOpTypes.TRANSIENTWRITE, null);
 							transientwrite.setOutputParams(ae.getDim1(), ae.getDim2(), ae.getNnz(), ae.getUpdateType(), ae.getRowsInBlock(), ae.getColsInBlock());
-							transientwrite.setAllPositions(target.getFilename(), target.getBeginLine(), target.getBeginColumn(), target.getEndLine(), target.getEndLine());
+							transientwrite.setParseInfo(target);
 							updatedLiveOut.addVariable(target.getName(), target);
 							output.add(transientwrite);
 						}
@@ -1423,7 +1420,7 @@ public class DMLTranslator
 						if ((statementId != null) && (statementId.intValue() == i)) {
 							DataOp transientwrite = new DataOp(target.getName(), target.getDataType(), target.getValueType(), ae, DataOpTypes.TRANSIENTWRITE, null);
 							transientwrite.setOutputParams(origDim1, origDim2, ae.getNnz(), ae.getUpdateType(), ae.getRowsInBlock(), ae.getColsInBlock());
-							transientwrite.setAllPositions(target.getFilename(), target.getBeginLine(), target.getBeginColumn(), target.getEndLine(), target.getEndColumn());
+							transientwrite.setParseInfo(target);
 							updatedLiveOut.addVariable(target.getName(), target);
 							output.add(transientwrite);
 						}
@@ -1633,7 +1630,7 @@ public class DMLTranslator
 				
 				read = new DataOp(var.getName(), var.getDataType(), var.getValueType(), DataOpTypes.TRANSIENTREAD,
 						null, actualDim1, actualDim2, var.getNnz(), var.getRowsInBlock(), var.getColumnsInBlock());
-				read.setAllPositions(var.getFilename(), var.getBeginLine(), var.getBeginColumn(), var.getEndLine(), var.getEndColumn());
+				read.setParseInfo(var);
 			}
 			_ids.put(varName, read);
 		}
@@ -1641,7 +1638,7 @@ public class DMLTranslator
 		DataIdentifier target = new DataIdentifier(Expression.getTempName());
 		target.setDataType(DataType.SCALAR);
 		target.setValueType(ValueType.BOOLEAN);
-		target.setAllPositions(passedSB.getFilename(), passedSB.getBeginLine(), passedSB.getBeginColumn(), passedSB.getEndLine(), passedSB.getEndColumn());
+		target.setParseInfo(passedSB);
 		Hop predicateHops = null;
 		Expression predicate = cp.getPredicate();
 		
@@ -1656,30 +1653,21 @@ public class DMLTranslator
 			// handle constant identifier
 			//  a) translate 0 --> FALSE; translate 1 --> TRUE
 			//	b) disallow string values
-			if ( (predicate instanceof IntIdentifier && ((IntIdentifier)predicate).getValue() == 0) || (predicate instanceof DoubleIdentifier && ((DoubleIdentifier)predicate).getValue() == 0.0)) {
-				cp.setPredicate(new BooleanIdentifier(false, 
-						predicate.getFilename(),
-						predicate.getBeginLine(), predicate.getBeginColumn(),
-						predicate.getEndLine(), predicate.getEndColumn()));
-				
-			}
-			else if ( (predicate instanceof IntIdentifier && ((IntIdentifier)predicate).getValue() == 1) || (predicate instanceof DoubleIdentifier && ((DoubleIdentifier)predicate).getValue() == 1.0)) {
-				cp.setPredicate(new BooleanIdentifier(true,
-						predicate.getFilename(),
-						predicate.getBeginLine(), predicate.getBeginColumn(),
-						predicate.getEndLine(), predicate.getEndColumn()));
-			}
-			else if (predicate instanceof IntIdentifier || predicate instanceof DoubleIdentifier){
-				cp.setPredicate(new BooleanIdentifier(true,
-						predicate.getFilename(),
-						predicate.getBeginLine(), predicate.getBeginColumn(),
-						predicate.getEndLine(), predicate.getEndColumn()));
-				LOG.warn(predicate.printWarningLocation() + "Numerical value '" + predicate.toString() + "' (!= 0/1) is converted to boolean TRUE by DML");
-			}
-			else if (predicate instanceof StringIdentifier) {
-				LOG.error(predicate.printErrorLocation() + "String value '" + predicate.toString() + "' is not allowed for iterable predicate");
-				throw new ParseException(predicate.printErrorLocation() + "String value '" + predicate.toString() + "' is not allowed for iterable predicate");
-
+			if ((predicate instanceof IntIdentifier && ((IntIdentifier) predicate).getValue() == 0)
+					|| (predicate instanceof DoubleIdentifier && ((DoubleIdentifier) predicate).getValue() == 0.0)) {
+				cp.setPredicate(new BooleanIdentifier(false, predicate));
+			} else if ((predicate instanceof IntIdentifier && ((IntIdentifier) predicate).getValue() == 1)
+					|| (predicate instanceof DoubleIdentifier && ((DoubleIdentifier) predicate).getValue() == 1.0)) {
+				cp.setPredicate(new BooleanIdentifier(true, predicate));
+			} else if (predicate instanceof IntIdentifier || predicate instanceof DoubleIdentifier) {
+				cp.setPredicate(new BooleanIdentifier(true, predicate));
+				LOG.warn(predicate.printWarningLocation() + "Numerical value '" + predicate.toString()
+						+ "' (!= 0/1) is converted to boolean TRUE by DML");
+			} else if (predicate instanceof StringIdentifier) {
+				LOG.error(predicate.printErrorLocation() + "String value '" + predicate.toString()
+						+ "' is not allowed for iterable predicate");
+				throw new ParseException(predicate.printErrorLocation() + "String value '" + predicate.toString()
+						+ "' is not allowed for iterable predicate");
 			}
 			predicateHops = processExpression(cp.getPredicate(), null, _ids);
 		}
@@ -1731,7 +1719,7 @@ public class DMLTranslator
 						long actualDim2 = (var instanceof IndexedIdentifier) ? ((IndexedIdentifier)var).getOrigDim2() : var.getDim2();
 						read = new DataOp(var.getName(), var.getDataType(), var.getValueType(), DataOpTypes.TRANSIENTREAD,
 								null, actualDim1, actualDim2,  var.getNnz(), var.getRowsInBlock(),  var.getColumnsInBlock());
-						read.setAllPositions(var.getFilename(), var.getBeginLine(), var.getBeginColumn(), var.getEndLine(), var.getEndColumn());
+						read.setParseInfo(var);
 					}
 					_ids.put(varName, read);
 				}
@@ -1809,28 +1797,28 @@ public class DMLTranslator
 			else if (source instanceof IntIdentifier) {
 				IntIdentifier sourceInt = (IntIdentifier) source;
 				LiteralOp litop = new LiteralOp(sourceInt.getValue());
-				litop.setAllPositions(sourceInt.getFilename(), sourceInt.getBeginLine(), sourceInt.getBeginColumn(), sourceInt.getEndLine(), sourceInt.getEndColumn());
+				litop.setParseInfo(sourceInt);
 				setIdentifierParams(litop, sourceInt);
 				return litop;
 			} 
 			else if (source instanceof DoubleIdentifier) {
 				DoubleIdentifier sourceDouble = (DoubleIdentifier) source;
 				LiteralOp litop = new LiteralOp(sourceDouble.getValue());
-				litop.setAllPositions(source.getFilename(), sourceDouble.getBeginLine(), sourceDouble.getBeginColumn(), sourceDouble.getEndLine(), sourceDouble.getEndColumn());
+				litop.setParseInfo(sourceDouble);
 				setIdentifierParams(litop, sourceDouble);
 				return litop;
 			}
 			else if (source instanceof BooleanIdentifier) {
 				BooleanIdentifier sourceBoolean = (BooleanIdentifier) source;
 				LiteralOp litop = new LiteralOp(sourceBoolean.getValue());
-				litop.setAllPositions(sourceBoolean.getFilename(), sourceBoolean.getBeginLine(), sourceBoolean.getBeginColumn(), sourceBoolean.getEndLine(), sourceBoolean.getEndColumn());
+				litop.setParseInfo(sourceBoolean);
 				setIdentifierParams(litop, sourceBoolean);
 				return litop;
 			} 
 			else if (source instanceof StringIdentifier) {
 				StringIdentifier sourceString = (StringIdentifier) source;
 				LiteralOp litop = new LiteralOp(sourceString.getValue());
-				litop.setAllPositions(sourceString.getFilename(), sourceString.getBeginLine(), sourceString.getBeginColumn(), sourceString.getEndLine(), sourceString.getEndColumn());
+				litop.setParseInfo(sourceString);
 				setIdentifierParams(litop, sourceString);
 				return litop;
 			} 
@@ -1897,7 +1885,7 @@ public class DMLTranslator
 				rowUpperHops = new LiteralOp(target.getOrigDim1());
 			else {
 				rowUpperHops = new UnaryOp(target.getName(), DataType.SCALAR, ValueType.INT, Hop.OpOp1.NROW, hops.get(target.getName()));
-				rowUpperHops.setAllPositions(target.getFilename(), target.getBeginLine(), target.getBeginColumn(), target.getEndLine(), target.getEndColumn());
+				rowUpperHops.setParseInfo(target);
 			}
 		}
 		if (target.getColLowerBound() != null)
@@ -1934,7 +1922,7 @@ public class DMLTranslator
 		
 		setIdentifierParams(leftIndexOp, target);
 	
-		leftIndexOp.setAllPositions(target.getFilename(), target.getBeginLine(), target.getBeginColumn(), target.getEndLine(), target.getEndColumn());
+		leftIndexOp.setParseInfo(target);
 		leftIndexOp.setDim1(target.getOrigDim1());
 		leftIndexOp.setDim2(target.getOrigDim2());
 	
@@ -1961,7 +1949,7 @@ public class DMLTranslator
 				rowUpperHops = new LiteralOp(source.getOrigDim1());
 			else {
 				rowUpperHops = new UnaryOp(source.getName(), DataType.SCALAR, ValueType.INT, Hop.OpOp1.NROW, hops.get(source.getName()));
-				rowUpperHops.setAllPositions(source.getFilename(), source.getBeginLine(),source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+				rowUpperHops.setParseInfo(source);
 			}
 		}
 		if (source.getColLowerBound() != null)
@@ -1990,7 +1978,7 @@ public class DMLTranslator
 				hops.get(source.getName()), rowLowerHops, rowUpperHops, colLowerHops, colUpperHops,
 				source.getRowLowerEqualsUpper(), source.getColLowerEqualsUpper());
 	
-		indexOp.setAllPositions(target.getFilename(), target.getBeginLine(), target.getBeginColumn(), target.getEndLine(), target.getEndColumn());
+		indexOp.setParseInfo(target);
 		setIdentifierParams(indexOp, target);
 		
 		return indexOp;
@@ -2048,7 +2036,7 @@ public class DMLTranslator
 			throw new ParseException("Unsupported parsing of binary expression: "+source.getOpCode());
 		}
 		setIdentifierParams(currBop, source.getOutput());
-		currBop.setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+		currBop.setParseInfo(source);
 		return currBop;
 		
 	}
@@ -2092,7 +2080,7 @@ public class DMLTranslator
 			op = OpOp2.NOTEQUAL;
 		}
 		currBop = new BinaryOp(target.getName(), target.getDataType(), target.getValueType(), op, left, right);
-		currBop.setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+		currBop.setParseInfo(source);
 		return currBop;
 	}
 
@@ -2126,7 +2114,7 @@ public class DMLTranslator
 		
 		if (source.getRight() == null) {
 			Hop currUop = new UnaryOp(target.getName(), target.getDataType(), target.getValueType(), Hop.OpOp1.NOT, left);
-			currUop.setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+			currUop.setParseInfo(source);
 			return currUop;
 		} 
 		else {
@@ -2142,7 +2130,7 @@ public class DMLTranslator
 				throw new RuntimeException(source.printErrorLocation() + "Unknown boolean operation " + source.getOpCode());
 			}
 			currBop = new BinaryOp(target.getName(), target.getDataType(), target.getValueType(), op, left, right);
-			currBop.setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+			currBop.setParseInfo(source);
 			// setIdentifierParams(currBop,source.getOutput());
 			return currBop;
 		}
@@ -2221,9 +2209,9 @@ public class DMLTranslator
 		// set properties for created hops based on outputs of source expression
 		for ( int i=0; i < source.getOutputs().length; i++ ) {
 			setIdentifierParams( outputs.get(i), source.getOutputs()[i]);
-			outputs.get(i).setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+			outputs.get(i).setParseInfo(source);
 		}
-		currBuiltinOp.setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+		currBuiltinOp.setParseInfo(source);
 
 		return currBuiltinOp;
 	}
@@ -2342,9 +2330,7 @@ public class DMLTranslator
 		}
 		
 		setIdentifierParams(currBuiltinOp, source.getOutput());
-		
-		currBuiltinOp.setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
-		
+		currBuiltinOp.setParseInfo(source);
 		return currBuiltinOp;
 	}
 	
@@ -2431,7 +2417,7 @@ public class DMLTranslator
 		setIdentifierParams(currBuiltinOp, source.getOutput());
 		if( source.getOpCode()==DataExpression.DataOp.READ )
 			((DataOp)currBuiltinOp).setInputBlockSizes(target.getRowsInBlock(), target.getColumnsInBlock());
-		currBuiltinOp.setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+		currBuiltinOp.setParseInfo(source);
 		
 		return currBuiltinOp;
 	}
@@ -2493,9 +2479,9 @@ public class DMLTranslator
 		// set properties for created hops based on outputs of source expression
 		for ( int i=0; i < source.getOutputs().length; i++ ) {
 			setIdentifierParams( outputs.get(i), source.getOutputs()[i]);
-			outputs.get(i).setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+			outputs.get(i).setParseInfo(source);
 		}
-		currBuiltinOp.setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+		currBuiltinOp.setParseInfo(source);
 
 		return currBuiltinOp;
 	}
@@ -3168,7 +3154,7 @@ public class DMLTranslator
 			// Since the dimension of output doesnot match that of input variable for these operations
 			setIdentifierParams(currBuiltinOp, source.getOutput());
 		}
-		currBuiltinOp.setAllPositions(source.getFilename(), source.getBeginLine(), source.getBeginColumn(), source.getEndLine(), source.getEndColumn());
+		currBuiltinOp.setParseInfo(source);
 		return currBuiltinOp;
 	}
 	
@@ -3229,20 +3215,17 @@ public class DMLTranslator
 			throw new ParseException("Unsupported skip");
 		}
 
-		for(int i = skip; i < allExpr.length; i++) {
-			if(i == numImgIndex) { // skip=1 ==> i==5  and skip=2 => i==6
+		for (int i = skip; i < allExpr.length; i++) {
+			if (i == numImgIndex) { // skip=1 ==> i==5 and skip=2 => i==6
 				Expression numImg = allExpr[numImgIndex];
-				Expression numChannels = allExpr[numImgIndex+1];
-				BinaryExpression tmp = new BinaryExpression(org.apache.sysml.parser.Expression.BinaryOp.MULT, 
-						numImg.getFilename(), numImg.getBeginLine(), numImg.getBeginColumn(), numImg.getEndLine(), numImg.getEndColumn());
+				Expression numChannels = allExpr[numImgIndex + 1];
+				BinaryExpression tmp = new BinaryExpression(org.apache.sysml.parser.Expression.BinaryOp.MULT, numImg);
 				tmp.setLeft(numImg);
 				tmp.setRight(numChannels);
 				ret.add(processTempIntExpression(tmp, hops));
-				ret.add(processExpression(new IntIdentifier(1, numImg.getFilename(), numImg.getBeginLine(), numImg.getBeginColumn(), 
-						numImg.getEndLine(), numImg.getEndColumn()), null, hops));
+				ret.add(processExpression(new IntIdentifier(1, numImg), null, hops));
 				i++;
-			}
-			else
+			} else
 				ret.add(processExpression(allExpr[i], null, hops));
 		}
 		return ret;
@@ -3338,22 +3321,24 @@ public class DMLTranslator
 						&& ((AssignmentStatement)s).getSource() instanceof DataExpression )
 				{
 					DataExpression dexpr = (DataExpression) ((AssignmentStatement)s).getSource();
-					if( dexpr.isRead() ){
+					if (dexpr.isRead()) {
 						String pfname = dexpr.getVarParam(DataExpression.IO_FILENAME).toString();
-						if( pWrites.containsKey(pfname) && !pfname.trim().isEmpty() ) //found read-after-write
-						{
-							//update read with essential write meta data
+						// found read-after-write
+						if (pWrites.containsKey(pfname) && !pfname.trim().isEmpty()) {
+							// update read with essential write meta data
 							DataIdentifier di = pWrites.get(pfname);
-							FormatType ft = (di.getFormatType()!=null) ? di.getFormatType() : FormatType.TEXT;
-							dexpr.addVarParam(DataExpression.FORMAT_TYPE, new StringIdentifier(ft.toString(),di.getFilename(),di.getBeginLine(),di.getBeginColumn(),di.getEndLine(),di.getEndColumn()));							
-							if( di.getDim1()>=0 )
-								dexpr.addVarParam(DataExpression.READROWPARAM, new IntIdentifier(di.getDim1(),di.getFilename(),di.getBeginLine(),di.getBeginColumn(),di.getEndLine(),di.getEndColumn()));
-							if( di.getDim2()>=0 )
-								dexpr.addVarParam(DataExpression.READCOLPARAM, new IntIdentifier(di.getDim2(),di.getFilename(),di.getBeginLine(),di.getBeginColumn(),di.getEndLine(),di.getEndColumn()));
-							if( di.getValueType()!=ValueType.UNKNOWN )
-								dexpr.addVarParam(DataExpression.VALUETYPEPARAM, new StringIdentifier(di.getValueType().toString(),di.getFilename(),di.getBeginLine(),di.getBeginColumn(),di.getEndLine(),di.getEndColumn()));
-							if( di.getDataType()!=DataType.UNKNOWN )
-								dexpr.addVarParam(DataExpression.DATATYPEPARAM, new StringIdentifier(di.getDataType().toString(),di.getFilename(),di.getBeginLine(),di.getBeginColumn(),di.getEndLine(),di.getEndColumn()));
+							FormatType ft = (di.getFormatType() != null) ? di.getFormatType() : FormatType.TEXT;
+							dexpr.addVarParam(DataExpression.FORMAT_TYPE, new StringIdentifier(ft.toString(), di));
+							if (di.getDim1() >= 0)
+								dexpr.addVarParam(DataExpression.READROWPARAM, new IntIdentifier(di.getDim1(), di));
+							if (di.getDim2() >= 0)
+								dexpr.addVarParam(DataExpression.READCOLPARAM, new IntIdentifier(di.getDim2(), di));
+							if (di.getValueType() != ValueType.UNKNOWN)
+								dexpr.addVarParam(DataExpression.VALUETYPEPARAM,
+										new StringIdentifier(di.getValueType().toString(), di));
+							if (di.getDataType() != DataType.UNKNOWN)
+								dexpr.addVarParam(DataExpression.DATATYPEPARAM,
+										new StringIdentifier(di.getDataType().toString(), di));
 							ret = true;
 						}
 					}

--- a/src/main/java/org/apache/sysml/parser/DataIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/DataIdentifier.java
@@ -31,11 +31,7 @@ public class DataIdentifier extends Identifier
 		_valueTypeString = passed.getValueType().toString();	
 		
 		// set location information
-		setFilename(passed.getFilename());
-		setBeginLine(passed.getBeginLine());
-		setBeginColumn(passed.getBeginColumn());
-		setEndLine(passed.getEndLine());
-		setEndColumn(passed.getEndColumn());
+		setParseInfo(passed);
 	}
 	
 	public Expression rewriteExpression(String prefix) throws LanguageException{

--- a/src/main/java/org/apache/sysml/parser/DoubleIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/DoubleIdentifier.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysml.parser;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
 
@@ -27,26 +28,39 @@ public class DoubleIdentifier extends ConstIdentifier
 {
 	
 	private double _val;
-	
-	
-	public DoubleIdentifier(double val, String filename, int blp, int bcp, int elp, int ecp){
+
+	public DoubleIdentifier(double val) {
 		super();
-		 _val = val;
-		setDimensions(0,0);
-        computeDataType();
-        setValueType(ValueType.DOUBLE);
-        setAllPositions(filename, blp, bcp, elp, ecp);
+		setInfo(val);
+		setBeginLine(-1);
+		setBeginColumn(-1);
+		setEndLine(-1);
+		setEndColumn(-1);
+		setText(null);
 	}
-	
-	public DoubleIdentifier(DoubleIdentifier d, String filename, int blp, int bcp, int elp, int ecp){
-		super();
-		 _val = d.getValue();
-		setDimensions(0,0);
-        computeDataType();
-        setValueType(ValueType.DOUBLE);
-        setAllPositions(filename, blp, bcp, elp, ecp);
+
+	public DoubleIdentifier(double val, ParseInfo parseInfo) {
+		this(val);
+		setParseInfo(parseInfo);
 	}
-	
+
+	public DoubleIdentifier(DoubleIdentifier d, ParseInfo parseInfo) {
+		this(d.getValue());
+		setParseInfo(parseInfo);
+	}
+
+	public DoubleIdentifier(ParserRuleContext ctx, double val, String filename) {
+		this(val);
+		setCtxValuesAndFilename(ctx, filename);
+	}
+
+	private void setInfo(double val) {
+		_val = val;
+		setDimensions(0, 0);
+		computeDataType();
+		setValueType(ValueType.DOUBLE);
+	}
+
 	public Expression rewriteExpression(String prefix) throws LanguageException{
 		return this;
 	}

--- a/src/main/java/org/apache/sysml/parser/Expression.java
+++ b/src/main/java/org/apache/sysml/parser/Expression.java
@@ -637,9 +637,16 @@ public abstract class Expression implements ParseInfo
 				&& (ctx.start.getInputStream() != null)) {
 			String text = ctx.start.getInputStream()
 					.getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+			if (text != null) {
+				text = text.trim();
+			}
 			setText(text);
 		} else {
-			setText(ctx.getText());
+			String text = ctx.getText();
+			if (text != null) {
+				text = text.trim();
+			}
+			setText(text);
 		}
 	}
 

--- a/src/main/java/org/apache/sysml/parser/Expression.java
+++ b/src/main/java/org/apache/sysml/parser/Expression.java
@@ -632,8 +632,11 @@ public abstract class Expression implements ParseInfo
 		setEndLine(ctx.stop.getLine());
 		setEndColumn(ctx.stop.getCharPositionInLine());
 		// preserve whitespace if possible
-		if ((ctx.start != null) && (ctx.stop != null) && (ctx.start.getStartIndex() != -1) && (ctx.stop.getStopIndex() != -1)) {
-			String text = ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+		if ((ctx.start != null) && (ctx.stop != null) && (ctx.start.getStartIndex() != -1)
+				&& (ctx.stop.getStopIndex() != -1) && (ctx.start.getStartIndex() <= ctx.stop.getStopIndex())
+				&& (ctx.start.getInputStream() != null)) {
+			String text = ctx.start.getInputStream()
+					.getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
 			setText(text);
 		} else {
 			setText(ctx.getText());

--- a/src/main/java/org/apache/sysml/parser/Expression.java
+++ b/src/main/java/org/apache/sysml/parser/Expression.java
@@ -22,6 +22,8 @@ package org.apache.sysml.parser;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.misc.Interval;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -29,7 +31,7 @@ import org.apache.sysml.hops.Hop.FileFormatTypes;
 import org.apache.sysml.runtime.controlprogram.parfor.util.IDSequence;
 
 
-public abstract class Expression 
+public abstract class Expression implements ParseInfo
 {
 	/**
 	 * Binary operators.
@@ -517,28 +519,19 @@ public abstract class Expression
 	 * @param errorCode optional error code
 	 * @throws LanguageException thrown if conditional is {@code false}.
 	 */
-	public void raiseValidateError( String message, boolean conditional, String errorCode ) 
-		throws LanguageException
-	{
-		if( conditional )  //warning if conditional
-		{
-			String fullMsg = this.printWarningLocation() + message;
-			
-			LOG.warn( fullMsg );
-		}
-		else  //error and exception if unconditional
-		{
-			String fullMsg = this.printErrorLocation() + message;
-			
-			//LOG.error( fullMsg ); //no redundant error			
-			if( errorCode != null )
-				throw new LanguageException( fullMsg, errorCode );
-			else 
-				throw new LanguageException( fullMsg );
+	public void raiseValidateError(String msg, boolean conditional, String errorCode) throws LanguageException {
+		if (conditional) {// warning if conditional
+			String fullMsg = this.printWarningLocation() + msg;
+			LOG.warn(fullMsg);
+		} else {// error and exception if unconditional
+			String fullMsg = this.printErrorLocation() + msg;
+			if (errorCode != null)
+				throw new LanguageException(fullMsg, errorCode);
+			else
+				throw new LanguageException(fullMsg);
 		}
 	}
-	
-	
+
 	/**
 	 * Returns the matrix characteristics for scalar-scalar, scalar-matrix, matrix-scalar, matrix-matrix
 	 * operations. This method is aware of potentially unknowns and matrix-vector (col/row) operations.
@@ -596,6 +589,7 @@ public abstract class Expression
 	private String _filename;
 	private int _beginLine, _beginColumn;
 	private int _endLine, _endColumn;
+	private String _text;
 	private ArrayList<String> _parseExceptionList = new ArrayList<String>();
 	
 	public void setFilename(String passed)  { _filename = passed;   }
@@ -603,50 +597,100 @@ public abstract class Expression
 	public void setBeginColumn(int passed) 	{ _beginColumn = passed; }
 	public void setEndLine(int passed) 		{ _endLine = passed;   }
 	public void setEndColumn(int passed)	{ _endColumn = passed; }
+	public void setText(String text) { _text = text; }
 	public void setParseExceptionList(ArrayList<String> passed) { _parseExceptionList = passed;}
-	
+
 	/**
-	 * Set the filename, the beginning line/column positions, and the ending line/column positions.
-	 * 
-	 * @param filename The DML/PYDML filename (if it exists)
-	 * @param blp Beginning line position
-	 * @param bcp Beginning column position
-	 * @param elp Ending line position
-	 * @param ecp Ending column position
+	 * Set parse information.
+	 *
+	 * @param parseInfo
+	 *            parse information, such as beginning line position, beginning
+	 *            column position, ending line position, ending column position,
+	 *            text, and filename
+	 * @param filename
+	 *            the DML/PYDML filename (if it exists)
 	 */
-	public void setAllPositions(String filename, int blp, int bcp, int elp, int ecp){
-		_filename    = filename;
-		_beginLine	 = blp; 
-		_beginColumn = bcp; 
-		_endLine 	 = elp;
-		_endColumn 	 = ecp;
+	public void setParseInfo(ParseInfo parseInfo) {
+		_beginLine = parseInfo.getBeginLine();
+		_beginColumn = parseInfo.getBeginColumn();
+		_endLine = parseInfo.getEndLine();
+		_endColumn = parseInfo.getEndColumn();
+		_text = parseInfo.getText();
+		_filename = parseInfo.getFilename();
 	}
+
+	/**
+	 * Set ParserRuleContext values (begin line, begin column, end line, end
+	 * column, and text).
+	 *
+	 * @param ctx
+	 *            the antlr ParserRuleContext
+	 */
+	public void setCtxValues(ParserRuleContext ctx) {
+		setBeginLine(ctx.start.getLine());
+		setBeginColumn(ctx.start.getCharPositionInLine());
+		setEndLine(ctx.stop.getLine());
+		setEndColumn(ctx.stop.getCharPositionInLine());
+		// preserve whitespace if possible
+		if ((ctx.start != null) && (ctx.stop != null) && (ctx.start.getStartIndex() != -1) && (ctx.stop.getStopIndex() != -1)) {
+			String text = ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+			setText(text);
+		} else {
+			setText(ctx.getText());
+		}
+	}
+
+	/**
+	 * Set ParserRuleContext values (begin line, begin column, end line, end
+	 * column, and text) and file name.
+	 *
+	 * @param ctx
+	 *            the antlr ParserRuleContext
+	 * @param filename
+	 *            the filename (if it exists)
+	 */
+	public void setCtxValuesAndFilename(ParserRuleContext ctx, String filename) {
+		setCtxValues(ctx);
+		setFilename(filename);
+	}
+
 
 	public String getFilename()	{ return _filename;   }
 	public int getBeginLine()	{ return _beginLine;   }
 	public int getBeginColumn() { return _beginColumn; }
 	public int getEndLine() 	{ return _endLine;   }
 	public int getEndColumn()	{ return _endColumn; }
+	public String getText() { return _text; }
 	public ArrayList<String> getParseExceptionList() { return _parseExceptionList; }
-	
-	/**
-	 * Return error message containing the filename, the beginning line position, and the beginning column position.
-	 * 
-	 * @return the error message
-	 */
-	public String printErrorLocation(){
-		return "ERROR: " + _filename + " -- line " + _beginLine + ", column " + _beginColumn + " -- ";
+
+	public String printErrorLocation() {
+		String file = _filename;
+		if (file == null) {
+			file = "";
+		} else {
+			file = file + " ";
+		}
+		if (getText() != null) {
+			return "ERROR: " + file + "[line " + _beginLine + ":" + _beginColumn + "] -> " + getText() + " -- ";
+		} else {
+			return "ERROR: " + file + "[line " + _beginLine + ":" + _beginColumn + "] -- ";
+		}
 	}
-	
-	/**
-	 * Return warning message containing the filename, the beginning line position, and the beginning column position.
-	 * 
-	 * @return the warning message
-	 */
-	public String printWarningLocation(){
-		return "WARNING: " + _filename + " -- line " + _beginLine + ", column " + _beginColumn + " -- ";
+
+	public String printWarningLocation() {
+		String file = _filename;
+		if (file == null) {
+			file = "";
+		} else {
+			file = file + " ";
+		}
+		if (getText() != null) {
+			return "WARNING: " + file + "[line " + _beginLine + ":" + _beginColumn + "] -> " + getText() + " -- ";
+		} else {
+			return "WARNING: " + file + "[line " + _beginLine + ":" + _beginColumn + "] -- ";
+		}
 	}
-	
+
 	/**
 	 * Return info message containing the filename, the beginning line position, and the beginning column position.
 	 * 

--- a/src/main/java/org/apache/sysml/parser/ForStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/ForStatementBlock.java
@@ -376,31 +376,24 @@ public class ForStatementBlock extends StatementBlock
 		if (expr instanceof DataIdentifier && !(expr instanceof IndexedIdentifier)) 
 		{	
 			// check if the DataIdentifier variable is a ConstIdentifier
-			String identifierName = ((DataIdentifier)expr).getName();
-			if (currConstVars.containsKey(identifierName))
-			{
+			String identifierName = ((DataIdentifier) expr).getName();
+			if (currConstVars.containsKey(identifierName)) {
 				ConstIdentifier constValue = currConstVars.get(identifierName);
-				//AUTO CASTING (using runtime operations for consistency)
-				switch( constValue.getValueType() ) 
-				{
-					case DOUBLE: 
-						ret = new IntIdentifier(new DoubleObject(((DoubleIdentifier)constValue).getValue()).getLongValue(),
-								expr.getFilename(), expr.getBeginLine(), expr.getBeginColumn(), 
-								expr.getEndLine(), expr.getEndColumn());
-						break;
-					case INT:    
-						ret = new IntIdentifier((IntIdentifier)constValue,
-								expr.getFilename(), expr.getBeginLine(), expr.getBeginColumn(), 
-								expr.getEndLine(), expr.getEndColumn());
-						break;
-					case BOOLEAN: 
-						ret = new IntIdentifier(new BooleanObject(((BooleanIdentifier)constValue).getValue()).getLongValue(),
-								expr.getFilename(), expr.getBeginLine(), expr.getBeginColumn(), 
-								expr.getEndLine(), expr.getEndColumn());
-						break;
-						
-					default:
-						//do nothing
+				// AUTO CASTING (using runtime operations for consistency)
+				switch (constValue.getValueType()) {
+				case DOUBLE:
+					ret = new IntIdentifier(new DoubleObject(((DoubleIdentifier) constValue).getValue()).getLongValue(),
+							expr);
+					break;
+				case INT:
+					ret = new IntIdentifier((IntIdentifier) constValue, expr);
+					break;
+				case BOOLEAN:
+					ret = new IntIdentifier(
+							new BooleanObject(((BooleanIdentifier) constValue).getValue()).getLongValue(), expr);
+					break;
+				default:
+					// do nothing
 				}
 			}
 		}

--- a/src/main/java/org/apache/sysml/parser/FunctionCallIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/FunctionCallIdentifier.java
@@ -60,11 +60,7 @@ public class FunctionCallIdentifier extends DataIdentifier
 		
 		// rewrite each output expression
 		FunctionCallIdentifier fci = new FunctionCallIdentifier(newParameterExpressions);
-		
-		fci.setBeginLine(this.getBeginLine());
-		fci.setBeginColumn(this.getBeginColumn());
-		fci.setEndLine(this.getEndLine());
-		fci.setEndColumn(this.getEndColumn());
+		fci.setParseInfo(this);
 			
 		fci._name = this._name;
 		fci._namespace = this._namespace;

--- a/src/main/java/org/apache/sysml/parser/FunctionStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/FunctionStatementBlock.java
@@ -110,9 +110,8 @@ public class FunctionStatementBlock extends StatementBlock
 							if (curr.getValueType() == ValueType.INT){
 								IntIdentifier currIntValue = (IntIdentifier)constVars.get(curr.getName());
 								if (currIntValue != null){
-									DoubleIdentifier currDoubleValue = new DoubleIdentifier(currIntValue.getValue(), 
-											curr.getFilename(), curr.getBeginLine(), curr.getBeginColumn(), 
-											curr.getEndLine(), curr.getEndColumn());
+									DoubleIdentifier currDoubleValue = new DoubleIdentifier(currIntValue.getValue(),
+											curr);
 									constVars.put(curr.getName(), currDoubleValue);
 								}
 								LOG.warn(curr.printWarningLocation() + "for function " + fstmt.getName() 

--- a/src/main/java/org/apache/sysml/parser/IndexedIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/IndexedIdentifier.java
@@ -146,16 +146,10 @@ public class IndexedIdentifier extends DataIdentifier
 					}	
 					
 					if (validRowLB) {
-						if (constValue instanceof IntIdentifier){
-							_rowLowerBound = new IntIdentifier((IntIdentifier)constValue,
-									constValue.getFilename(), constValue.getBeginLine(), constValue.getBeginColumn(), 
-									constValue.getEndLine(), constValue.getEndColumn());
-							
-						}
-						else{
-							_rowLowerBound = new DoubleIdentifier((DoubleIdentifier)constValue, 
-									constValue.getFilename(), constValue.getBeginLine(), constValue.getBeginColumn(), 
-									constValue.getEndLine(), constValue.getEndColumn());
+						if (constValue instanceof IntIdentifier) {
+							_rowLowerBound = new IntIdentifier((IntIdentifier) constValue, constValue);
+						} else {
+							_rowLowerBound = new DoubleIdentifier((DoubleIdentifier) constValue, constValue);
 						}
 						isConst_rowLowerBound = true;
 					}
@@ -237,19 +231,12 @@ public class IndexedIdentifier extends DataIdentifier
 								+ rowLB_1 + " May cause runtime exception");
 						validRowUB = false;
 					}
-					
+
 					if (validRowUB) {
-						if (constValue instanceof IntIdentifier){
-							_rowUpperBound = new IntIdentifier((IntIdentifier)constValue, 
-									constValue.getFilename(), constValue.getBeginLine(), 
-									constValue.getBeginColumn(), constValue.getEndLine(), 
-									constValue.getEndColumn());
-						}
-						else{
-							_rowUpperBound = new DoubleIdentifier((DoubleIdentifier)constValue, 
-									constValue.getFilename(), constValue.getBeginLine(), 
-									constValue.getBeginColumn(), constValue.getEndLine(), 
-									constValue.getEndColumn());
+						if (constValue instanceof IntIdentifier) {
+							_rowUpperBound = new IntIdentifier((IntIdentifier) constValue, constValue);
+						} else {
+							_rowUpperBound = new DoubleIdentifier((DoubleIdentifier) constValue, constValue);
 						}
 						isConst_rowUpperBound = true;
 					}
@@ -316,19 +303,12 @@ public class IndexedIdentifier extends DataIdentifier
 								+ ": " + this.getOrigDim2() +")");
 						validColLB = false;
 					}	
-					
+
 					if (validColLB) {
-						if (constValue instanceof IntIdentifier){
-							_colLowerBound = new IntIdentifier((IntIdentifier)constValue, 
-									constValue.getFilename(), constValue.getBeginLine(), 
-									constValue.getBeginColumn(), constValue.getEndLine(), 
-									constValue.getEndColumn());
-						}
-						else{
-							_colLowerBound = new DoubleIdentifier((DoubleIdentifier)constValue, 
-									constValue.getFilename(), constValue.getBeginLine(), 
-									constValue.getBeginColumn(), constValue.getEndLine(), 
-									constValue.getEndColumn());
+						if (constValue instanceof IntIdentifier) {
+							_colLowerBound = new IntIdentifier((IntIdentifier) constValue, constValue);
+						} else {
+							_colLowerBound = new DoubleIdentifier((DoubleIdentifier) constValue, constValue);
 						}
 						isConst_colLowerBound = true;
 					}
@@ -420,19 +400,12 @@ public class IndexedIdentifier extends DataIdentifier
 					+ " May cause runtime exception");
 						validColUB = false;
 					}
-					
+
 					if (validColUB) {
-						if (constValue instanceof IntIdentifier){
-							_colUpperBound = new IntIdentifier((IntIdentifier)constValue, 
-									constValue.getFilename(), constValue.getBeginLine(), 
-									constValue.getBeginColumn(), constValue.getEndLine(), 
-									constValue.getEndColumn());
-						}
-						else{
-							_colUpperBound = new DoubleIdentifier((DoubleIdentifier)constValue, 
-									constValue.getFilename(), constValue.getBeginLine(), 
-									constValue.getBeginColumn(), constValue.getEndLine(), 
-									constValue.getEndColumn());
+						if (constValue instanceof IntIdentifier) {
+							_colUpperBound = new IntIdentifier((IntIdentifier) constValue, constValue);
+						} else {
+							_colUpperBound = new DoubleIdentifier((DoubleIdentifier) constValue, constValue);
 						}
 						isConst_colUpperBound = true;
 					}
@@ -557,12 +530,7 @@ public class IndexedIdentifier extends DataIdentifier
 	public Expression rewriteExpression(String prefix) throws LanguageException {
 		
 		IndexedIdentifier newIndexedIdentifier = new IndexedIdentifier(this.getName(), this._rowLowerEqualsUpper, this._colLowerEqualsUpper);
-		
-		newIndexedIdentifier.setFilename(getFilename());
-		newIndexedIdentifier.setBeginLine(this.getBeginLine());
-		newIndexedIdentifier.setBeginColumn(this.getBeginColumn());
-		newIndexedIdentifier.setEndLine(this.getEndLine());
-		newIndexedIdentifier.setEndColumn(this.getEndColumn());
+		newIndexedIdentifier.setParseInfo(this);
 			
 		// set dimensionality information and other Identifier specific properties for new IndexedIdentifier
 		newIndexedIdentifier.setProperties(this);

--- a/src/main/java/org/apache/sysml/parser/IntIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/IntIdentifier.java
@@ -19,7 +19,7 @@
 
 package org.apache.sysml.parser;
 
-
+import org.antlr.v4.runtime.ParserRuleContext;
 
 public class IntIdentifier extends ConstIdentifier 
 {
@@ -29,25 +29,39 @@ public class IntIdentifier extends ConstIdentifier
 	public Expression rewriteExpression(String prefix) throws LanguageException{
 		return this;
 	}
-	
-	public IntIdentifier(long val, String filename, int blp, int bcp, int elp, int ecp){
+
+	public IntIdentifier(long val) {
 		super();
-		 _val = val;
-		setDimensions(0,0);
-        computeDataType();
-        setValueType(ValueType.INT);
-        setAllPositions(filename, blp, bcp, elp, ecp);
+		setInfo(val);
+		setBeginLine(-1);
+		setBeginColumn(-1);
+		setEndLine(-1);
+		setEndColumn(-1);
+		setText(null);
 	}
-	
-	public IntIdentifier(IntIdentifier i, String filename, int blp, int bcp, int elp, int ecp){
-		super();
-		 _val = i.getValue();
-		setDimensions(0,0);
-        computeDataType();
-        setValueType(ValueType.INT);
-        setAllPositions(filename, blp, bcp, elp, ecp);
+
+	public IntIdentifier(long val, ParseInfo parseInfo) {
+		this(val);
+		setParseInfo(parseInfo);
 	}
-	
+
+	public IntIdentifier(IntIdentifier i, ParseInfo parseInfo) {
+		this(i.getValue());
+		setParseInfo(parseInfo);
+	}
+
+	public IntIdentifier(ParserRuleContext ctx, long val, String filename) {
+		this(val);
+		setCtxValuesAndFilename(ctx, filename);
+	}
+
+	private void setInfo(long val) {
+		_val = val;
+		setDimensions(0, 0);
+		computeDataType();
+		setValueType(ValueType.INT);
+	}
+
 	// Used only by the parser for unary operation
 	public void multiplyByMinusOne() {
 		_val = -1 * _val;

--- a/src/main/java/org/apache/sysml/parser/IterablePredicate.java
+++ b/src/main/java/org/apache/sysml/parser/IterablePredicate.java
@@ -21,6 +21,7 @@ package org.apache.sysml.parser;
 
 import java.util.HashMap;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.sysml.lops.Lop;
 
 
@@ -33,20 +34,17 @@ public class IterablePredicate extends Expression
 	private Expression _incrementExpr;
 	private HashMap<String,String> _parforParams;
 	
-	
-	public IterablePredicate(DataIdentifier iterVar, Expression fromExpr, Expression toExpr, 
-			Expression incrementExpr, HashMap<String,String> parForParamValues,
-			String filename, int blp, int bcp, int elp, int ecp)
-	{
+	public IterablePredicate(ParserRuleContext ctx, DataIdentifier iterVar, Expression fromExpr, Expression toExpr,
+			Expression incrementExpr, HashMap<String, String> parForParamValues, String filename) {
 		_iterVar = iterVar;
 		_fromExpr = fromExpr;
 		_toExpr = toExpr;
 		_incrementExpr = incrementExpr;
-		
+
 		_parforParams = parForParamValues;
-		this.setAllPositions(filename, blp, bcp, elp, ecp);
+		this.setCtxValuesAndFilename(ctx, filename);
 	}
-		
+
 	public String toString()
 	{ 
 		StringBuilder sb = new StringBuilder();
@@ -133,14 +131,12 @@ public class IterablePredicate extends Expression
 		
 		//2) VALIDATE FOR PREDICATE in (from, to, increment)		
 		// handle default increment if unspecified
-		if( _incrementExpr == null && _fromExpr instanceof ConstIdentifier 
-			&& _toExpr instanceof ConstIdentifier ) {
+		if (_incrementExpr == null && _fromExpr instanceof ConstIdentifier && _toExpr instanceof ConstIdentifier) {
 			ConstIdentifier cFrom = (ConstIdentifier) _fromExpr;
 			ConstIdentifier cTo = (ConstIdentifier) _toExpr;
-			_incrementExpr = new IntIdentifier( (cFrom.getLongValue() <= cTo.getLongValue()) ? 1 : -1, 
-					getFilename(), getBeginLine(), getBeginColumn(), getEndLine(), getEndColumn());
+			_incrementExpr = new IntIdentifier((cFrom.getLongValue() <= cTo.getLongValue()) ? 1 : -1, this);
 		}
-		
+
 		//recursively validate the individual expression
 		_fromExpr.validateExpression(ids, constVars, conditional);
 		_toExpr.validateExpression(ids, constVars, conditional);

--- a/src/main/java/org/apache/sysml/parser/MultiAssignmentStatement.java
+++ b/src/main/java/org/apache/sysml/parser/MultiAssignmentStatement.java
@@ -48,10 +48,7 @@ public class MultiAssignmentStatement extends Statement
 		
 		// create rewritten assignment statement (deep copy)
 		MultiAssignmentStatement retVal = new MultiAssignmentStatement(newTargetList, newSource);
-		retVal.setBeginLine(this.getBeginLine());
-		retVal.setBeginColumn(this.getBeginColumn());
-		retVal.setEndLine(this.getEndLine());
-		retVal.setEndColumn(this.getEndColumn());
+		retVal.setParseInfo(this);
 		
 		return retVal;
 	}

--- a/src/main/java/org/apache/sysml/parser/ParseInfo.java
+++ b/src/main/java/org/apache/sysml/parser/ParseInfo.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.parser;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.misc.Interval;
+
+public interface ParseInfo {
+
+	public void setBeginLine(int beginLine);
+
+	public void setBeginColumn(int beginColumn);
+
+	public void setEndLine(int endLine);
+
+	public void setEndColumn(int endColumn);
+
+	public void setText(String text);
+	
+	public void setFilename(String filename);
+
+	public int getBeginLine();
+
+	public int getBeginColumn();
+
+	public int getEndLine();
+
+	public int getEndColumn();
+
+	public String getText();
+	
+	public String getFilename();
+
+	public static ParseInfo ctxAndFilenameToParseInfo(ParserRuleContext ctx, String filename) {
+		ParseInfo pi = new ParseInfo() {
+			private int beginLine;
+			private int beginColumn;
+			private int endLine;
+			private int endColumn;
+			private String text;
+			private String filename;
+
+			@Override
+			public void setBeginLine(int beginLine) {
+				this.beginLine = beginLine;
+			}
+
+			@Override
+			public void setBeginColumn(int beginColumn) {
+				this.beginColumn = beginColumn;
+			}
+
+			@Override
+			public void setEndLine(int endLine) {
+				this.endLine = endLine;
+			}
+
+			@Override
+			public void setEndColumn(int endColumn) {
+				this.endColumn = endColumn;
+			}
+
+			@Override
+			public void setText(String text) {
+				this.text = text;
+			}
+
+			@Override
+			public void setFilename(String filename) {
+				this.filename = filename;
+			}
+			@Override
+			public int getBeginLine() {
+				return beginLine;
+			}
+
+			@Override
+			public int getBeginColumn() {
+				return beginColumn;
+			}
+
+			@Override
+			public int getEndLine() {
+				return endLine;
+			}
+
+			@Override
+			public int getEndColumn() {
+				return endColumn;
+			}
+
+			@Override
+			public String getText() {
+				return text;
+			}
+			
+			@Override
+			public String getFilename() {
+				return filename;
+			}
+		};
+		pi.setBeginLine(ctx.start.getLine());
+		pi.setBeginColumn(ctx.start.getCharPositionInLine());
+		pi.setEndLine(ctx.stop.getLine());
+		pi.setEndColumn(ctx.stop.getCharPositionInLine());
+		// preserve whitespace if possible
+		if ((ctx.start != null) && (ctx.stop != null) && (ctx.start.getStartIndex() != -1) && (ctx.stop.getStopIndex() != -1)) {
+			String text = ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+			pi.setText(text);
+		} else {
+			pi.setText(ctx.getText());
+		}
+		pi.setFilename(filename);
+		return pi;
+	}
+}

--- a/src/main/java/org/apache/sysml/parser/ParseInfo.java
+++ b/src/main/java/org/apache/sysml/parser/ParseInfo.java
@@ -126,9 +126,16 @@ public interface ParseInfo {
 				&& (ctx.start.getInputStream() != null)) {
 			String text = ctx.start.getInputStream()
 					.getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+			if (text != null) {
+				text = text.trim();
+			}
 			pi.setText(text);
 		} else {
-			pi.setText(ctx.getText());
+			String text = ctx.getText();
+			if (text != null) {
+				text = text.trim();
+			}
+			pi.setText(text);
 		}
 		pi.setFilename(filename);
 		return pi;

--- a/src/main/java/org/apache/sysml/parser/ParseInfo.java
+++ b/src/main/java/org/apache/sysml/parser/ParseInfo.java
@@ -121,8 +121,11 @@ public interface ParseInfo {
 		pi.setEndLine(ctx.stop.getLine());
 		pi.setEndColumn(ctx.stop.getCharPositionInLine());
 		// preserve whitespace if possible
-		if ((ctx.start != null) && (ctx.stop != null) && (ctx.start.getStartIndex() != -1) && (ctx.stop.getStopIndex() != -1)) {
-			String text = ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+		if ((ctx.start != null) && (ctx.stop != null) && (ctx.start.getStartIndex() != -1)
+				&& (ctx.stop.getStopIndex() != -1) && (ctx.start.getStartIndex() <= ctx.stop.getStopIndex())
+				&& (ctx.start.getInputStream() != null)) {
+			String text = ctx.start.getInputStream()
+					.getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
 			pi.setText(text);
 		} else {
 			pi.setText(ctx.getText());

--- a/src/main/java/org/apache/sysml/parser/RelationalExpression.java
+++ b/src/main/java/org/apache/sysml/parser/RelationalExpression.java
@@ -37,26 +37,21 @@ public class RelationalExpression extends Expression
 		setBeginColumn(0);
 		setEndLine(0);
 		setEndColumn(0);
+		setText(null);
 	}
-	
-	public RelationalExpression(RelationalOp bop, String filename, int beginLine, int beginColumn, int endLine, int endColumn) {
+
+	public RelationalExpression(RelationalOp bop, ParseInfo parseInfo) {
 		_opcode = bop;
-		
-		setFilename(filename);
-		setBeginLine(beginLine);
-		setBeginColumn(beginColumn);
-		setEndLine(endLine);
-		setEndColumn(endColumn);
+		setParseInfo(parseInfo);
 	}
-	
-	public Expression rewriteExpression(String prefix) throws LanguageException{
-		
-		RelationalExpression newExpr = new RelationalExpression(this._opcode, getFilename(), getBeginLine(), getBeginColumn(), getEndLine(), getEndColumn());
+
+	public Expression rewriteExpression(String prefix) throws LanguageException {
+		RelationalExpression newExpr = new RelationalExpression(this._opcode, this);
 		newExpr.setLeft(_left.rewriteExpression(prefix));
 		newExpr.setRight(_right.rewriteExpression(prefix));
 		return newExpr;
 	}
-	
+
 	public RelationalOp getOpCode(){
 		return _opcode;
 	}
@@ -65,22 +60,18 @@ public class RelationalExpression extends Expression
 		_left = l;
 		
 		// update script location information --> left expression is BEFORE in script
-		if (_left != null){
-			setFilename(_left.getFilename());
-			setBeginLine(_left.getBeginLine());
-			setBeginColumn(_left.getBeginColumn());
+		if (_left != null) {
+			setParseInfo(_left);
 		}
-		
+
 	}
 	
 	public void setRight(Expression r){
 		_right = r;
 		
 		// update script location information --> right expression is AFTER in script
-		if (_right != null){
-			setFilename(_right.getFilename());
-			setBeginLine(_right.getEndLine());
-			setBeginColumn(_right.getEndColumn());
+		if (_right != null) {
+			setParseInfo(_right);
 		}
 	}
 	
@@ -110,23 +101,24 @@ public class RelationalExpression extends Expression
 		}
 		
 		// handle <NUMERIC> == <BOOLEAN> --> convert <BOOLEAN> to numeric value
-		if ((_left != null && _left instanceof BooleanIdentifier) || (_right != null && _right instanceof BooleanIdentifier)){
-			if ((_left instanceof IntIdentifier || _left instanceof DoubleIdentifier) || _right instanceof IntIdentifier || _right instanceof DoubleIdentifier){
-				if (_left instanceof BooleanIdentifier){
+		if ((_left != null && _left instanceof BooleanIdentifier)
+				|| (_right != null && _right instanceof BooleanIdentifier)) {
+			if ((_left instanceof IntIdentifier || _left instanceof DoubleIdentifier) || _right instanceof IntIdentifier
+					|| _right instanceof DoubleIdentifier) {
+				if (_left instanceof BooleanIdentifier) {
 					if (((BooleanIdentifier) _left).getValue())
-						this.setLeft(new IntIdentifier(1, _left.getFilename(), _left.getBeginLine(), _left.getBeginColumn(), _left.getEndLine(), _left.getEndColumn()));
+						this.setLeft(new IntIdentifier(1, _left));
 					else
-						this.setLeft(new IntIdentifier(0, _left.getFilename(), _left.getBeginLine(), _left.getBeginColumn(), _left.getEndLine(), _left.getEndColumn()));
-				}
-				else if (_right instanceof BooleanIdentifier){
+						this.setLeft(new IntIdentifier(0, _left));
+				} else if (_right instanceof BooleanIdentifier) {
 					if (((BooleanIdentifier) _right).getValue())
-						this.setRight(new IntIdentifier(1, _right.getFilename(), _right.getBeginLine(), _right.getBeginColumn(), _right.getEndLine(),_right.getEndColumn()));
+						this.setRight(new IntIdentifier(1, _right));
 					else
-						this.setRight(new IntIdentifier(0,  _right.getFilename(), _right.getBeginLine(), _right.getBeginColumn(), _right.getEndLine(),_right.getEndColumn()));
+						this.setRight(new IntIdentifier(0, _right));
 				}
 			}
 		}
-		
+
 		//recursive validate
 		_left.validateExpression(ids, constVars, conditional);
 		if( _right !=null )
@@ -140,7 +132,7 @@ public class RelationalExpression extends Expression
 		
 		String outputName = getTempName();
 		DataIdentifier output = new DataIdentifier(outputName);
-		output.setAllPositions(this.getFilename(), this.getBeginLine(), this.getBeginColumn(), this.getEndLine(), this.getEndColumn());
+		output.setParseInfo(this);
 		
 		boolean isLeftMatrix = (_left.getOutput() != null && _left.getOutput().getDataType() == DataType.MATRIX);
 		boolean isRightMatrix = (_right.getOutput() != null && _right.getOutput().getDataType() == DataType.MATRIX); 

--- a/src/main/java/org/apache/sysml/parser/Statement.java
+++ b/src/main/java/org/apache/sysml/parser/Statement.java
@@ -19,10 +19,12 @@
 
 package org.apache.sysml.parser;
 
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.misc.Interval;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-public abstract class Statement 
+public abstract class Statement implements ParseInfo
 {
 
 	
@@ -87,19 +89,47 @@ public abstract class Statement
 	private String _filename;
 	private int _beginLine, _beginColumn;
 	private int _endLine,   _endColumn;
+	private String _text;
 	
 	public void setFilename(String passed)  { _filename = passed;	}
 	public void setBeginLine(int passed)    { _beginLine = passed;	}
 	public void setBeginColumn(int passed) 	{ _beginColumn = passed;}
 	public void setEndLine(int passed) 		{ _endLine = passed;   }
 	public void setEndColumn(int passed)	{ _endColumn = passed; }
-	
-	public void setAllPositions(String filename, int blp, int bcp, int elp, int ecp){
-		_filename    = filename;
-		_beginLine	 = blp; 
-		_beginColumn = bcp; 
-		_endLine 	 = elp;
-		_endColumn 	 = ecp;
+
+	/**
+	 * Set ParserRuleContext values (begin line, begin column, end line, end
+	 * column, and text).
+	 *
+	 * @param ctx
+	 *            the antlr ParserRuleContext
+	 */
+	public void setCtxValues(ParserRuleContext ctx) {
+		setBeginLine(ctx.start.getLine());
+		setBeginColumn(ctx.start.getCharPositionInLine());
+		setEndLine(ctx.stop.getLine());
+		setEndColumn(ctx.stop.getCharPositionInLine());
+		// preserve whitespace if possible
+		if ((ctx.start != null) && (ctx.stop != null) && (ctx.start.getStartIndex() != -1) && (ctx.stop.getStopIndex() != -1)) {
+			String text = ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+			setText(text);
+		} else {
+			setText(ctx.getText());
+		}
+	}
+
+	/**
+	 * Set ParserRuleContext values (begin line, begin column, end line, end
+	 * column, and text) and file name.
+	 *
+	 * @param ctx
+	 *            the antlr ParserRuleContext
+	 * @param filename
+	 *            the filename (if it exists)
+	 */
+	public void setCtxValuesAndFilename(ParserRuleContext ctx, String filename) {
+		setCtxValues(ctx);
+		setFilename(filename);
 	}
 
 	public int getBeginLine()	{ return _beginLine;   }
@@ -107,37 +137,77 @@ public abstract class Statement
 	public int getEndLine() 	{ return _endLine;   }
 	public int getEndColumn()	{ return _endColumn; }
 	public String getFilename() { return _filename;  }
-		
-	public String printErrorLocation(){
-		return "ERROR: " + _filename + " -- line " + _beginLine + ", column " + _beginColumn + " -- ";
-	}
-	
-	public String printWarningLocation(){
-		return "WARNING: " + _filename + " -- line " + _beginLine + ", column " + _beginColumn + " -- ";
+
+	public String printErrorLocation() {
+		String file = _filename;
+		if (file == null) {
+			file = "";
+		} else {
+			file = file + " ";
+		}
+		if (getText() != null) {
+			return "ERROR: " + file + "[line " + _beginLine + ":" + _beginColumn + "] -> " + getText() + " -- ";
+		} else {
+			return "ERROR: " + file + "[line " + _beginLine + ":" + _beginColumn + "] -- ";
+		}
 	}
 
-	public void raiseValidateError( String msg, boolean conditional ) throws LanguageException {
+	public String printWarningLocation() {
+		String file = _filename;
+		if (file == null) {
+			file = "";
+		} else {
+			file = file + " ";
+		}
+		if (getText() != null) {
+			return "WARNING: " + file + "[line " + _beginLine + ":" + _beginColumn + "] -> " + getText() + " -- ";
+		} else {
+			return "WARNING: " + file + "[line " + _beginLine + ":" + _beginColumn + "] -- ";
+		}
+	}
+
+	public void raiseValidateError(String msg, boolean conditional) throws LanguageException {
 		raiseValidateError(msg, conditional, null);
 	}
-	
-	public void raiseValidateError( String msg, boolean conditional, String errorCode ) 
-		throws LanguageException
-	{
-		if( conditional )  //warning if conditional
-		{
+
+	public void raiseValidateError(String msg, boolean conditional, String errorCode) throws LanguageException {
+		if (conditional) {// warning if conditional
 			String fullMsg = this.printWarningLocation() + msg;
-			
-			LOG.warn( fullMsg );
-		}
-		else  //error and exception if unconditional
-		{
+			LOG.warn(fullMsg);
+		} else {// error and exception if unconditional
 			String fullMsg = this.printErrorLocation() + msg;
-			
-			//LOG.error( fullMsg ); //no redundant error	
-			if( errorCode != null )
-				throw new LanguageException( fullMsg, errorCode );
-			else 
-				throw new LanguageException( fullMsg );
+			if (errorCode != null)
+				throw new LanguageException(fullMsg, errorCode);
+			else
+				throw new LanguageException(fullMsg);
 		}
-	}	
+	}
+
+	public String getText() {
+		return _text;
+	}
+
+	public void setText(String text) {
+		this._text = text;
+	}
+
+	/**
+	 * Set parse information.
+	 *
+	 * @param parseInfo
+	 *            parse information, such as beginning line position, beginning
+	 *            column position, ending line position, ending column position,
+	 *            text, and filename
+	 * @param filename
+	 *            the DML/PYDML filename (if it exists)
+	 */
+	public void setParseInfo(ParseInfo parseInfo) {
+		_beginLine = parseInfo.getBeginLine();
+		_beginColumn = parseInfo.getBeginColumn();
+		_endLine = parseInfo.getEndLine();
+		_endColumn = parseInfo.getEndColumn();
+		_text = parseInfo.getText();
+		_filename = parseInfo.getFilename();
+	}
+
 }

--- a/src/main/java/org/apache/sysml/parser/Statement.java
+++ b/src/main/java/org/apache/sysml/parser/Statement.java
@@ -110,8 +110,11 @@ public abstract class Statement implements ParseInfo
 		setEndLine(ctx.stop.getLine());
 		setEndColumn(ctx.stop.getCharPositionInLine());
 		// preserve whitespace if possible
-		if ((ctx.start != null) && (ctx.stop != null) && (ctx.start.getStartIndex() != -1) && (ctx.stop.getStopIndex() != -1)) {
-			String text = ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+		if ((ctx.start != null) && (ctx.stop != null) && (ctx.start.getStartIndex() != -1)
+				&& (ctx.stop.getStopIndex() != -1) && (ctx.start.getStartIndex() <= ctx.stop.getStopIndex())
+				&& (ctx.start.getInputStream() != null)) {
+			String text = ctx.start.getInputStream()
+					.getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
 			setText(text);
 		} else {
 			setText(ctx.getText());

--- a/src/main/java/org/apache/sysml/parser/Statement.java
+++ b/src/main/java/org/apache/sysml/parser/Statement.java
@@ -115,9 +115,16 @@ public abstract class Statement implements ParseInfo
 				&& (ctx.start.getInputStream() != null)) {
 			String text = ctx.start.getInputStream()
 					.getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+			if (text != null) {
+				text = text.trim();
+			}
 			setText(text);
 		} else {
-			setText(ctx.getText());
+			String text = ctx.getText();
+			if (text != null) {
+				text = text.trim();
+			}
+			setText(text);
 		}
 	}
 

--- a/src/main/java/org/apache/sysml/parser/StringIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/StringIdentifier.java
@@ -19,24 +19,34 @@
 
 package org.apache.sysml.parser;
 
-
+import org.antlr.v4.runtime.ParserRuleContext;
 
 public class StringIdentifier extends ConstIdentifier 
 {
 	
 	private String _val;
-	
-	public Expression rewriteExpression(String prefix) throws LanguageException{
+
+	public Expression rewriteExpression(String prefix) throws LanguageException {
 		return this;
 	}
-	
-	public StringIdentifier(String val, String filename, int blp, int bcp, int elp, int ecp){
+
+	public StringIdentifier(String val, ParseInfo parseInfo) {
 		super();
-		 _val = val;
-		setDimensions(0,0);
-        computeDataType();
-        setValueType(ValueType.STRING);
-        setAllPositions(filename, blp, bcp, elp, ecp);
+		setInfo(val);
+		setParseInfo(parseInfo);
+	}
+
+	public StringIdentifier(ParserRuleContext ctx, String val, String filename) {
+		super();
+		setInfo(val);
+		setCtxValuesAndFilename(ctx, filename);
+	}
+
+	private void setInfo(String val) {
+		_val = val;
+		setDimensions(0, 0);
+		computeDataType();
+		setValueType(ValueType.STRING);
 	}
 
 	public String getValue(){

--- a/src/main/java/org/apache/sysml/parser/common/CustomErrorListener.java
+++ b/src/main/java/org/apache/sysml/parser/common/CustomErrorListener.java
@@ -29,6 +29,7 @@ import org.antlr.v4.runtime.Recognizer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysml.api.DMLScript;
+import org.apache.sysml.parser.ParseInfo;
 
 public class CustomErrorListener extends BaseErrorListener {
 
@@ -82,6 +83,25 @@ public class CustomErrorListener extends BaseErrorListener {
 			}
 		} catch (Exception e1) {
 			log.error("ERROR: while customizing error message:" + e1);
+		}
+	}
+
+	public void validationError(ParseInfo parseInfo, String msg) {
+		parseIssues.add(new ParseIssue(parseInfo.getBeginLine(), parseInfo.getBeginColumn(), msg, currentFileName,
+				ParseIssueType.VALIDATION_ERROR));
+
+		try {
+			setAtLeastOneError(true);
+			if (currentFileName == null) {
+				log.error("line " + parseInfo.getBeginLine() + ":" + parseInfo.getBeginColumn() + " ("
+						+ parseInfo.getText() + "): " + msg);
+			} else {
+				String fileName = currentFileName;
+				log.error(fileName + " line " + parseInfo.getBeginLine() + ":" + parseInfo.getBeginColumn() + " ("
+						+ parseInfo.getText() + "): " + msg);
+			}
+		} catch (Exception e) {
+			log.error("ERROR: while customizing error message:" + e);
 		}
 	}
 

--- a/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysml/parser/pydml/PydmlSyntacticValidator.java
@@ -358,21 +358,14 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 					// Add expression for nrow(X) for implicit upper bound
 					Expression.BuiltinFunctionOp bop = Expression.BuiltinFunctionOp.NROW;
 					DataIdentifier x = new DataIdentifier(ctx.name.getText());
-					int line = ctx.start.getLine();
-					int col = ctx.start.getCharPositionInLine();
-					Expression expr = new BuiltinFunctionExpression(bop, new Expression[]{x},
-							currentFile, line, col, line, col);
-					setFileLineColumn(expr, ctx);
+					Expression expr = new BuiltinFunctionExpression(ctx, bop, new Expression[] { x }, currentFile);
 					rowIndices.add(expr);
 				}
 			}
 			else if(!isRowLower && isRowUpper && isRowSliceImplicit) {
 				// Add expression for `1` for implicit lower bound
 				// Note: We go ahead and increment by 1 to convert from 0-based to 1-based indexing
-				int line = ctx.start.getLine();
-				int col = ctx.start.getCharPositionInLine();
-				IntIdentifier one = new IntIdentifier(1, currentFile, line, col, line, col);
-				setFileLineColumn(one, ctx);
+				IntIdentifier one = new IntIdentifier(ctx, 1, currentFile);
 				rowIndices.add(one);
 
 				// Add given upper bound
@@ -398,21 +391,14 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 					// Add expression for ncol(X) for implicit upper bound
 					Expression.BuiltinFunctionOp bop = Expression.BuiltinFunctionOp.NCOL;
 					DataIdentifier x = new DataIdentifier(ctx.name.getText());
-					int line = ctx.start.getLine();
-					int col = ctx.start.getCharPositionInLine();
-					Expression expr = new BuiltinFunctionExpression(bop, new Expression[]{x},
-							currentFile, line, col, line, col);
-					setFileLineColumn(expr, ctx);
+					Expression expr = new BuiltinFunctionExpression(ctx, bop, new Expression[] { x }, currentFile);
 					colIndices.add(expr);
 				}
 			}
 			else if(!isColLower && isColUpper && isColSliceImplicit) {
 				// Add expression for `1` for implicit lower bound
 				// Note: We go ahead and increment by 1 to convert from 0-based to 1-based indexing
-				int line = ctx.start.getLine();
-				int col = ctx.start.getCharPositionInLine();
-				IntIdentifier one = new IntIdentifier(1, currentFile, line, col, line, col);
-				setFileLineColumn(one, ctx);
+				IntIdentifier one = new IntIdentifier(ctx, 1, currentFile);
 				colIndices.add(one);
 
 				// Add given upper bound
@@ -445,9 +431,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		Expression.BinaryOp bop = Expression.getBinaryOp("+");
 		Expression retVal = new BinaryExpression(bop);
 		((BinaryExpression)retVal).setLeft(expr);
-		int line = ctx.start.getLine();
-		int col = ctx.start.getCharPositionInLine();
-		((BinaryExpression)retVal).setRight(new DoubleIdentifier(1.0, currentFile, line, col, line, col));
+		((BinaryExpression)retVal).setRight(new DoubleIdentifier(ctx, 1.0, currentFile));
 		setFileLineColumn(retVal, ctx);
 		return retVal;
 	}
@@ -470,14 +454,14 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 	private void handleCommandlineArgumentExpression(DataIdentifierContext ctx)
 	{
 		String varName = ctx.getText().trim();
-		fillExpressionInfoCommandLineParameters(varName, ctx.dataInfo, ctx.start);
+		fillExpressionInfoCommandLineParameters(ctx, varName, ctx.dataInfo);
 
 		if(ctx.dataInfo.expr == null) {
 			if(!(ctx.parent instanceof IfdefAssignmentStatementContext)) {
 				String msg = "The parameter " + varName + " either needs to be passed "
 						+ "through commandline or initialized to default value.";
 				if( ConfigurationManager.getCompilerConfigFlag(ConfigType.IGNORE_UNSPECIFIED_ARGS) ) {
-					ctx.dataInfo.expr = getConstIdFromString(" ", ctx.start);
+					ctx.dataInfo.expr = getConstIdFromString(ctx, " ");
 					if (!ConfigurationManager.getCompilerConfigFlag(ConfigType.MLCONTEXT)) {
 						raiseWarning(msg, ctx.start);
 					}
@@ -664,10 +648,6 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			return new ConvertedDMLSyntax(namespace, functionName, paramExpression);
 		}
 
-		String fileName = currentFile;
-		int line = ctx.start.getLine();
-		int col = ctx.start.getCharPositionInLine();
-
 		if(namespace.equals(DMLProgram.DEFAULT_NAMESPACE) && functionName.equals("len")) {
 			if(paramExpression.size() != 1) {
 				notifyErrorListeners("The builtin function \'" + functionName + "\' accepts 1 arguments", fnName);
@@ -812,7 +792,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			paramExpression.get(0).setName("rows");
 			paramExpression.get(1).setName("cols");
 			paramExpression.get(2).setName("sparsity");
-			paramExpression.add(new ParameterExpression("pdf", new StringIdentifier("normal", fileName, line, col, line, col)));
+			paramExpression.add(new ParameterExpression("pdf", new StringIdentifier(ctx, "normal", currentFile)));
 			functionName = "rand";
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
@@ -826,7 +806,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			paramExpression.get(1).setName("cols");
 			paramExpression.get(2).setName("sparsity");
 			paramExpression.get(3).setName("lambda");
-			paramExpression.add(new ParameterExpression("pdf", new StringIdentifier("poisson", fileName, line, col, line, col)));
+			paramExpression.add(new ParameterExpression("pdf", new StringIdentifier(ctx, "poisson", currentFile)));
 			functionName = "rand";
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
@@ -841,7 +821,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			paramExpression.get(2).setName("sparsity");
 			paramExpression.get(3).setName("min");
 			paramExpression.get(4).setName("max");
-			paramExpression.add(new ParameterExpression("pdf", new StringIdentifier("uniform", fileName, line, col, line, col)));
+			paramExpression.add(new ParameterExpression("pdf", new StringIdentifier(ctx, "uniform", currentFile)));
 			functionName = "rand";
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
@@ -885,9 +865,9 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 				initializerString = initializerString.replaceAll("\\[", "");
 				initializerString = initializerString.replaceAll("\\]", "");
 				paramExpression = new ArrayList<ParameterExpression>();
-				paramExpression.add(new ParameterExpression(null, new StringIdentifier(initializerString, fileName, line, col, line, col)));
-				paramExpression.add(new ParameterExpression("rows", new IntIdentifier(rows, fileName, line, col, line, col)));
-				paramExpression.add(new ParameterExpression("cols", new IntIdentifier(cols, fileName, line, col, line, col)));
+				paramExpression.add(new ParameterExpression(null, new StringIdentifier(ctx, initializerString, currentFile)));
+				paramExpression.add(new ParameterExpression("rows", new IntIdentifier(ctx, rows, currentFile)));
+				paramExpression.add(new ParameterExpression("cols", new IntIdentifier(ctx, cols, currentFile)));
 			}
 			else {
 				functionName = "as.matrix";
@@ -955,10 +935,10 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			}
 			StringIdentifier marginVal = null;
 			if(axis == 0) {
-				marginVal = new StringIdentifier("rows", fileName, line, col, line, col);
+				marginVal = new StringIdentifier(ctx, "rows", currentFile);
 			}
 			else {
-				marginVal = new StringIdentifier("cols", fileName, line, col, line, col);
+				marginVal = new StringIdentifier(ctx, "cols", currentFile);
 			}
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("margin");
@@ -997,7 +977,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("mean");
 			paramExpression.get(2).setName("sd");
-			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("normal", fileName, line, col, line, col)));
+			paramExpression.add(new ParameterExpression("dist", new StringIdentifier(ctx, "normal", currentFile)));
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
 		else if(namespace.equals("expon") && functionName.equals("cdf")) {
@@ -1009,7 +989,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			functionName = "cdf";
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("mean");
-			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("exp", fileName, line, col, line, col)));
+			paramExpression.add(new ParameterExpression("dist", new StringIdentifier(ctx, "exp", currentFile)));
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
 		else if(namespace.equals("chi") && functionName.equals("cdf")) {
@@ -1021,7 +1001,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			functionName = "cdf";
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("df");
-			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("chisq", fileName, line, col, line, col)));
+			paramExpression.add(new ParameterExpression("dist", new StringIdentifier(ctx, "chisq", currentFile)));
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
 		else if(namespace.equals("f") && functionName.equals("cdf")) {
@@ -1034,7 +1014,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("df1");
 			paramExpression.get(2).setName("df2");
-			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("f", fileName, line, col, line, col)));
+			paramExpression.add(new ParameterExpression("dist", new StringIdentifier(ctx, "f", currentFile)));
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
 		else if(namespace.equals("t") && functionName.equals("cdf")) {
@@ -1046,7 +1026,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			functionName = "cdf";
 			paramExpression.get(0).setName("target");
 			paramExpression.get(1).setName("df");
-			paramExpression.add(new ParameterExpression("dist", new StringIdentifier("t", fileName, line, col, line, col)));
+			paramExpression.add(new ParameterExpression("dist", new StringIdentifier(ctx, "t", currentFile)));
 			namespace = DMLProgram.DEFAULT_NAMESPACE;
 		}
 		else if(namespace.equals(DMLProgram.DEFAULT_NAMESPACE) && functionName.equals("percentile")) {
@@ -1245,10 +1225,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		IfStatement ifStmt = new IfStatement();
 		ConditionalPredicate predicate = new ConditionalPredicate(ctx.predicate.info.expr);
 		ifStmt.setConditionalPredicate(predicate);
-		String fileName = currentFile;
-		int line = ctx.start.getLine();
-		int col = ctx.start.getCharPositionInLine();
-		ifStmt.setAllPositions(fileName, line, col, line, col);
+		ifStmt.setCtxValuesAndFilename(ctx, currentFile);
 
 		if(ctx.ifBody.size() > 0) {
 			for(StatementContext stmtCtx : ctx.ifBody) {
@@ -1282,10 +1259,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		IfStatement elifStmt = new IfStatement();
 		ConditionalPredicate predicate = new ConditionalPredicate(ctx.predicate.info.expr);
 		elifStmt.setConditionalPredicate(predicate);
-		String fileName = currentFile;
-		int line = ctx.start.getLine();
-		int col = ctx.start.getCharPositionInLine();
-		elifStmt.setAllPositions(fileName, line, col, line, col);
+		elifStmt.setCtxValuesAndFilename(ctx, currentFile);
 
 		if(ctx.elifBody.size() > 0) {
 			for (StatementContext stmtCtx : ctx.elifBody) {
@@ -1303,9 +1277,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		WhileStatement whileStmt = new WhileStatement();
 		ConditionalPredicate predicate = new ConditionalPredicate(ctx.predicate.info.expr);
 		whileStmt.setPredicate(predicate);
-		int line = ctx.start.getLine();
-		int col = ctx.start.getCharPositionInLine();
-		whileStmt.setAllPositions(currentFile, line, col, line, col);
+		whileStmt.setCtxValuesAndFilename(ctx, currentFile);
 
 		if(ctx.body.size() > 0) {
 			for(StatementContext stmtCtx : ctx.body) {
@@ -1321,8 +1293,6 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 	@Override
 	public void exitForStatement(ForStatementContext ctx) {
 		ForStatement forStmt = new ForStatement();
-		int line = ctx.start.getLine();
-		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
 		HashMap<String, String> parForParamValues = null;
@@ -1330,7 +1300,8 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		if(ctx.iterPred.info.increment != null) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(ctx, iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to,
+				incrementExpr, parForParamValues, currentFile);
 		forStmt.setPredicate(predicate);
 
 		if(ctx.body.size() > 0) {
@@ -1346,8 +1317,6 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 	@Override
 	public void exitParForStatement(ParForStatementContext ctx) {
 		ParForStatement parForStmt = new ParForStatement();
-		int line = ctx.start.getLine();
-		int col = ctx.start.getCharPositionInLine();
 
 		DataIdentifier iterVar = new DataIdentifier(ctx.iterVar.getText());
 		HashMap<String, String> parForParamValues = new HashMap<String, String>();
@@ -1364,7 +1333,8 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		if( ctx.iterPred.info.increment != null ) {
 			incrementExpr = ctx.iterPred.info.increment;
 		}
-		IterablePredicate predicate = new IterablePredicate(iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to, incrementExpr, parForParamValues, currentFile, line, col, line, col);
+		IterablePredicate predicate = new IterablePredicate(ctx, iterVar, ctx.iterPred.info.from, ctx.iterPred.info.to,
+				incrementExpr, parForParamValues, currentFile);
 		parForStmt.setPredicate(predicate);
 		if(ctx.body.size() > 0) {
 			for(StatementContext stmtCtx : ctx.body) {
@@ -1373,7 +1343,6 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 			parForStmt.mergeStatementBlocks();
 		}
 		ctx.info.stmt = parForStmt;
-		setFileLineColumn(ctx.info.stmt, ctx);
 	}
 
 
@@ -1576,11 +1545,8 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 				source = ctx.source.info.expr;
 			}
 
-			int line = ctx.start.getLine();
-			int col = ctx.start.getCharPositionInLine();
 			try {
-				ctx.info.stmt = new AssignmentStatement(target, source, line, col, line, col);
-				setFileLineColumn(ctx.info.stmt, ctx);
+				ctx.info.stmt = new AssignmentStatement(ctx, target, source, currentFile);
 			} catch (LanguageException e) {
 				notifyErrorListeners("invalid assignment for ifdef function", ctx.targetList.start);
 				return;
@@ -1621,7 +1587,7 @@ public class PydmlSyntacticValidator extends CommonSyntacticValidator implements
 		// Introduce empty StatementInfo
 		// This is later ignored by PyDMLParserWrapper
 		try {
-			ctx.info.stmt = new AssignmentStatement(null, null, 0, 0, 0, 0);
+			ctx.info.stmt = new AssignmentStatement(ctx, null, null);
 			ctx.info.stmt.setEmptyNewLineStatement(true);
 		} catch (LanguageException e) {
 			e.printStackTrace();

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
@@ -30,6 +30,7 @@ import org.apache.sysml.hops.OptimizerUtils;
 import org.apache.sysml.hops.recompile.Recompiler;
 import org.apache.sysml.lops.Lop;
 import org.apache.sysml.parser.Expression.ValueType;
+import org.apache.sysml.parser.ParseInfo;
 import org.apache.sysml.parser.StatementBlock;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.DMLScriptException;
@@ -50,7 +51,7 @@ import org.apache.sysml.utils.Statistics;
 import org.apache.sysml.yarn.DMLAppMasterUtils;
 
 
-public class ProgramBlock
+public class ProgramBlock implements ParseInfo
 {
 	protected static final Log LOG = LogFactory.getLog(ProgramBlock.class.getName());
 	private static final boolean CHECK_MATRIX_SPARSITY = false;
@@ -412,28 +413,43 @@ public class ProgramBlock
 	public String _filename;
 	public int _beginLine, _beginColumn;
 	public int _endLine, _endColumn;
+	public String _text;
 
 	public void setFilename(String passed)    { _filename = passed;   }
 	public void setBeginLine(int passed)    { _beginLine = passed;   }
 	public void setBeginColumn(int passed) 	{ _beginColumn = passed; }
 	public void setEndLine(int passed) 		{ _endLine = passed;   }
 	public void setEndColumn(int passed)	{ _endColumn = passed; }
-
-	public void setAllPositions(String filename, int blp, int bcp, int elp, int ecp){
-		_filename = filename;
-		_beginLine	 = blp;
-		_beginColumn = bcp;
-		_endLine 	 = elp;
-		_endColumn 	 = ecp;
-	}
+	public void setText(String text) { _text = text; }
 
 	public String getFilename()	{ return _filename;   }
 	public int getBeginLine()	{ return _beginLine;   }
 	public int getBeginColumn() { return _beginColumn; }
 	public int getEndLine() 	{ return _endLine;   }
 	public int getEndColumn()	{ return _endColumn; }
+	public String getText() { return _text; }
 
 	public String printBlockErrorLocation(){
 		return "ERROR: Runtime error in program block generated from statement block between lines " + _beginLine + " and " + _endLine + " -- ";
 	}
+
+	/**
+	 * Set parse information.
+	 *
+	 * @param parseInfo
+	 *            parse information, such as beginning line position, beginning
+	 *            column position, ending line position, ending column position,
+	 *            text, and filename
+	 * @param filename
+	 *            the DML/PYDML filename (if it exists)
+	 */
+	public void setParseInfo(ParseInfo parseInfo) {
+		_beginLine = parseInfo.getBeginLine();
+		_beginColumn = parseInfo.getBeginColumn();
+		_endLine = parseInfo.getEndLine();
+		_endColumn = parseInfo.getEndColumn();
+		_text = parseInfo.getText();
+		_filename = parseInfo.getFilename();
+	}
+
 }

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
@@ -551,7 +551,7 @@ public class ProgramConverter
 				//create new statement (shallow copy livein/liveout for recompile, line numbers for explain)
 				ret = new StatementBlock();
 				ret.setDMLProg(sb.getDMLProg());
-				ret.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+				ret.setParseInfo(sb);
 				ret.setLiveIn( sb.liveIn() ); 
 				ret.setLiveOut( sb.liveOut() ); 
 				ret.setUpdatedVariables( sb.variablesUpdated() );
@@ -591,7 +591,7 @@ public class ProgramConverter
 				//create new statement (shallow copy livein/liveout for recompile, line numbers for explain)
 				ret = new IfStatementBlock();
 				ret.setDMLProg(sb.getDMLProg());
-				ret.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+				ret.setParseInfo(sb);
 				ret.setLiveIn( sb.liveIn() );
 				ret.setLiveOut( sb.liveOut() );
 				ret.setUpdatedVariables( sb.variablesUpdated() );
@@ -632,7 +632,7 @@ public class ProgramConverter
 				//create new statement (shallow copy livein/liveout for recompile, line numbers for explain)
 				ret = new WhileStatementBlock();
 				ret.setDMLProg(sb.getDMLProg());
-				ret.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+				ret.setParseInfo(sb);
 				ret.setLiveIn( sb.liveIn() );
 				ret.setLiveOut( sb.liveOut() );
 				ret.setUpdatedVariables( sb.variablesUpdated() );
@@ -678,7 +678,7 @@ public class ProgramConverter
 				
 				//create new statement (shallow copy livein/liveout for recompile, line numbers for explain)
 				ret.setDMLProg(sb.getDMLProg());
-				ret.setAllPositions(sb.getFilename(), sb.getBeginLine(), sb.getBeginColumn(), sb.getEndLine(), sb.getEndColumn());
+				ret.setParseInfo(sb);
 				ret.setLiveIn( sb.liveIn() );
 				ret.setLiveOut( sb.liveOut() );
 				ret.setUpdatedVariables( sb.variablesUpdated() );

--- a/src/test/java/org/apache/sysml/test/integration/functions/misc/OuterTableExpandTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/misc/OuterTableExpandTest.java
@@ -256,7 +256,7 @@ public class OuterTableExpandTest extends AutomatedTestBase
 			
 				//check compiled/executed jobs
 				if( rtplatform == RUNTIME_PLATFORM.HADOOP ) {
-					int expectedNumCompiled = 3; //reblock+gmr+gmr if rexpand; otherwise 3/5 
+					int expectedNumCompiled = 2; //reblock+gmr if rexpand; otherwise 3/5
 					int expectedNumExecuted = expectedNumCompiled; 
 					checkNumCompiledMRJobs(expectedNumCompiled); 
 					checkNumExecutedMRJobs(expectedNumExecuted); 	


### PR DESCRIPTION
Add parsed text from original script into objects such as Statements
and Expressions so that it is available in validation errors.
Improve several validation error messages.