### PR TITLE
[SYSTEMML-1444][WIP] Language changes/tests for UDFs in expressions (part 2)

### DIFF
--- a/src/main/java/org/apache/sysml/hops/FunctionOp.java
+++ b/src/main/java/org/apache/sysml/hops/FunctionOp.java
@@ -227,7 +227,7 @@ public class FunctionOp extends Hop
 		}
 	}
 	
-	@Override
+	//@Override
 	protected long[] inferOutputCharacteristics( MemoTable memo )
 	{
 		long[] ret = null;
@@ -322,7 +322,7 @@ public class FunctionOp extends Hop
 		return _etype;
 	}
 
-	@Override
+	//@Override
 	public void refreshSizeInformation()
 	{
 		//only for refreshing the size of single output

--- a/src/main/java/org/apache/sysml/hops/ipa/IPAPassFlagDimensionPreserveFunctionOp.java
+++ b/src/main/java/org/apache/sysml/hops/ipa/IPAPassFlagDimensionPreserveFunctionOp.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.hops.ipa;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Map.Entry;
+
+import org.apache.sysml.conf.ConfigurationManager;
+import org.apache.sysml.hops.FunctionOp;
+import org.apache.sysml.hops.HopsException;
+import org.apache.sysml.lops.FunctionCallCPSingle;
+import org.apache.sysml.parser.DMLProgram;
+import org.apache.sysml.parser.FunctionStatementBlock;
+import org.apache.sysml.parser.LanguageException;
+import org.apache.sysml.parser.StatementBlock;
+
+/**
+ * A rewrite to split DAGs after FunctionOps that return matrices/frames
+ * and are not dimension-preserving.
+ *
+ */
+public class IPAPassFlagDimensionPreserveFunctionOp extends IPAPass {
+    @Override
+    public boolean isApplicable() {
+        return InterProceduralAnalysis.DIMENSION_PRESERVE_FUNCTIONOP;
+    }
+
+    @Override
+    public void rewriteProgram( DMLProgram prog, FunctionCallGraph fgraph, FunctionCallSizeInfo fcallSizes )
+            throws HopsException
+    {
+        if( !ConfigurationManager.isDynamicRecompilation() )
+            return;
+
+        try {
+            for( String fkey : fgraph.getReachableFunctions() ) {
+                FunctionOp first = fgraph.getFunctionCalls(fkey).get(0);
+
+                //allow size propagation over FunctionOps during dynamic recompilation
+                //TODO: find out how to propagate the size.
+                FunctionStatementBlock fsblock = prog.getFunctionStatementBlocks(namespaceKey, fname);
+                if( !fgraph.isRecursiveFunction(namespaceKey, fname) &&
+                        rFlagDimensionPreserveFunctionOp(fsblock)) {
+                    fsblock.setSplitDag(true);
+                    if( LOG.isDebugEnabled() )
+                        LOG.debug("IPA: FUNC flagged for hop dag-split:" +
+                            DMLProgram.constructFunctionKey(namespaceKey, fname));
+                }
+
+            }
+        }
+        catch( LanguageException ex ) {
+            throw new HopsException(ex);
+        }
+    }
+
+    /**
+     * Return true if this statement block requires recompilation.
+     *
+     * @param sb statement block
+     * @return true if statement block requires recompilation
+     */
+    public boolean rFlagDimensionPreserveFunctionOp(StatementBlock sb ) {
+        boolean ret = false;
+
+        if (sb instanceof FunctionCallCPSingle) {
+            //do something
+        }
+        else {
+            ret |= ( sb.requiresRecompilation() );
+        }
+
+        return ret;
+    }
+
+}

--- a/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/ProgramRewriter.java
@@ -110,9 +110,11 @@ public class ProgramRewriter
 				_sbRuleSet.add(  new RewriteRemoveUnnecessaryBranches()          ); //dependency: constant folding		
 				_sbRuleSet.add(  new RewriteMergeBlockSequence()                 ); //dependency: remove branches
  			}
- 			if( OptimizerUtils.ALLOW_SPLIT_HOP_DAGS )
+ 			if( OptimizerUtils.ALLOW_SPLIT_HOP_DAGS ) {
  				_sbRuleSet.add(  new RewriteSplitDagUnknownCSVRead()             ); //dependency: reblock, merge blocks	
- 			if( ConfigurationManager.getCompilerConfigFlag(ConfigType.ALLOW_INDIVIDUAL_SB_SPECIFIC_OPS) )
+ 			        _sbRuleSet.add(new RewriteSplitDagFunctionOp()                   ); //dependency: ...
+			}	
+			if( ConfigurationManager.getCompilerConfigFlag(ConfigType.ALLOW_INDIVIDUAL_SB_SPECIFIC_OPS) )
  				_sbRuleSet.add(  new RewriteSplitDagDataDependentOperators()     ); //dependency: merge blocks
  			if( OptimizerUtils.ALLOW_AUTO_VECTORIZATION )
 				_sbRuleSet.add(  new RewriteForLoopVectorization()               ); //dependency: reblock (reblockop)

--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteSplitDagFunctionOp.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteSplitDagFunctionOp.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.hops.rewrite;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import org.apache.sysml.api.DMLScript;
+import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
+import org.apache.sysml.conf.ConfigurationManager;
+import org.apache.sysml.hops.*;
+import org.apache.sysml.hops.recompile.Recompiler;
+import org.apache.sysml.parser.DataIdentifier;
+import org.apache.sysml.parser.StatementBlock;
+import org.apache.sysml.parser.VariableSet;
+import org.apache.sysml.runtime.controlprogram.caching.MatrixObject.UpdateType;
+import org.apache.sysml.runtime.controlprogram.parfor.util.IDSequence;
+import org.apache.sysml.runtime.matrix.data.Pair;
+
+/**
+ * Rule: rewrite to split DAGs after FunctionOps that return matrices/frames
+ * and are not dimension-preserving. This is important to create recompile
+ * hooks if output dimensions are usually significantly overestimated.
+ *
+ * This is a recursive statementblock rewrite rule.
+ */
+
+public class RewriteSplitDagFunctionOp extends StatementBlockRewriteRule {
+
+    private static String _var = "_abc";
+    private static IDSequence _seq = new IDSequence();
+
+    @Override
+    public List<StatementBlock> rewriteStatementBlock(StatementBlock sb, ProgramRewriteStatus state)
+            throws HopsException {
+        //DAG splits not required for forced single node
+        if (DMLScript.rtplatform == RUNTIME_PLATFORM.SINGLE_NODE)
+            return new ArrayList<StatementBlock>(Arrays.asList(sb));
+
+        ArrayList<StatementBlock> ret = new ArrayList<StatementBlock>();
+
+        //collect all unknown csv reads hops
+        ArrayList<Hop> cand = new ArrayList<Hop>();
+        collectFunctionOp(sb.get_hops(), cand);
+        Hop.resetVisitStatus(sb.get_hops());
+
+        //split hop dag on demand
+        if (!cand.isEmpty()) {
+            //collect child operators of candindates (to prevent rewrite anomalies)
+            HashSet<Hop> candChilds = new HashSet<Hop>();
+            collectCandidateChildFunctionOp(cand, candChilds);
+
+            try {
+                //duplicate sb incl live variable sets
+                StatementBlock sb1 = new StatementBlock();
+                sb1.setDMLProg(sb.getDMLProg());
+                sb1.setParseInfo(sb);
+                sb1.setLiveIn(new VariableSet());
+                sb1.setLiveOut(new VariableSet());
+
+                //move data-dependent ops incl transient writes to new statement block
+                //(and replace original persistent read with transient read)
+                ArrayList<Hop> sb1hops = new ArrayList<Hop>();
+                for (Hop c : cand) {
+                    //if there are already transient writes use them
+                    boolean hasTWrites = hasTransientWriteParents(c);
+                    boolean moveTWrite = hasTWrites ? HopRewriteUtils.rHasSimpleReadChain(c,
+                            getFirstTransientWriteParent(c).getName()) : false;
+
+                    String varname = null;
+                    long rlen = c.getDim1();
+                    long clen = c.getDim2();
+                    long nnz = c.getNnz();
+                    UpdateType update = c.getUpdateType();
+                    long brlen = c.getRowsInBlock();
+                    long bclen = c.getColsInBlock();
+
+                    //update live in and out of new statement block (for piggybacking)
+                    DataIdentifier diVar = new DataIdentifier(varname);
+                    diVar.setDimensions(rlen, clen);
+                    diVar.setBlockDimensions(brlen, bclen);
+                    diVar.setDataType(c.getDataType());
+                    diVar.setValueType(c.getValueType());
+                    sb1.liveOut().addVariable(varname, new DataIdentifier(diVar));
+                    sb1.liveIn().addVariable(varname, new DataIdentifier(diVar));
+
+                    //ensure disjoint operators across DAGs (prevent replicated operations)
+                    handleReplicationOperators(sb1hops, sb.get_hops(), sb1.liveOut(), sb.liveIn());
+
+                    //deep copy new dag (in order to prevent any dangling references)
+                    sb1.set_hops(Recompiler.deepCopyHopsDag(sb1hops));
+                    sb1.updateRecompilationFlag();
+                    sb1.setSplitDag(true); //avoid later merge by other rewrites
+
+                    //recursive application of rewrite rule
+                    List<StatementBlock> tmp = rewirteStatementBlock(sb1, state);
+
+                    //add new statement blocks to output
+                    ret.addAll(tmp); //statement block with FunctionOp related
+                    ret.add(sb); //statement block with remaining hops
+                    sb.setSplitDag(true); //avoid later merge by rewrites
+                }
+            } catch (Exception ex) {
+                throw new HopsException("Failed to split hops dag for data dependent operators with unknown size.", ex);
+            }
+
+            LOG.debug("Applied splitDagDataDependentOperators (lines " + sb.getBeginLine() + "-" + sb.getEndLine() + ").");
+        }
+        //keep original hop dag
+        else
+        {
+            ret.add(sb);
+        }
+
+        return ret;
+    }
+
+    private void collectFunctionOp( ArrayList<Hop> roots, ArrayList<Hop> cand )
+    {
+        if( roots == null )
+            return;
+
+        Hop.resetVisitStatus(roots);
+        for( Hop root : roots )
+            rCollectFunctionOp(root, cand);
+    }
+
+    @Override
+    private void rCollectFunctionOp( Hop hop, ArrayList<Hop> cand )
+    {
+        if( hop.isVisited() )
+            return;
+
+        //prevent unnecessary dag split (dims known or no consumer operations
+        boolean noSplitRequired = ( hop.dimsKnown() || HopRewriteUtils.hasOnlyWriteParents(hop, true, true));
+        boolean investigateChilds = true;
+
+        //collect function operators(FunctionOp)
+        //#1 removeEmpty
+        if(   hop instanceof FunctionOp )
+        {
+            FunctionOp fop = (FunctionOp)hop;
+            cand.add(fop);
+            investigaeChilds = false;
+
+            //keep interesting consumer information, flag hop accordingly
+            boolean noEmpltyBlocks = true;
+            boolean onlyPMM        = true;
+            boolean diagInput      = fop.isTargetDiagInput();
+            //for( Hop p : hop.getParent() ) {
+            //list of operations without the need for empty blocks to be extended as needed.
+
+            //}
+
+            fop.setOutputEmptyBlocks(!noEmptyBlocks);
+
+            if( onlyPMM && diagInput ) {
+                //configure rmEmpty to directly output selection vector
+                //(only applied if dynamic recompilation enabled)
+
+                if(ConfigurationManager.isDynamicRecompilation() )
+                    fop.setOutputPermutationMatrix(true);
+                for( Hop p: hop.getParent() )
+                    ((FunctionOp)p).setHasLeftPMInput(true);
+            }
+        }
+    }
+
+    private void hasTrasientWriteParents( Hop hop )
+    {
+        for( Hop p : hop.getParent() )
+            if( p instanceof FunctionOp )
+                return true;
+        return false;
+    }
+
+    private Hop getFirstTransientWriteParent( Hop hop )
+    {
+        for( Hop p : hop.getParent() )
+            if( p instanceof FunctionOp )
+                return p;
+        return null;
+    }
+
+    private void handleReplicatedOperators( ArrayList<Hop> rootsSB1, ArrayList<Hop> rootsSB2, VariableSet sb1out, VariableSet sb2in )
+    {
+        //step 1: create probe set SB1
+        HashSet<Hop> probeSet = new HashSet<Hop>();
+        Hop.restVisitStatus(rootsSB1);
+        for( Hop h : rootsSB1 )
+            rAddHopsToProbSet( h, probeSet );
+
+        //step 2: probe SB2 operators top-down (collect cut candidates)
+        HashSet<Pair<Hop,Hop>> candSet = new HashSet<Pair<Hop,Hop>>();
+        Hop.resetVisitStatus(rootsSB2);
+        for( Hop h : rootsSB2 )
+            rProbeAndAddHopsToCandidateSet(h, probeSet, candSet);
+
+        //step 3: create additional cuts
+        for( Pair<Hop,Hop> p : candSet )
+        {
+            String varname = _var + _seq.getNextID();
+
+            Hop hop = p.getKey();
+            Hop c   = p.getValue();
+
+            FunctionOp tread = new FunctionOp();
+            tread.setVisited();
+            HopRewriteUtils.copyLineNumbers(c, tread);
+
+            //create additional cut by rewriting both hop dags
+            int pos = HopRewriteUtils.getChildReferencePos(hop, c);
+            HopRewriteUtils.removeChildReferenceByPos(hop, c, pos);
+            HopRewriteUtils.addChildReference(hop, tread, pos);
+
+            //update live in and out of new statement block (for piggybacking)
+            DataIdentifier diVar = new DataIdentifier(varname);
+            diVar.setDimensions(c.getDim1(), c.getDim2());
+            diVar.setBlockDimensions(c.getRowsInBlock(), c.getColsInBlock());
+            diVar.setDataType(c.getDataType());
+            diVar.setValueType(c.getValueType());
+            sb1out.addVariable(varname, new DataIdentifier(diVar));
+            sb2in.addVariable(varname, new DataIdentifier(diVar));
+
+            rootsSB1.add(twrite);
+        }
+    }
+
+    private void rAddHopsToProbeSet(Hop hop, HashSet<Hop> probeSet )
+    {
+        if( hop.isVisited() )
+            return;
+
+        //prevent cuts for no-ops
+        if( !( hop instanceof FunctionOp))
+        {
+            probeSet.add(hop);
+        }
+
+        if( hop.getInput() != null )
+            for( Hop c : hop.getInput() )
+                rAddHopsToProbeSet(c, probeSet);
+
+        hop.setVisited();
+    }
+
+    /**
+     * NOTE: candset is a set of parent-child pairs because a parent might have
+     * multiple references to replicated hops.
+     *
+     * @param hop high-level operator
+     * @param probeSet probe set?
+     * @param candSet candidate set?
+     */
+    private void rProbeAndAddHopsToCandidateSet( Hop hop, HashSet<Hop> probeSet, HashSet<Pair<Hop,Hop>> candSet ) {
+        if (hop.isVisited())
+            return;
+
+        if (hop.getInput() != null)
+            for (Hop c : hop.getInput()) {
+                //probe for replicated operator, if any child is replicated, keep parent
+                //for cut between parent-child; otherwise recursively descend.
+                if (!probeSet.contains(c))
+                    rProbeAndAddHopsToCandidateSet(c, probeSet, candSet);
+                else {
+                    candSet.add(new Pair<Hop, Hop>(hop, c));
+                }
+
+            }
+
+        hop.setVisited();
+    }
+
+
+    private void collectCandidateChildOperators( ArrayList<Hop> cand, HashSet<Hop> candChilds )
+    {
+        Hop.resetVisitStatus(cand);
+        if( cand != null )
+            for( Hop root : cand )
+                rCollectCandidateChildOperators(root, cand, candChilds, false);
+
+        // Immediately reset teh visit status because candidates might be inner nodes in the DAG.
+        // Subsequent resets on the root nodes of the DAG would otherwise not necessarily reach
+        // these nodes which could lead to missing checks on subsequent passes (e.g. when checking
+        // for replicated operators);
+        Hop.resetVisitStatus(cand);
+    }
+
+    private void rCollectCandidateChildOperators( Hop hop, ArrayList<Hop> cand, HashSet<Hop> candChilds, boolean collect )
+    {
+        if( hop.isVisited() )
+            return;
+
+        //collect operator if necessary
+        if( collect ) {
+            candChilds.add(hop);
+        }
+
+        //activate collection if we passed a candidate
+        boolean passedFlag = collect;
+        if( cand.contains(hop) ) {
+            passedFlag = true;
+        }
+
+        //process childs recursively
+        if( hop.getInput() != null ) {
+            for( Hop c: hop.getInput() )
+                rCollectCandidateChildOperators(c, cand, candChilds, passedFlag);
+        }
+
+        hop.setVisited();
+    }
+
+    @Override
+    public List<StatementBlock> rewriteStatementBlocks(List<StatementBlock> sbs,
+                                                       ProgramRewriteStatus state) throws HopsException {
+        return sbs;
+    }
+
+}

--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -1427,8 +1427,8 @@ public class DMLTranslator
 						new FunctionOp(ftype, fci.getNamespace(), fci.getName(), finputs, new String[]{target.getName()}, false);
 					output.add(fcall);
 					
-					DataOp trFoutput = new DataOp(target.getName(), target.getDataType(), target.getValueType(), fcall, DataOpTypes.FUNCTIONOUTPUT, null);
-					DataOp twFoutput = new DataOp(target.getName(), target.getDataType(), target.getValueType(), trFoutput, DataOpTypes.TRANSIENTWRITE, null);					
+					//DataOp trFoutput = new DataOp(target.getName(), target.getDataType(), target.getValueType(), fcall, DataOpTypes.FUNCTIONOUTPUT, null);
+					//DataOp twFoutput = new DataOp(target.getName(), target.getDataType(), target.getValueType(), trFoutput, DataOpTypes.TRANSIENTWRITE, null);					
 				}
 			}
 
@@ -1463,10 +1463,10 @@ public class DMLTranslator
 					FunctionOp fcall = new FunctionOp(ftype, fci.getNamespace(), fci.getName(), finputs, foutputs, false);
 					output.add(fcall);
 
-					for ( DataIdentifier paramName : mas.getTargetList() ){
+				     	/*for ( DataIdentifier paramName : mas.getTargetList() ){
 						DataOp twFoutput = new DataOp(paramName.getName(), paramName.getDataType(), paramName.getValueType(), fcall, DataOpTypes.TRANSIENTWRITE, null);
 						output.add(twFoutput);
-					}
+					} */
 				}
 				else if ( source instanceof BuiltinFunctionExpression && ((BuiltinFunctionExpression)source).multipleReturns() ) {
 					// construct input hops

--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -1427,9 +1427,8 @@ public class DMLTranslator
 						new FunctionOp(ftype, fci.getNamespace(), fci.getName(), finputs, new String[]{target.getName()}, false);
 					output.add(fcall);
 					
-					//TODO function output dataops (phase 3)
-					//DataOp trFoutput = new DataOp(target.getName(), target.getDataType(), target.getValueType(), fcall, DataOpTypes.FUNCTIONOUTPUT, null);
-					//DataOp twFoutput = new DataOp(target.getName(), target.getDataType(), target.getValueType(), trFoutput, DataOpTypes.TRANSIENTWRITE, null);					
+					DataOp trFoutput = new DataOp(target.getName(), target.getDataType(), target.getValueType(), fcall, DataOpTypes.FUNCTIONOUTPUT, null);
+					DataOp twFoutput = new DataOp(target.getName(), target.getDataType(), target.getValueType(), trFoutput, DataOpTypes.TRANSIENTWRITE, null);					
 				}
 			}
 
@@ -1463,12 +1462,11 @@ public class DMLTranslator
 					FunctionType ftype = fsb.getFunctionOpType();
 					FunctionOp fcall = new FunctionOp(ftype, fci.getNamespace(), fci.getName(), finputs, foutputs, false);
 					output.add(fcall);
-					
-					//TODO function output dataops (phase 3)
-					/*for ( DataIdentifier paramName : mas.getTargetList() ){
+
+					for ( DataIdentifier paramName : mas.getTargetList() ){
 						DataOp twFoutput = new DataOp(paramName.getName(), paramName.getDataType(), paramName.getValueType(), fcall, DataOpTypes.TRANSIENTWRITE, null);
 						output.add(twFoutput);
-					}*/
+					}
 				}
 				else if ( source instanceof BuiltinFunctionExpression && ((BuiltinFunctionExpression)source).multipleReturns() ) {
 					// construct input hops

--- a/src/main/java/org/apache/sysml/parser/FunctionCallIdentifier.java
+++ b/src/main/java/org/apache/sysml/parser/FunctionCallIdentifier.java
@@ -22,6 +22,7 @@ package org.apache.sysml.parser;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.io.IOException;
+import org.apache.sysml.hops.FunctionOp;
 
 
 public class FunctionCallIdentifier extends DataIdentifier 
@@ -64,7 +65,8 @@ public class FunctionCallIdentifier extends DataIdentifier
 			
 		fci._name = this._name;
 		fci._namespace = this._namespace;
-		fci._opcode = this._opcode;	 
+		fci._opcode = this._opcode;
+		FunctionOp.refreshSizeInformation;
 		
 		return fci;
 	}
@@ -199,5 +201,3 @@ public class FunctionCallIdentifier extends DataIdentifier
 		return true;
 	}
 }
-
-

--- a/src/test/java/org/apache/sysml/test/integration/functions/external/FunInExpressionsTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/external/FunInExpressionsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.test.integration.functions.external;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.sysml.runtime.matrix.data.InputInfo;
+import org.apache.sysml.runtime.util.MapReduceTool;
+import org.apache.sysml.test.integration.AutomatedTestBase;
+import org.apache.sysml.test.integration.TestConfiguration;
+import org.apache.sysml.utils.Statistics;
+
+public class FunctionExpressionsTest extends AutomatedTestBase 
+{
+	
+	private final static String TEST_NAME1 = "FunctionExpressions1";
+	private final static String TEST_NAME2 = "FunctionExpressions2";
+	private final static String TEST_DIR = "functions/external/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionExpressionsTest.class.getSimpleName() + "/";
+	private final static double eps = 1e-10;
+	
+	private final static int rows = 12;
+	private final static int cols = 11;    
+	private final static double sparsity = 0.7;
+	
+	
+	@Override
+	public void setUp() 
+	{
+		addTestConfiguration(TEST_NAME1,
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "Y" }) );
+		addTestConfiguration(TEST_NAME2,
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "Y" }) ); 
+	}
+
+	
+	@Test
+	public void testDMLFunction() 
+	{
+		runFunctionExpressionsTest( TEST_NAME1 );
+	}
+	
+	@Test
+	public void testExternalFunction() 
+	{
+		runFunctionExpressionsTest( TEST_NAME2 );
+	}
+
+	private void runFunctionExpressionsTest( String TEST_NAME )
+	{		
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		config.addVariable("rows", rows);
+		config.addVariable("cols", cols);
+		loadTestConfiguration(config);
+		
+		/* This is for running the junit test the new way, i.e., construct the arguments directly */
+		String HOME = SCRIPT_DIR + TEST_DIR;
+		fullDMLScriptName = HOME + TEST_NAME + ".dml";
+		programArgs = new String[]{"-args", input("X"),
+			Integer.toString(rows), Integer.toString(cols), output("Y") };
+
+		try 
+		{
+			long seed = System.nanoTime();
+	        double[][] X = getRandomMatrix(rows, cols, 0, 1, sparsity, seed);
+			writeInputMatrix("X", X, false);
+
+			runTest(true, false, null, -1);
+
+			double[][] Y = MapReduceTool.readMatrixFromHDFS(output("Y"), InputInfo.TextCellInputInfo, rows, cols, 1000, 1000);
+		
+			double sx = sum(X,rows,cols);
+			double sy = sum(Y,rows,cols);
+			Assert.assertEquals(sx, sy, eps);
+			
+			Assert.assertEquals("Unexpected number of executed MR jobs.", 
+					             0, Statistics.getNoOfExecutedMRJobs());
+		} 
+		catch (Exception e) 
+		{
+			e.printStackTrace();
+		}
+	}
+	
+	private static double sum( double[][] X, int rows, int cols )
+	{
+		double sum = 0;
+		for( int i=0; i<rows; i++ )
+			for( int j=0; j<cols; j++ )
+				sum += X[i][j];
+		return sum;
+	}
+}

--- a/src/test/java/org/apache/sysml/test/integration/functions/external/FunInExpressionsTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/external/FunInExpressionsTest.java
@@ -28,13 +28,13 @@ import org.apache.sysml.test.integration.AutomatedTestBase;
 import org.apache.sysml.test.integration.TestConfiguration;
 import org.apache.sysml.utils.Statistics;
 
-public class FunctionExpressionsTest extends AutomatedTestBase 
+public class FunInExpressionsTest extends AutomatedTestBase 
 {
 	
-	private final static String TEST_NAME1 = "FunctionExpressions1";
-	private final static String TEST_NAME2 = "FunctionExpressions2";
+	private final static String TEST_NAME1 = "FunInExpressions1";
+	private final static String TEST_NAME2 = "FunInExpressions2";
 	private final static String TEST_DIR = "functions/external/";
-	private final static String TEST_CLASS_DIR = TEST_DIR + FunctionExpressionsTest.class.getSimpleName() + "/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + FunInExpressionsTest.class.getSimpleName() + "/";
 	private final static double eps = 1e-10;
 	
 	private final static int rows = 12;
@@ -55,16 +55,16 @@ public class FunctionExpressionsTest extends AutomatedTestBase
 	@Test
 	public void testDMLFunction() 
 	{
-		runFunctionExpressionsTest( TEST_NAME1 );
+		runFunInExpressionsTest( TEST_NAME1 );
 	}
 	
 	@Test
 	public void testExternalFunction() 
 	{
-		runFunctionExpressionsTest( TEST_NAME2 );
+		runFunInExpressionsTest( TEST_NAME2 );
 	}
 
-	private void runFunctionExpressionsTest( String TEST_NAME )
+	private void runFunInExpressionsTest( String TEST_NAME )
 	{		
 		TestConfiguration config = getTestConfiguration(TEST_NAME);
 		config.addVariable("rows", rows);

--- a/src/test/scripts/functions/external/FunInExpressions1.dml
+++ b/src/test/scripts/functions/external/FunInExpressions1.dml
@@ -26,10 +26,10 @@ orderExternal = externalFunction(Matrix[Double] A, Integer col, Boolean desc) re
 foo = function( Matrix[Double] A ) return (Matrix[Double] B)  
 {
    for( i in 1:ncol(A) ) {
-      B = orderExternal(A, i, TRUE) * orderExternal(A, i, TRUE) + 7;
+      B = orderExternal(A, i, TRUE);
    }
 }
  
 X = read( $1, rows=$2, cols=$3 );
-Y = sqrt( foo( X ) -7 );
+Y = sqrt( foo( X*X + 7) - 7);
 write( Y, $4 ); #ordered input

--- a/src/test/scripts/functions/external/FunInExpressions1.dml
+++ b/src/test/scripts/functions/external/FunInExpressions1.dml
@@ -1,0 +1,36 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+orderExternal = externalFunction(Matrix[Double] A, Integer col, Boolean desc) return (Matrix[Double] B) 
+			    implemented in (classname="org.apache.sysml.udf.lib.OrderWrapper",exectype="mem")
+
+foo = function( Matrix[Double] A ) return (Matrix[Double] B)  
+{
+   for( i in 1:ncol(A) ) {
+      B = orderExternal(A, i, TRUE);
+   }
+}
+ 
+X = read( $1, rows=$2, cols=$3 );
+Y = foo( X*X+7 );
+Y = sqrt( Y-7 );
+write( Y, $4 ); #ordered input

--- a/src/test/scripts/functions/external/FunInExpressions1.dml
+++ b/src/test/scripts/functions/external/FunInExpressions1.dml
@@ -26,11 +26,10 @@ orderExternal = externalFunction(Matrix[Double] A, Integer col, Boolean desc) re
 foo = function( Matrix[Double] A ) return (Matrix[Double] B)  
 {
    for( i in 1:ncol(A) ) {
-      B = orderExternal(A, i, TRUE);
+      B = orderExternal(A, i, TRUE) * orderExternal(A, i, TRUE) + 7;
    }
 }
  
 X = read( $1, rows=$2, cols=$3 );
-Y = foo( X*X+7 );
-Y = sqrt( Y-7 );
+Y = sqrt( foo( X ) -7 );
 write( Y, $4 ); #ordered input

--- a/src/test/scripts/functions/external/FunInExpressions2.dml
+++ b/src/test/scripts/functions/external/FunInExpressions2.dml
@@ -26,11 +26,12 @@ orderExternal = externalFunction(Matrix[Double] A, Integer col, Boolean desc) re
 foo = function( Matrix[Double] A ) return (Matrix[Double] B)  
 {
    for( i in 1:ncol(A) ) {
-      B = orderExternal(A*A+7, i, TRUE);
+      B = orderExternal(A, i, TRUE) * orderExternal(A, i, TRUE) + 7;
    }
 }
  
 X = read( $1, rows=$2, cols=$3 );
-Y = foo( X );
-Y = sqrt( Y-7 );
+Y = sqrt( foo( X ) -7 );
+# Y = foo( X );
+# Y = sqrt( Y-7 );
 write( Y, $4 ); #ordered input

--- a/src/test/scripts/functions/external/FunInExpressions2.dml
+++ b/src/test/scripts/functions/external/FunInExpressions2.dml
@@ -1,0 +1,36 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+orderExternal = externalFunction(Matrix[Double] A, Integer col, Boolean desc) return (Matrix[Double] B) 
+			    implemented in (classname="org.apache.sysml.udf.lib.OrderWrapper",exectype="mem")
+
+foo = function( Matrix[Double] A ) return (Matrix[Double] B)  
+{
+   for( i in 1:ncol(A) ) {
+      B = orderExternal(A*A+7, i, TRUE);
+   }
+}
+ 
+X = read( $1, rows=$2, cols=$3 );
+Y = foo( X );
+Y = sqrt( Y-7 );
+write( Y, $4 ); #ordered input


### PR DESCRIPTION
Part 2:
- [ ] According to the change of HOP and LOPs, construct differently configured HOPs for single-output functions at language level (i.e., `DMLTranslator`).
- [ ] changes of validation.
- [x] Tests for functions in expressions.

Part 3:
- [x] flag dimension-preserving `FunctionOp`s during `InterProceduralAnalysis`
- [x] accordingly, modify `FunctionOp.refreshSizeInformation` and `FunctionOp.inferOutputCharacteristics` to allow size propagation over FunctionOps during dynamic recompilation
- [x] introduce a rewrite to split DAGs after FunctionOps that return matrices/frames and are not dimension-preserving (like in `RewriteSplitDagDataDependentOperators` )