### PR TITLE
[MINOR] Use default namespace constant rather than String literal

### DIFF
--- a/src/main/java/org/apache/sysml/parser/DMLProgram.java
+++ b/src/main/java/org/apache/sysml/parser/DMLProgram.java
@@ -33,8 +33,8 @@ public class DMLProgram
 	private ArrayList<StatementBlock> _blocks;
 	private HashMap<String, FunctionStatementBlock> _functionBlocks;
 	private HashMap<String,DMLProgram> _namespaces;
-	public static String DEFAULT_NAMESPACE = ".defaultNS";
-	public static String INTERNAL_NAMESPACE = "_internal"; // used for multi-return builtin functions
+	public static final String DEFAULT_NAMESPACE = ".defaultNS";
+	public static final String INTERNAL_NAMESPACE = "_internal"; // used for multi-return builtin functions
 	private static final Log LOG = LogFactory.getLog(DMLProgram.class.getName());
 	
 	public DMLProgram(){

--- a/src/main/java/org/apache/sysml/parser/FunctionCallIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/FunctionCallIdentifier.java
@@ -168,8 +168,8 @@ public class FunctionCallIdentifier extends DataIdentifier
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		if (_namespace != null && _namespace.length() > 0 && !_namespace.equals(".defaultNS")) 
-			sb.append(_namespace + "::"); 
+		if (_namespace != null && _namespace.length() > 0 && !_namespace.equals(DMLProgram.DEFAULT_NAMESPACE))
+			sb.append(_namespace + "::");
 		sb.append(_name);
 		sb.append(" ( ");		
 				


### PR DESCRIPTION
Make DMLProgram's DEFAULT_NAMESPACE and INTERNAL_NAMESPACE final.
Use DEFAULT_NAMESPACE rather than String literal in FunctionCallIdentifier.