### PR TITLE
[SYSTEMML-1873] Update instruction constructor scopes to reflect use

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/AggregateBinaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/AggregateBinaryCPInstruction.java
@@ -32,10 +32,10 @@ import org.apache.sysml.runtime.matrix.operators.AggregateBinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class AggregateBinaryCPInstruction extends BinaryCPInstruction
-{
-	
-	public AggregateBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr ){
+public class AggregateBinaryCPInstruction extends BinaryCPInstruction {
+
+	private AggregateBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.AggregateBinary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/AggregateTernaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/AggregateTernaryCPInstruction.java
@@ -26,11 +26,10 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.AggregateTernaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class AggregateTernaryCPInstruction extends ComputationCPInstruction
-{	
-	public AggregateTernaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, 
-		CPOperand in3, CPOperand out, String opcode, String istr  )
-	{
+public class AggregateTernaryCPInstruction extends ComputationCPInstruction {
+
+	private AggregateTernaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.AggregateTernary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/AggregateUnaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/AggregateUnaryCPInstruction.java
@@ -35,18 +35,18 @@ import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 
-public class AggregateUnaryCPInstruction extends UnaryCPInstruction
-{
-	
-	public AggregateUnaryCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr){
+public class AggregateUnaryCPInstruction extends UnaryCPInstruction {
+
+	private AggregateUnaryCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		this(op, in, null, null, out, opcode, istr);
 	}
-	
-	public AggregateUnaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, String opcode, String istr){
+
+	protected AggregateUnaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
-		_cptype = CPINSTRUCTION_TYPE.AggregateUnary;		
+		_cptype = CPINSTRUCTION_TYPE.AggregateUnary;
 	}
-	
+
 	public static AggregateUnaryCPInstruction parseInstruction(String str)
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/AppendCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/AppendCPInstruction.java
@@ -37,12 +37,12 @@ public abstract class AppendCPInstruction extends BinaryCPInstruction
 
 	//type (matrix cbind / scalar string concatenation)
 	protected AppendType _type;
-	
-	public AppendCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, AppendType type, String opcode, String istr)
-	{
+
+	protected AppendCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			AppendType type, String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.Append;
-		
+
 		_type = type;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ArithmeticBinaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ArithmeticBinaryCPInstruction.java
@@ -26,13 +26,14 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
 
-public abstract class ArithmeticBinaryCPInstruction extends BinaryCPInstruction 
-{		
-	public ArithmeticBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
+public abstract class ArithmeticBinaryCPInstruction extends BinaryCPInstruction {
+
+	protected ArithmeticBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.ArithmeticBinary;
 	}
-	
+
 	public static ArithmeticBinaryCPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/BinaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/BinaryCPInstruction.java
@@ -24,17 +24,15 @@ import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public abstract class BinaryCPInstruction extends ComputationCPInstruction {
 
-public abstract class BinaryCPInstruction extends ComputationCPInstruction
-{
-	
-	public BinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, 
-			String opcode, String istr ){
+	protected BinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
 
-	public BinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, 
-			String opcode, String istr ){
+	protected BinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/BooleanBinaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/BooleanBinaryCPInstruction.java
@@ -27,16 +27,14 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class BooleanBinaryCPInstruction extends BinaryCPInstruction {
 
-public class BooleanBinaryCPInstruction extends BinaryCPInstruction 
-{
-	
-	public BooleanBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr )
-	{
+	private BooleanBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.BooleanBinary;
 	}
-	
+
 	public static BooleanBinaryCPInstruction parseInstruction (String str) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/BooleanUnaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/BooleanUnaryCPInstruction.java
@@ -26,12 +26,9 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 
+public class BooleanUnaryCPInstruction extends UnaryCPInstruction {
 
-public class BooleanUnaryCPInstruction extends UnaryCPInstruction
-{
-	
-	public BooleanUnaryCPInstruction(Operator op, CPOperand in, CPOperand out,
-			String opcode, String instr){
+	private BooleanUnaryCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr) {
 		super(op, in, out, opcode, instr);
 		_cptype = CPINSTRUCTION_TYPE.BooleanUnary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/BuiltinBinaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/BuiltinBinaryCPInstruction.java
@@ -28,12 +28,11 @@ import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.RightScalarOperator;
 
-
-public abstract class BuiltinBinaryCPInstruction extends BinaryCPInstruction 
-{
+public abstract class BuiltinBinaryCPInstruction extends BinaryCPInstruction {
 	private int _arity;
-	
-	public BuiltinBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, int arity, String opcode, String istr) {
+
+	protected BuiltinBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, int arity,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.BuiltinBinary;
 		_arity = arity;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/BuiltinMultipleCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/BuiltinMultipleCPInstruction.java
@@ -43,8 +43,7 @@ public abstract class BuiltinMultipleCPInstruction extends CPInstruction {
 	public CPOperand output;
 	public CPOperand[] inputs;
 
-	public BuiltinMultipleCPInstruction(Operator op, String opcode, String istr, CPOperand output,
-			CPOperand... inputs) {
+	BuiltinMultipleCPInstruction(Operator op, String opcode, String istr, CPOperand output, CPOperand... inputs) {
 		super(op, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.BuiltinMultiple;
 		this.output = output;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/BuiltinUnaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/BuiltinUnaryCPInstruction.java
@@ -31,14 +31,12 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
+public abstract class BuiltinUnaryCPInstruction extends UnaryCPInstruction {
 
-public abstract class BuiltinUnaryCPInstruction extends UnaryCPInstruction 
-{
-	
 	int arity;
-	
-	public BuiltinUnaryCPInstruction(Operator op, CPOperand in, CPOperand out, int _arity, String opcode, String istr )
-	{
+
+	protected BuiltinUnaryCPInstruction(Operator op, CPOperand in, CPOperand out, int _arity, String opcode,
+			String istr) {
 		super(op, in, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.BuiltinUnary;
 		arity = _arity;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/CPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/CPInstruction.java
@@ -57,21 +57,21 @@ public abstract class CPInstruction extends Instruction
 	// SystemML committers have to be judicious about adding them by weighing the tradeoffs between reuse in future analysis and unnecessary overheads.
 	public final static String MISC_TIMER_CSR_LIX_COPY =				"csrlix";// time spent in CSR-specific method to address performance issues due to repeated re-shifting on update-in-place.
 	public final static String MISC_TIMER_LIX_COPY =					"lixcp";// time spent in range copy
-	
-	public CPInstruction(String opcode, String istr) {
+
+	protected CPInstruction(String opcode, String istr) {
 		type = INSTRUCTION_TYPE.CONTROL_PROGRAM;
 		instString = istr;
-		
-		//prepare opcode and update requirement for repeated usage
+
+		// prepare opcode and update requirement for repeated usage
 		instOpcode = opcode;
 		_requiresLabelUpdate = super.requiresLabelUpdate();
 	}
-	
-	public CPInstruction(Operator op, String opcode, String istr) {
+
+	protected CPInstruction(Operator op, String opcode, String istr) {
 		this(opcode, istr);
 		_optr = op;
 	}
-	
+
 	public CPINSTRUCTION_TYPE getCPInstructionType() {
 		return _cptype;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/CPOperand.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/CPOperand.java
@@ -46,14 +46,14 @@ public class CPOperand
 	public CPOperand(String name, ValueType vt, DataType dt ) {
 		this(name, vt, dt, false);
 	}
-	
-	public CPOperand(String name, ValueType vt, DataType dt, boolean literal ) {
+
+	private CPOperand(String name, ValueType vt, DataType dt, boolean literal) {
 		_name = name;
 		_valueType = vt;
 		_dataType = dt;
 		_isLiteral = literal;
 	}
-	
+
 	public String getName() {
 		return _name;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/CentralMomentCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/CentralMomentCPInstruction.java
@@ -29,11 +29,10 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.CMOperator;
 import org.apache.sysml.runtime.matrix.operators.CMOperator.AggregateOperationTypes;
 
-public class CentralMomentCPInstruction extends AggregateUnaryCPInstruction
-{	
-	public CentralMomentCPInstruction(CMOperator cm, CPOperand in1, CPOperand in2, 
-			CPOperand in3, CPOperand out, String opcode, String str) 
-	{
+public class CentralMomentCPInstruction extends AggregateUnaryCPInstruction {
+
+	private CentralMomentCPInstruction(CMOperator cm, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String str) {
 		super(cm, in1, in2, in3, out, opcode, str);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/CompressionCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/CompressionCPInstruction.java
@@ -28,13 +28,12 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class CompressionCPInstruction extends UnaryCPInstruction
-{
-	
-	public CompressionCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr){
+public class CompressionCPInstruction extends UnaryCPInstruction {
+
+	private CompressionCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		super(op, in, null, null, out, opcode, istr);
 	}
-	
+
 	public static Instruction parseInstruction(String str)
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ComputationCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ComputationCPInstruction.java
@@ -23,14 +23,13 @@ import org.apache.sysml.hops.OptimizerUtils;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public abstract class ComputationCPInstruction extends CPInstruction 
-{
-	
+public abstract class ComputationCPInstruction extends CPInstruction {
 
 	public CPOperand output;
 	public CPOperand input1, input2, input3;
-	
-	public ComputationCPInstruction ( Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr ) {
+
+	protected ComputationCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, opcode, istr);
 		input1 = in1;
 		input2 = in2;
@@ -38,7 +37,8 @@ public abstract class ComputationCPInstruction extends CPInstruction
 		output = out;
 	}
 
-	public ComputationCPInstruction ( Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, String opcode, String istr ) {
+	protected ComputationCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String istr) {
 		super(op, opcode, istr);
 		input1 = in1;
 		input2 = in2;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ConvolutionCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ConvolutionCPInstruction.java
@@ -34,33 +34,32 @@ import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysml.runtime.util.ConvolutionUtils;
 import org.apache.sysml.utils.NativeHelper;
 
-public class ConvolutionCPInstruction extends UnaryCPInstruction 
-{	
+public class ConvolutionCPInstruction extends UnaryCPInstruction {
 	private CPOperand _in2;
-	private CPOperand _in3; 
+	private CPOperand _in3;
 	private ArrayList<CPOperand> _input_shape;
 	private ArrayList<CPOperand> _filter_shape;
 	private ArrayList<CPOperand> _stride = new ArrayList<CPOperand>();
 	private ArrayList<CPOperand> _padding = new ArrayList<CPOperand>();
 	private int _numThreads = -1;
-	
-	public ConvolutionCPInstruction(CPOperand in, CPOperand in2, CPOperand out, String opcode, String istr, int numThreads) throws DMLRuntimeException {
-		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out,
-				opcode, istr);
-		if( !(opcode.equals("bias_add") || opcode.equals("relu_backward") || opcode.equals("bias_multiply") ) ) {
-			throw new DMLRuntimeException("Incorrect usage. Expected the opcode to be bias_add or bias_multiply or relu_backward, but found " + opcode);
+
+	private ConvolutionCPInstruction(CPOperand in, CPOperand in2, CPOperand out, String opcode, String istr,
+			int numThreads) throws DMLRuntimeException {
+		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out, opcode, istr);
+		if (!(opcode.equals("bias_add") || opcode.equals("relu_backward") || opcode.equals("bias_multiply"))) {
+			throw new DMLRuntimeException(
+					"Incorrect usage. Expected the opcode to be bias_add or bias_multiply or relu_backward, but found "
+							+ opcode);
 		}
 		_in2 = in2;
 		_cptype = CPINSTRUCTION_TYPE.Convolution;
 		_numThreads = numThreads;
 	}
-	
-	public ConvolutionCPInstruction(CPOperand in, CPOperand out, String opcode,
-			String istr, ArrayList<CPOperand> stride,
-			ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
+
+	private ConvolutionCPInstruction(CPOperand in, CPOperand out, String opcode, String istr,
+			ArrayList<CPOperand> stride, ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
 			ArrayList<CPOperand> filter_shape, int numThreads) {
-		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out,
-				opcode, istr);
+		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.Convolution;
 		_stride = stride;
 		_padding = padding;
@@ -68,13 +67,11 @@ public class ConvolutionCPInstruction extends UnaryCPInstruction
 		_filter_shape = filter_shape;
 		_numThreads = numThreads;
 	}
-	
-	public ConvolutionCPInstruction(CPOperand in, CPOperand in2, CPOperand out, String opcode,
-			String istr, ArrayList<CPOperand> stride,
-			ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
+
+	private ConvolutionCPInstruction(CPOperand in, CPOperand in2, CPOperand out, String opcode, String istr,
+			ArrayList<CPOperand> stride, ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
 			ArrayList<CPOperand> filter_shape, int numThreads) {
-		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out,
-				opcode, istr);
+		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out, opcode, istr);
 		_in2 = in2;
 		_cptype = CPINSTRUCTION_TYPE.Convolution;
 		_stride = stride;
@@ -83,13 +80,11 @@ public class ConvolutionCPInstruction extends UnaryCPInstruction
 		_filter_shape = filter_shape;
 		_numThreads = numThreads;
 	}
-	
-	public ConvolutionCPInstruction(CPOperand in, CPOperand in2, CPOperand in3, CPOperand out, String opcode,
-			String istr, ArrayList<CPOperand> stride,
-			ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
+
+	private ConvolutionCPInstruction(CPOperand in, CPOperand in2, CPOperand in3, CPOperand out, String opcode,
+			String istr, ArrayList<CPOperand> stride, ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
 			ArrayList<CPOperand> filter_shape, int numThreads) {
-		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out,
-				opcode, istr);
+		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out, opcode, istr);
 		_in2 = in2;
 		_in3 = in3;
 		_cptype = CPINSTRUCTION_TYPE.Convolution;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/CovarianceCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/CovarianceCPInstruction.java
@@ -29,18 +29,16 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.COVOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class CovarianceCPInstruction extends BinaryCPInstruction
-{
-	
-	public CovarianceCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr )
-	{
+public class CovarianceCPInstruction extends BinaryCPInstruction {
+
+	private CovarianceCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.AggregateBinary;
 	}
-	
-	public CovarianceCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
-								   String opcode, String istr )
-	{
+
+	private CovarianceCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.AggregateBinary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/DataGenCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/DataGenCPInstruction.java
@@ -32,11 +32,10 @@ import org.apache.sysml.runtime.matrix.data.RandomMatrixGenerator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class DataGenCPInstruction extends UnaryCPInstruction
-{
-	
+public class DataGenCPInstruction extends UnaryCPInstruction {
+
 	private DataGenMethod method = DataGenMethod.INVALID;
-	
+
 	private long rows;
 	private long cols;
 	private int rowsInBlock;
@@ -45,24 +44,22 @@ public class DataGenCPInstruction extends UnaryCPInstruction
 	private double maxValue;
 	private double sparsity;
 	private String pdf, pdfParams;
-	private long seed=0;
-	
-	//sequence specific attributes
+	private long seed = 0;
+
+	// sequence specific attributes
 	private double seq_from;
-	private double seq_to; 
+	private double seq_to;
 	private double seq_incr;
-	
-	//sample specific attributes
+
+	// sample specific attributes
 	private boolean replace;
- 	private int numThreads = -1;
-	
-	public DataGenCPInstruction (Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, 
-							  long rows, long cols, int rpb, int cpb,
-							  double minValue, double maxValue, double sparsity, long seed,
-							  String probabilityDensityFunction, String pdfParams, int k, String opcode, String istr) 
-	{
+	private int numThreads = -1;
+
+	private DataGenCPInstruction(Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, long rows, long cols,
+			int rpb, int cpb, double minValue, double maxValue, double sparsity, long seed,
+			String probabilityDensityFunction, String pdfParams, int k, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
-		
+
 		this.method = mthd;
 		this.rows = rows;
 		this.cols = cols;
@@ -77,12 +74,10 @@ public class DataGenCPInstruction extends UnaryCPInstruction
 		this.pdfParams = pdfParams;
 	}
 
-	public DataGenCPInstruction (Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, 
-			  					long rows, long cols, int rpb, int cpb, double maxValue,
-			  					boolean replace, long seed, String opcode, String istr) 
-	{
+	private DataGenCPInstruction(Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, long rows, long cols,
+			int rpb, int cpb, double maxValue, boolean replace, long seed, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
-		
+
 		this.method = mthd;
 		this.rows = rows;
 		this.cols = cols;
@@ -92,13 +87,11 @@ public class DataGenCPInstruction extends UnaryCPInstruction
 		this.replace = replace;
 		this.seed = seed;
 	}
-	
-	public DataGenCPInstruction(Operator op, DataGenMethod mthd, CPOperand in, CPOperand out,
-							long rows, long cols, int rpb, int cpb, double seqFrom,
-							double seqTo, double seqIncr, String opcode, String istr) 
-	{
+
+	private DataGenCPInstruction(Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, long rows, long cols,
+			int rpb, int cpb, double seqFrom, double seqTo, double seqIncr, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
-		
+
 		this.method = mthd;
 		this.rows = rows;
 		this.cols = cols;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/DataPartitionCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/DataPartitionCPInstruction.java
@@ -37,13 +37,12 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.OutputInfo;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class DataPartitionCPInstruction extends UnaryCPInstruction
-{	
-	
+public class DataPartitionCPInstruction extends UnaryCPInstruction {
+
 	private PDataPartitionFormat _pformat = null;
-	
-	public DataPartitionCPInstruction(Operator op, CPOperand in1, PDataPartitionFormat pformat, CPOperand out, String opcode, String istr)
-	{
+
+	private DataPartitionCPInstruction(Operator op, CPOperand in1, PDataPartitionFormat pformat, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.MMTSJ;
 		_pformat = pformat;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/FrameAppendCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/FrameAppendCPInstruction.java
@@ -24,9 +24,10 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public final class FrameAppendCPInstruction extends AppendCPInstruction
-{	
-	public FrameAppendCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, AppendType type, String opcode, String istr) {
+public final class FrameAppendCPInstruction extends AppendCPInstruction {
+
+	protected FrameAppendCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			AppendType type, String opcode, String istr) {
 		super(op, in1, in2, in3, out, type, opcode, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/FrameIndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/FrameIndexingCPInstruction.java
@@ -26,16 +26,18 @@ import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.IndexRange;
 
-public final class FrameIndexingCPInstruction extends IndexingCPInstruction
-{	
-	public FrameIndexingCPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr){
+public final class FrameIndexingCPInstruction extends IndexingCPInstruction {
+
+	protected FrameIndexingCPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl,
+			CPOperand cu, CPOperand out, String opcode, String istr) {
 		super(op, in, rl, ru, cl, cu, out, opcode, istr);
 	}
-	
-	public FrameIndexingCPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr){
+
+	protected FrameIndexingCPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl,
+			CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr) {
 		super(op, lhsInput, rhsInput, rl, ru, cl, cu, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec)
 			throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/FunctionCallCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/FunctionCallCPInstruction.java
@@ -40,34 +40,34 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContextFactory;
 import org.apache.sysml.runtime.instructions.Instruction;
 import org.apache.sysml.runtime.instructions.InstructionUtils;
 
-public class FunctionCallCPInstruction extends CPInstruction 
-{	
+public class FunctionCallCPInstruction extends CPInstruction {
 	private String _functionName;
 	private String _namespace;
-	
-	public String getFunctionName(){
+
+	public String getFunctionName() {
 		return _functionName;
 	}
-	
+
 	public String getNamespace() {
 		return _namespace;
 	}
-	
+
 	// stores both the bound input and output parameters
 	private ArrayList<CPOperand> _boundInputParamOperands;
 	private ArrayList<String> _boundInputParamNames;
 	private ArrayList<String> _boundOutputParamNames;
-	
-	public FunctionCallCPInstruction(String namespace, String functName, ArrayList<CPOperand> boundInParamOperands, ArrayList<String> boundInParamNames, ArrayList<String> boundOutParamNames, String istr) {
+
+	private FunctionCallCPInstruction(String namespace, String functName, ArrayList<CPOperand> boundInParamOperands,
+			ArrayList<String> boundInParamNames, ArrayList<String> boundOutParamNames, String istr) {
 		super(null, functName, istr);
-		
+
 		_cptype = CPINSTRUCTION_TYPE.External;
 		_functionName = functName;
 		_namespace = namespace;
 		_boundInputParamOperands = boundInParamOperands;
 		_boundInputParamNames = boundInParamNames;
 		_boundOutputParamNames = boundOutParamNames;
-		
+
 	}
 
 	public static FunctionCallCPInstruction parseInstruction(String str) 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/IndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/IndexingCPInstruction.java
@@ -27,19 +27,20 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 import org.apache.sysml.runtime.util.IndexRange;
 
-public abstract class IndexingCPInstruction extends UnaryCPInstruction
-{
+public abstract class IndexingCPInstruction extends UnaryCPInstruction {
 	protected CPOperand rowLower, rowUpper, colLower, colUpper;
-	
-	public IndexingCPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr){
+
+	protected IndexingCPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu,
+			CPOperand out, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
 		rowLower = rl;
 		rowUpper = ru;
 		colLower = cl;
 		colUpper = cu;
 	}
-	
-	public IndexingCPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr){
+
+	protected IndexingCPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl, CPOperand ru,
+			CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr) {
 		super(op, lhsInput, rhsInput, out, opcode, istr);
 		rowLower = rl;
 		rowUpper = ru;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MMChainCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MMChainCPInstruction.java
@@ -26,14 +26,13 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MMChainCPInstruction extends UnaryCPInstruction
-{	
-	
+public class MMChainCPInstruction extends UnaryCPInstruction {
+
 	private ChainType _type = null;
 	private int _numThreads = -1;
-	
-	public MMChainCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, ChainType type, int k, String opcode, String istr)
-	{
+
+	private MMChainCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			ChainType type, int k, String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.MMChain;
 		_type = type;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MMTSJCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MMTSJCPInstruction.java
@@ -26,14 +26,12 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MMTSJCPInstruction extends UnaryCPInstruction
-{	
-	
+public class MMTSJCPInstruction extends UnaryCPInstruction {
 	private MMTSJType _type = null;
 	private int _numThreads = 1;
-	
-	public MMTSJCPInstruction(Operator op, CPOperand in1, MMTSJType type, CPOperand out, int k, String opcode, String istr)
-	{
+
+	private MMTSJCPInstruction(Operator op, CPOperand in1, MMTSJType type, CPOperand out, int k, String opcode,
+			String istr) {
 		super(op, in1, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.MMTSJ;
 		_type = type;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixAppendCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixAppendCPInstruction.java
@@ -24,9 +24,10 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public final class MatrixAppendCPInstruction extends AppendCPInstruction
-{	
-	public MatrixAppendCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, AppendType type, String opcode, String istr) {
+public final class MatrixAppendCPInstruction extends AppendCPInstruction {
+
+	protected MatrixAppendCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			AppendType type, String opcode, String istr) {
 		super(op, in1, in2, in3, out, type, opcode, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixBuiltinCPInstruction.java
@@ -26,10 +26,8 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
-
-public class MatrixBuiltinCPInstruction extends BuiltinUnaryCPInstruction
-{
-	public MatrixBuiltinCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr){
+public class MatrixBuiltinCPInstruction extends BuiltinUnaryCPInstruction {
+	protected MatrixBuiltinCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr) {
 		super(op, in, out, 1, opcode, instr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixIndexingCPInstruction.java
@@ -31,16 +31,18 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.IndexRange;
 import org.apache.sysml.utils.Statistics;
 
-public final class MatrixIndexingCPInstruction extends IndexingCPInstruction
-{	
-	public MatrixIndexingCPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr){
+public final class MatrixIndexingCPInstruction extends IndexingCPInstruction {
+
+	protected MatrixIndexingCPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl,
+			CPOperand cu, CPOperand out, String opcode, String istr) {
 		super(op, in, rl, ru, cl, cu, out, opcode, istr);
 	}
-	
-	public MatrixIndexingCPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr){
+
+	protected MatrixIndexingCPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl,
+			CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr) {
 		super(op, lhsInput, rhsInput, rl, ru, cl, cu, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec)
 			throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixMatrixArithmeticCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixMatrixArithmeticCPInstruction.java
@@ -25,19 +25,13 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class MatrixMatrixArithmeticCPInstruction extends ArithmeticBinaryCPInstruction {
 
-public class MatrixMatrixArithmeticCPInstruction extends ArithmeticBinaryCPInstruction
-{
-	
-	public MatrixMatrixArithmeticCPInstruction(Operator op, 
-											   CPOperand in1, 
-											   CPOperand in2, 
-											   CPOperand out, 
-											   String opcode,
-											   String istr){
+	protected MatrixMatrixArithmeticCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixMatrixBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixMatrixBuiltinCPInstruction.java
@@ -27,19 +27,13 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class MatrixMatrixBuiltinCPInstruction extends BuiltinBinaryCPInstruction {
 
-public class MatrixMatrixBuiltinCPInstruction extends BuiltinBinaryCPInstruction
-{
-	
-	public MatrixMatrixBuiltinCPInstruction(Operator op, 
-											   CPOperand in1, 
-											   CPOperand in2, 
-											   CPOperand out, 
-											   String opcode,
-											   String istr){
+	protected MatrixMatrixBuiltinCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, 2, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixMatrixRelationalCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixMatrixRelationalCPInstruction.java
@@ -25,16 +25,10 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class MatrixMatrixRelationalCPInstruction extends RelationalBinaryCPInstruction {
 
-public class MatrixMatrixRelationalCPInstruction extends RelationalBinaryCPInstruction
-{
-	
-	public MatrixMatrixRelationalCPInstruction(Operator op, 
-											   CPOperand in1, 
-											   CPOperand in2, 
-											   CPOperand out,
-											   String opcode,
-											   String istr){
+	protected MatrixMatrixRelationalCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixReshapeCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixReshapeCPInstruction.java
@@ -27,18 +27,17 @@ import org.apache.sysml.runtime.matrix.data.LibMatrixReorg;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixReshapeCPInstruction extends UnaryCPInstruction
-{	
-	
+public class MatrixReshapeCPInstruction extends UnaryCPInstruction {
+
 	private CPOperand _opRows = null;
 	private CPOperand _opCols = null;
 	private CPOperand _opByRow = null;
-	
-	public MatrixReshapeCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand in4, CPOperand out, String opcode, String istr)
-	{
+
+	private MatrixReshapeCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand in4,
+			CPOperand out, String opcode, String istr) {
 		super(op, in1, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.MatrixReshape;
-		
+
 		_opRows = in2;
 		_opCols = in3;
 		_opByRow = in4;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixScalarBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixScalarBuiltinCPInstruction.java
@@ -26,19 +26,13 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ScalarOperator;
 
+public class MatrixScalarBuiltinCPInstruction extends BuiltinBinaryCPInstruction {
 
-public class MatrixScalarBuiltinCPInstruction extends BuiltinBinaryCPInstruction
-{
-	
-	public MatrixScalarBuiltinCPInstruction(Operator op,
-											CPOperand in1,
-											CPOperand in2,
-											CPOperand out,
-											String opcode,
-											String instr){
+	protected MatrixScalarBuiltinCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String instr) {
 		super(op, in1, in2, out, 2, opcode, instr);
 	}
-	
+
 	@Override 
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MultiReturnBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MultiReturnBuiltinCPInstruction.java
@@ -31,15 +31,13 @@ import org.apache.sysml.runtime.matrix.data.LibCommonsMath;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class MultiReturnBuiltinCPInstruction extends ComputationCPInstruction {
 
-public class MultiReturnBuiltinCPInstruction extends ComputationCPInstruction 
-{
-	
 	int arity;
 	protected ArrayList<CPOperand> _outputs;
-	
-	public MultiReturnBuiltinCPInstruction(Operator op, CPOperand input1, ArrayList<CPOperand> outputs, String opcode, String istr )
-	{
+
+	private MultiReturnBuiltinCPInstruction(Operator op, CPOperand input1, ArrayList<CPOperand> outputs, String opcode,
+			String istr) {
 		super(op, input1, null, outputs.get(0), opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.MultiReturnBuiltin;
 		_outputs = outputs;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MultiReturnParameterizedBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MultiReturnParameterizedBuiltinCPInstruction.java
@@ -32,17 +32,16 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.transform.encode.Encoder;
 import org.apache.sysml.runtime.transform.encode.EncoderFactory;
 
-
-public class MultiReturnParameterizedBuiltinCPInstruction extends ComputationCPInstruction 
-{
+public class MultiReturnParameterizedBuiltinCPInstruction extends ComputationCPInstruction {
 	protected ArrayList<CPOperand> _outputs;
-	
-	public MultiReturnParameterizedBuiltinCPInstruction(Operator op, CPOperand input1, CPOperand input2, ArrayList<CPOperand> outputs, String opcode, String istr ) {
+
+	private MultiReturnParameterizedBuiltinCPInstruction(Operator op, CPOperand input1, CPOperand input2,
+			ArrayList<CPOperand> outputs, String opcode, String istr) {
 		super(op, input1, input2, outputs.get(0), opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.MultiReturnBuiltin;
 		_outputs = outputs;
 	}
-	
+
 	public CPOperand getOutput(int i) {
 		return _outputs.get(i);
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/PMMJCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/PMMJCPInstruction.java
@@ -25,13 +25,12 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class PMMJCPInstruction extends ComputationCPInstruction
-{	
-	
+public class PMMJCPInstruction extends ComputationCPInstruction {
+
 	private int _numThreads = -1;
-	
-	public PMMJCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, int k, String opcode, String istr)
-	{
+
+	private PMMJCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, int k,
+			String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
 		_numThreads = k;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
@@ -46,21 +46,19 @@ import org.apache.sysml.runtime.transform.encode.EncoderFactory;
 import org.apache.sysml.runtime.transform.meta.TfMetaUtils;
 import org.apache.sysml.runtime.util.DataConverter;
 
-
-public class ParameterizedBuiltinCPInstruction extends ComputationCPInstruction 
-{
+public class ParameterizedBuiltinCPInstruction extends ComputationCPInstruction {
 	private static final int TOSTRING_MAXROWS = 100;
 	private static final int TOSTRING_MAXCOLS = 100;
 	private static final int TOSTRING_DECIMAL = 3;
 	private static final boolean TOSTRING_SPARSE = false;
 	private static final String TOSTRING_SEPARATOR = " ";
 	private static final String TOSTRING_LINESEPARATOR = "\n";
-	
+
 	private int arity;
-	protected HashMap<String,String> params;
-	
-	public ParameterizedBuiltinCPInstruction(Operator op, HashMap<String,String> paramsMap, CPOperand out, String opcode, String istr )
-	{
+	protected HashMap<String, String> params;
+
+	protected ParameterizedBuiltinCPInstruction(Operator op, HashMap<String, String> paramsMap, CPOperand out,
+			String opcode, String istr) {
 		super(op, null, null, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.ParameterizedBuiltin;
 		params = paramsMap;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/PlusMultCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/PlusMultCPInstruction.java
@@ -28,15 +28,13 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 
-public class PlusMultCPInstruction extends ArithmeticBinaryCPInstruction 
-{
-	public PlusMultCPInstruction(BinaryOperator op, CPOperand in1, CPOperand in2, 
-			CPOperand in3, CPOperand out, String opcode, String str) 
-	{
+public class PlusMultCPInstruction extends ArithmeticBinaryCPInstruction {
+	private PlusMultCPInstruction(BinaryOperator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String str) {
 		super(op, in1, in2, out, opcode, str);
-		input3=in3;
+		input3 = in3;
 	}
-	
+
 	public static PlusMultCPInstruction parseInstruction(String str)
 	{
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/QuantilePickCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/QuantilePickCPInstruction.java
@@ -34,20 +34,20 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.MapReduceTool;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class QuantilePickCPInstruction extends BinaryCPInstruction
-{
-	
+public class QuantilePickCPInstruction extends BinaryCPInstruction {
+
 	private OperationTypes _type = null;
 	private boolean _inmem = true;
-	
-	public QuantilePickCPInstruction(Operator op, CPOperand in, CPOperand out, OperationTypes type, boolean inmem, String opcode, String istr){
+
+	private QuantilePickCPInstruction(Operator op, CPOperand in, CPOperand out, OperationTypes type, boolean inmem,
+			String opcode, String istr) {
 		this(op, in, null, out, type, inmem, opcode, istr);
 	}
-	
-	public QuantilePickCPInstruction(Operator op, CPOperand in, CPOperand in2, CPOperand out,  OperationTypes type, boolean inmem, String opcode, String istr){
+
+	private QuantilePickCPInstruction(Operator op, CPOperand in, CPOperand in2, CPOperand out, OperationTypes type,
+			boolean inmem, String opcode, String istr) {
 		super(op, in, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.QPick;
-		
 		_type = type;
 		_inmem = inmem;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/QuantileSortCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/QuantileSortCPInstruction.java
@@ -29,27 +29,26 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 
-public class QuantileSortCPInstruction extends UnaryCPInstruction
-{
-	
-	/*
-	 * This class supports two variants of sort operation on a 1-dimensional input matrix. 
-	 * The two variants are <code> weighted </code> and <code> unweighted </code>.
-	 * Example instructions: 
-	 *     sort:mVar1:mVar2 (input=mVar1, output=mVar2)
-	 *     sort:mVar1:mVar2:mVar3 (input=mVar1, weights=mVar2, output=mVar3)
-	 *  
-	 */
-	
-	public QuantileSortCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr){
+/**
+ * This class supports two variants of sort operation on a 1-dimensional input matrix. 
+ * The two variants are <code> weighted </code> and <code> unweighted </code>.
+ * Example instructions: 
+ *     sort:mVar1:mVar2 (input=mVar1, output=mVar2)
+ *     sort:mVar1:mVar2:mVar3 (input=mVar1, weights=mVar2, output=mVar3)
+ *  
+ */
+public class QuantileSortCPInstruction extends UnaryCPInstruction {
+
+	private QuantileSortCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		this(op, in, null, out, opcode, istr);
 	}
-	
-	public QuantileSortCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr){
+
+	private QuantileSortCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.QSort;
 	}
-	
+
 	public static QuantileSortCPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/QuaternaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/QuaternaryCPInstruction.java
@@ -33,17 +33,15 @@ import org.apache.sysml.runtime.matrix.data.MatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.QuaternaryOperator;
 
-public class QuaternaryCPInstruction extends ComputationCPInstruction
-{
-	
+public class QuaternaryCPInstruction extends ComputationCPInstruction {
+
 	private CPOperand input4 = null;
- 	private int _numThreads = -1;
-	
-	public QuaternaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand in4, CPOperand out, 
-							       int k, String opcode, String istr )
-	{
+	private int _numThreads = -1;
+
+	private QuaternaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand in4,
+			CPOperand out, int k, String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
-		
+
 		input4 = in4;
 		_numThreads = k;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/RelationalBinaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/RelationalBinaryCPInstruction.java
@@ -25,14 +25,14 @@ import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public abstract class RelationalBinaryCPInstruction extends BinaryCPInstruction {
 
-public abstract class RelationalBinaryCPInstruction extends BinaryCPInstruction 
-{
-	public RelationalBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
+	protected RelationalBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.RelationalBinary;
 	}
-	
+
 	public static RelationalBinaryCPInstruction parseInstruction ( String str ) throws DMLRuntimeException {
 		InstructionUtils.checkNumFields (str, 3);
 		CPOperand in1 = new CPOperand("", ValueType.UNKNOWN, DataType.UNKNOWN);

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ReorgCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ReorgCPInstruction.java
@@ -32,47 +32,59 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 
+public class ReorgCPInstruction extends UnaryCPInstruction {
+	// sort-specific attributes (to enable variable attributes)
+	private CPOperand _col = null;
+	private CPOperand _desc = null;
+	private CPOperand _ixret = null;
 
-public class ReorgCPInstruction extends UnaryCPInstruction
-{
-	//sort-specific attributes (to enable variable attributes)
- 	private CPOperand _col = null;
- 	private CPOperand _desc = null;
- 	private CPOperand _ixret = null;
- 	
- 	/**
- 	 * for opcodes r' and rdiag
- 	 * 
- 	 * @param op operator
- 	 * @param in cp input operand
- 	 * @param out cp output operand
- 	 * @param opcode the opcode
- 	 * @param istr ?
- 	 */
-	public ReorgCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr){
+	/**
+	 * for opcodes r' and rdiag
+	 * 
+	 * @param op
+	 *            operator
+	 * @param in
+	 *            cp input operand
+	 * @param out
+	 *            cp output operand
+	 * @param opcode
+	 *            the opcode
+	 * @param istr
+	 *            ?
+	 */
+	private ReorgCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.Reorg;
 	}
-	
+
 	/**
 	 * for opcode rsort
 	 * 
-	 * @param op operator
-	 * @param in cp input operand
-	 * @param col ?
-	 * @param desc ?
-	 * @param ixret ?
-	 * @param out cp output operand
-	 * @param opcode the opcode
-	 * @param istr ?
+	 * @param op
+	 *            operator
+	 * @param in
+	 *            cp input operand
+	 * @param col
+	 *            ?
+	 * @param desc
+	 *            ?
+	 * @param ixret
+	 *            ?
+	 * @param out
+	 *            cp output operand
+	 * @param opcode
+	 *            the opcode
+	 * @param istr
+	 *            ?
 	 */
-	public ReorgCPInstruction(Operator op, CPOperand in, CPOperand col, CPOperand desc, CPOperand ixret, CPOperand out, String opcode, String istr){
+	private ReorgCPInstruction(Operator op, CPOperand in, CPOperand col, CPOperand desc, CPOperand ixret, CPOperand out,
+			String opcode, String istr) {
 		this(op, in, out, opcode, istr);
 		_col = col;
 		_desc = desc;
 		_ixret = ixret;
 	}
-	
+
 	public static ReorgCPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarAppendCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarAppendCPInstruction.java
@@ -23,12 +23,13 @@ import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public final class ScalarAppendCPInstruction extends AppendCPInstruction
-{	
-	public ScalarAppendCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, AppendType type, String opcode, String istr) {
+public final class ScalarAppendCPInstruction extends AppendCPInstruction {
+
+	protected ScalarAppendCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			AppendType type, String opcode, String istr) {
 		super(op, in1, in2, in3, out, type, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec)
 		throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarBuiltinCPInstruction.java
@@ -27,15 +27,12 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 
+public class ScalarBuiltinCPInstruction extends BuiltinUnaryCPInstruction {
 
-public class ScalarBuiltinCPInstruction extends BuiltinUnaryCPInstruction
-{	
-	
-	public ScalarBuiltinCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr)
-	{
+	protected ScalarBuiltinCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr) {
 		super(op, in, out, 1, opcode, instr);
 	}
-	
+
 	@Override 
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarBuiltinMultipleCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarBuiltinMultipleCPInstruction.java
@@ -38,7 +38,7 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
  */
 public class ScalarBuiltinMultipleCPInstruction extends BuiltinMultipleCPInstruction {
 
-	public ScalarBuiltinMultipleCPInstruction(Operator op, String opcode, String istr, CPOperand output,
+	protected ScalarBuiltinMultipleCPInstruction(Operator op, String opcode, String istr, CPOperand output,
 			CPOperand... inputs) {
 		super(op, opcode, istr, output, inputs);
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarMatrixArithmeticCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarMatrixArithmeticCPInstruction.java
@@ -27,18 +27,13 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ScalarOperator;
 
 // TODO rename to MatrixScalar...
-public class ScalarMatrixArithmeticCPInstruction extends ArithmeticBinaryCPInstruction
-{
-	
-	public ScalarMatrixArithmeticCPInstruction(Operator op, 
-											   CPOperand in1, 
-											   CPOperand in2, 
-											   CPOperand out, 
-											   String opcode,
-											   String istr){
+public class ScalarMatrixArithmeticCPInstruction extends ArithmeticBinaryCPInstruction {
+
+	protected ScalarMatrixArithmeticCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarMatrixRelationalCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarMatrixRelationalCPInstruction.java
@@ -27,15 +27,10 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ScalarOperator;
 
 //TODO rename to MatrixScalar...
-public class ScalarMatrixRelationalCPInstruction extends RelationalBinaryCPInstruction
-{
-	
-	public ScalarMatrixRelationalCPInstruction(Operator op, 
-			   								   CPOperand in1, 
-			   								   CPOperand in2, 
-			   								   CPOperand out, 
-			   								   String opcode,
-			   								   String istr){
+public class ScalarMatrixRelationalCPInstruction extends RelationalBinaryCPInstruction {
+
+	protected ScalarMatrixRelationalCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarScalarArithmeticCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarScalarArithmeticCPInstruction.java
@@ -25,13 +25,13 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class ScalarScalarArithmeticCPInstruction extends ArithmeticBinaryCPInstruction {
 
-public class ScalarScalarArithmeticCPInstruction extends ArithmeticBinaryCPInstruction
-{	
-	public ScalarScalarArithmeticCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr){
+	protected ScalarScalarArithmeticCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) throws DMLRuntimeException{
 		ScalarObject so1 = ec.getScalarInput(input1.getName(), input1.getValueType(), input1.isLiteral());

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarScalarBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarScalarBuiltinCPInstruction.java
@@ -25,10 +25,10 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class ScalarScalarBuiltinCPInstruction extends BuiltinBinaryCPInstruction {
 
-public class ScalarScalarBuiltinCPInstruction extends BuiltinBinaryCPInstruction
-{
-	public ScalarScalarBuiltinCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String instr){
+	protected ScalarScalarBuiltinCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String instr) {
 		super(op, in1, in2, out, 2, opcode, instr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarScalarRelationalCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalarScalarRelationalCPInstruction.java
@@ -25,13 +25,12 @@ import org.apache.sysml.runtime.functionobjects.ValueComparisonFunction;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class ScalarScalarRelationalCPInstruction extends RelationalBinaryCPInstruction
-{	
-	public ScalarScalarRelationalCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
+public class ScalarScalarRelationalCPInstruction extends RelationalBinaryCPInstruction {
+	protected ScalarScalarRelationalCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/SpoofCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/SpoofCPInstruction.java
@@ -29,21 +29,21 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 
-public class SpoofCPInstruction extends ComputationCPInstruction
-{
+public class SpoofCPInstruction extends ComputationCPInstruction {
 	private final Class<?> _class;
 	private final SpoofOperator _op;
 	private final int _numThreads;
 	private final CPOperand[] _in;
-	
-	public SpoofCPInstruction(SpoofOperator op, Class<?> cla, int k, CPOperand[] in, CPOperand out, String opcode, String str) {
+
+	private SpoofCPInstruction(SpoofOperator op, Class<?> cla, int k, CPOperand[] in, CPOperand out, String opcode,
+			String str) {
 		super(null, null, null, out, opcode, str);
 		_class = cla;
 		_op = op;
 		_numThreads = k;
 		_in = in;
 	}
-	
+
 	public Class<?> getOperatorClass() {
 		return _class;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/StringInitCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/StringInitCPInstruction.java
@@ -29,18 +29,15 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class StringInitCPInstruction extends UnaryCPInstruction
-{
-	
+public class StringInitCPInstruction extends UnaryCPInstruction {
 	private static final String DELIM = " ";
-	
+
 	private long _rlen = -1;
 	private long _clen = -1;
 	private String _data = null;
-		
-	public StringInitCPInstruction( Operator op, CPOperand in, CPOperand out, long rows, long cols, int rpb, int cpb, 
-			                        String data, String opcode, String inst) 
-	{
+
+	private StringInitCPInstruction(Operator op, CPOperand in, CPOperand out, long rows, long cols, int rpb, int cpb,
+			String data, String opcode, String inst) {
 		super(op, in, out, opcode, inst);
 		_rlen = rows;
 		_clen = cols;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/TernaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/TernaryCPInstruction.java
@@ -32,21 +32,17 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 import org.apache.sysml.runtime.util.DataConverter;
 
-
-public class TernaryCPInstruction extends ComputationCPInstruction
-{
-	
+public class TernaryCPInstruction extends ComputationCPInstruction {
 	private String _outDim1;
 	private String _outDim2;
-	private boolean _dim1Literal; 
+	private boolean _dim1Literal;
 	private boolean _dim2Literal;
 	private boolean _isExpand;
 	private boolean _ignoreZeros;
-	
-	public TernaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, 
-							 String outputDim1, boolean dim1Literal,String outputDim2, boolean dim2Literal, 
-							 boolean isExpand, boolean ignoreZeros, String opcode, String istr )
-	{
+
+	private TernaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String outputDim1, boolean dim1Literal, String outputDim2, boolean dim2Literal, boolean isExpand,
+			boolean ignoreZeros, String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
 		_outDim1 = outputDim1;
 		_dim1Literal = dim1Literal;

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/UaggOuterChainCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/UaggOuterChainCPInstruction.java
@@ -32,20 +32,19 @@ import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 
-public class UaggOuterChainCPInstruction extends UnaryCPInstruction
-{
-	//operators
+public class UaggOuterChainCPInstruction extends UnaryCPInstruction {
+	// operators
 	private AggregateUnaryOperator _uaggOp = null;
 	private BinaryOperator _bOp = null;
 
-	public UaggOuterChainCPInstruction(BinaryOperator bop, AggregateUnaryOperator uaggop, AggregateOperator aggop, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr )
-	{
+	private UaggOuterChainCPInstruction(BinaryOperator bop, AggregateUnaryOperator uaggop, AggregateOperator aggop,
+			CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
 		super(bop, in1, in2, out, opcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.UaggOuterChain;
-		
+
 		_uaggOp = uaggop;
 		_bOp = bop;
-			
+
 		instString = istr;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/UnaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/UnaryCPInstruction.java
@@ -25,22 +25,19 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 
+public abstract class UnaryCPInstruction extends ComputationCPInstruction {
 
-public abstract class UnaryCPInstruction extends ComputationCPInstruction
-{
-	
-	public UnaryCPInstruction(Operator op, CPOperand in, CPOperand out,
-			String opcode, String instr) {
-		this (op, in, null, null, out, opcode, instr);
+	protected UnaryCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr) {
+		this(op, in, null, null, out, opcode, instr);
 	}
 
-	public UnaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
-			String opcode, String instr) {
-		this (op, in1, in2, null, out, opcode, instr);
+	protected UnaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String instr) {
+		this(op, in1, in2, null, out, opcode, instr);
 	}
 
-	public UnaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
-			String opcode, String instr) {
+	protected UnaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, String opcode,
+			String instr) {
 		super(op, in1, in2, in3, out, opcode, instr);
 	}
 
@@ -62,7 +59,7 @@ public abstract class UnaryCPInstruction extends ComputationCPInstruction
 		return parse(instr, in1, in2, in3, out);
 	}
 
-	static String parse(String instr, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out) throws DMLRuntimeException {
+	private static String parse(String instr, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out) throws DMLRuntimeException {
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(instr);
 		
 		// first part is the opcode, last part is the output, middle parts are input operands

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/VariableCPInstruction.java
@@ -59,10 +59,8 @@ import org.apache.sysml.runtime.util.MapReduceTool;
 import org.apache.sysml.runtime.util.UtilFunctions;
 import org.apache.sysml.utils.Statistics;
 
+public class VariableCPInstruction extends CPInstruction {
 
-public class VariableCPInstruction extends CPInstruction 
-{
-	
 	/*
 	 * Supported Operations
 	 * --------------------
@@ -118,9 +116,9 @@ public class VariableCPInstruction extends CPInstruction
 	static {
 		_uniqueVarID  = new IDSequence(true); 
 	}
-	
-	public VariableCPInstruction (VariableOperationCode op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, int _arity, String sopcode, String istr )
-	{
+
+	private VariableCPInstruction(VariableOperationCode op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			int _arity, String sopcode, String istr) {
 		super(sopcode, istr);
 		_cptype = CPINSTRUCTION_TYPE.Variable;
 		opcode = op;
@@ -129,30 +127,31 @@ public class VariableCPInstruction extends CPInstruction
 		addInput(in2);
 		addInput(in3);
 		output = out;
-		
+
 		_formatProperties = null;
 		_schema = null;
 	}
 
 	// This version of the constructor is used only in case of CreateVariable
-	public VariableCPInstruction (VariableOperationCode op, CPOperand in1, CPOperand in2, CPOperand in3, MetaData md, UpdateType updateType, int _arity, String schema, String sopcode, String istr)
-	{
-		this(op, in1, in2, in3, (CPOperand)null, _arity, sopcode, istr);
+	private VariableCPInstruction(VariableOperationCode op, CPOperand in1, CPOperand in2, CPOperand in3, MetaData md,
+			UpdateType updateType, int _arity, String schema, String sopcode, String istr) {
+		this(op, in1, in2, in3, (CPOperand) null, _arity, sopcode, istr);
 		metadata = md;
-		_updateType = updateType;		
+		_updateType = updateType;
 		_schema = schema;
 	}
-	
+
 	// This version of the constructor is used only in case of CreateVariable
-	public VariableCPInstruction (VariableOperationCode op, CPOperand in1, CPOperand in2, CPOperand in3, MetaData md, UpdateType updateType, int _arity, FileFormatProperties formatProperties, String schema, String sopcode, String istr)
-	{
-		this(op, in1, in2, in3, (CPOperand)null, _arity, sopcode, istr);
+	private VariableCPInstruction(VariableOperationCode op, CPOperand in1, CPOperand in2, CPOperand in3, MetaData md,
+			UpdateType updateType, int _arity, FileFormatProperties formatProperties, String schema, String sopcode,
+			String istr) {
+		this(op, in1, in2, in3, (CPOperand) null, _arity, sopcode, istr);
 		metadata = md;
-		_updateType = updateType;  
+		_updateType = updateType;
 		_formatProperties = formatProperties;
 		_schema = schema;
 	}
-	
+
 	private static VariableOperationCode getVariableOperationCode ( String str ) throws DMLRuntimeException {
 		
 		if ( str.equalsIgnoreCase("createvar"))

--- a/src/main/java/org/apache/sysml/runtime/instructions/cpfile/MatrixIndexingCPFileInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cpfile/MatrixIndexingCPFileInstruction.java
@@ -42,10 +42,11 @@ import org.apache.sysml.runtime.util.MapReduceTool;
  * COLWISE partition formats. 
  * 
  */
-public final class MatrixIndexingCPFileInstruction extends IndexingCPInstruction 
-{
-	public MatrixIndexingCPFileInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr) {
-		super( op, in, rl, ru, cl, cu, out, opcode, istr );
+public final class MatrixIndexingCPFileInstruction extends IndexingCPInstruction {
+
+	private MatrixIndexingCPFileInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl,
+			CPOperand cu, CPOperand out, String opcode, String istr) {
+		super(op, in, rl, ru, cl, cu, out, opcode, istr);
 	}
 
 	public static MatrixIndexingCPFileInstruction parseInstruction ( String str ) 

--- a/src/main/java/org/apache/sysml/runtime/instructions/cpfile/ParameterizedBuiltinCPFileInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cpfile/ParameterizedBuiltinCPFileInstruction.java
@@ -76,11 +76,10 @@ import org.apache.sysml.runtime.util.MapReduceTool;
  * parallel version due to data-dependent row- and column dependencies.
  * 
  */
-public class ParameterizedBuiltinCPFileInstruction extends ParameterizedBuiltinCPInstruction 
-{	
-	
-	public ParameterizedBuiltinCPFileInstruction(Operator op, HashMap<String, String> paramsMap, CPOperand out, String opcode, String istr) 
-	{
+public class ParameterizedBuiltinCPFileInstruction extends ParameterizedBuiltinCPInstruction {
+
+	private ParameterizedBuiltinCPFileInstruction(Operator op, HashMap<String, String> paramsMap, CPOperand out,
+			String opcode, String istr) {
 		super(op, paramsMap, out, opcode, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/AggregateBinaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/AggregateBinaryGPUInstruction.java
@@ -34,17 +34,15 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysml.utils.GPUStatistics;
 
-public class AggregateBinaryGPUInstruction extends GPUInstruction
-{
+public class AggregateBinaryGPUInstruction extends GPUInstruction {
 	private CPOperand _input1 = null;
 	private CPOperand _input2 = null;
 	private CPOperand _output = null;
 	private boolean _isLeftTransposed;
 	private boolean _isRightTransposed;
-	
-	public AggregateBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, 
-			String opcode, String istr, boolean leftTranspose, boolean rightTranspose) 
-	{
+
+	private AggregateBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr, boolean leftTranspose, boolean rightTranspose) {
 		super(op, opcode, istr);
 		_gputype = GPUINSTRUCTION_TYPE.AggregateBinary;
 		_input1 = in1;

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/AggregateUnaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/AggregateUnaryGPUInstruction.java
@@ -36,17 +36,15 @@ import org.apache.sysml.utils.GPUStatistics;
  * Implements aggregate unary instructions for CUDA
  */
 public class AggregateUnaryGPUInstruction extends GPUInstruction {
-  private CPOperand _input1 = null;
-  private CPOperand _output = null;
+	private CPOperand _input1 = null;
+	private CPOperand _output = null;
 
-  public AggregateUnaryGPUInstruction(Operator op, CPOperand in1, CPOperand out,
-                                       String opcode, String istr)
-  {
-    super(op, opcode, istr);
-    _gputype = GPUINSTRUCTION_TYPE.AggregateUnary;
-    _input1 = in1;
-    _output = out;
-  }
+	private AggregateUnaryGPUInstruction(Operator op, CPOperand in1, CPOperand out, String opcode, String istr) {
+		super(op, opcode, istr);
+		_gputype = GPUINSTRUCTION_TYPE.AggregateUnary;
+		_input1 = in1;
+		_output = out;
+	}
 
   public static AggregateUnaryGPUInstruction parseInstruction(String str )
           throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ArithmeticBinaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ArithmeticBinaryGPUInstruction.java
@@ -26,19 +26,19 @@ import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
 public abstract class ArithmeticBinaryGPUInstruction extends GPUInstruction {
-
 	protected CPOperand _input1;
 	protected CPOperand _input2;
 	protected CPOperand _output;
 
-	public ArithmeticBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
+	protected ArithmeticBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, opcode, istr);
 		_gputype = GPUINSTRUCTION_TYPE.ArithmeticBinary;
 		_input1 = in1;
 		_input2 = in2;
-	    _output = out;
+		_output = out;
 	}
-	
+
 	public static ArithmeticBinaryGPUInstruction parseInstruction ( String str ) throws DMLRuntimeException {
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
 		InstructionUtils.checkNumFields ( parts, 3 );

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinBinaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinBinaryGPUInstruction.java
@@ -29,21 +29,20 @@ import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
 public abstract class BuiltinBinaryGPUInstruction extends GPUInstruction {
+	@SuppressWarnings("unused")
+	private int _arity;
 
-  @SuppressWarnings("unused")
-  private int _arity;
+	CPOperand output;
+	CPOperand input1, input2;
 
-  CPOperand output;
-  CPOperand input1, input2;
-
-
-  public BuiltinBinaryGPUInstruction(Operator op, CPOperand input1, CPOperand input2, CPOperand output, String opcode, String istr, int _arity) {
-    super(op, opcode, istr);
-    this._arity = _arity;
-    this.output = output;
-    this.input1 = input1;
-    this.input2 = input2;
-  }
+	protected BuiltinBinaryGPUInstruction(Operator op, CPOperand input1, CPOperand input2, CPOperand output,
+			String opcode, String istr, int _arity) {
+		super(op, opcode, istr);
+		this._arity = _arity;
+		this.output = output;
+		this.input1 = input1;
+		this.input2 = input2;
+	}
 
   public static BuiltinBinaryGPUInstruction parseInstruction(String str) throws DMLRuntimeException {
     CPOperand in1 = new CPOperand("", Expression.ValueType.UNKNOWN, Expression.DataType.UNKNOWN);

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinUnaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinUnaryGPUInstruction.java
@@ -30,15 +30,13 @@ import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
-public abstract class BuiltinUnaryGPUInstruction  extends GPUInstruction {
-
-
+public abstract class BuiltinUnaryGPUInstruction extends GPUInstruction {
 	int _arity;
 	CPOperand _input;
 	CPOperand _output;
-	
-	public BuiltinUnaryGPUInstruction(Operator op, CPOperand in, CPOperand out, int _arity, String opcode, String istr )
-	{
+
+	protected BuiltinUnaryGPUInstruction(Operator op, CPOperand in, CPOperand out, int _arity, String opcode,
+			String istr) {
 		super(op, opcode, istr);
 		_gputype = GPUINSTRUCTION_TYPE.BuiltinUnary;
 		this._arity = _arity;

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
@@ -31,45 +31,43 @@ import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysml.runtime.util.ConvolutionUtils;
 import org.apache.sysml.utils.GPUStatistics;
 
-public class ConvolutionGPUInstruction extends GPUInstruction 
-{
-	private CPOperand _input1; 
-	private CPOperand _input2; 
-	private CPOperand _input3; 
-	private CPOperand _output; 
+public class ConvolutionGPUInstruction extends GPUInstruction {
+	private CPOperand _input1;
+	private CPOperand _input2;
+	private CPOperand _input3;
+	private CPOperand _output;
 	private ArrayList<CPOperand> _input_shape;
 	private ArrayList<CPOperand> _filter_shape;
 	private ArrayList<CPOperand> _stride = new ArrayList<CPOperand>();
 	private ArrayList<CPOperand> _padding = new ArrayList<CPOperand>();
-	
-	public ConvolutionGPUInstruction(CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) throws DMLRuntimeException {
+
+	private ConvolutionGPUInstruction(CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr)
+			throws DMLRuntimeException {
 		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), opcode, istr);
-		if(!(opcode.equals("bias_add") || opcode.equals("bias_multiply") || opcode.equals("relu_backward"))) {
-			throw new DMLRuntimeException("Incorrect usage. Expected the opcode to be bias_add or bias_multiply or relu_backward, but found " + opcode);
+		if (!(opcode.equals("bias_add") || opcode.equals("bias_multiply") || opcode.equals("relu_backward"))) {
+			throw new DMLRuntimeException(
+					"Incorrect usage. Expected the opcode to be bias_add or bias_multiply or relu_backward, but found "
+							+ opcode);
 		}
 		_input1 = in1;
 		_input2 = in2;
 		_gputype = GPUINSTRUCTION_TYPE.Convolution;
 		_output = out;
 	}
-	
-	public ConvolutionGPUInstruction(CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, String opcode,
-			String istr, ArrayList<CPOperand> stride,
-			ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
-			ArrayList<CPOperand> filter_shape) 
-	{
-		this(in1, in2, out, opcode, istr, stride, padding,  input_shape, filter_shape);
+
+	private ConvolutionGPUInstruction(CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, String opcode,
+			String istr, ArrayList<CPOperand> stride, ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
+			ArrayList<CPOperand> filter_shape) {
+		this(in1, in2, out, opcode, istr, stride, padding, input_shape, filter_shape);
 		_input3 = in3;
 	}
-	
-	public ConvolutionGPUInstruction(CPOperand in1, CPOperand in2, CPOperand out, String opcode,
-			String istr, ArrayList<CPOperand> stride,
-			ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
-			ArrayList<CPOperand> filter_shape) 
-	{
+
+	private ConvolutionGPUInstruction(CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr,
+			ArrayList<CPOperand> stride, ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
+			ArrayList<CPOperand> filter_shape) {
 		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), opcode, istr);
 		_gputype = GPUINSTRUCTION_TYPE.Convolution;
-		
+
 		_input1 = in1;
 		_input2 = in2;
 		_output = out;
@@ -78,7 +76,7 @@ public class ConvolutionGPUInstruction extends GPUInstruction
 		_input_shape = input_shape;
 		_filter_shape = filter_shape;
 	}
-	
+
 	public static ConvolutionGPUInstruction parseInstruction(String str)
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
@@ -30,8 +30,7 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.utils.GPUStatistics;
 import org.apache.sysml.utils.Statistics;
 
-public abstract class GPUInstruction extends Instruction
-{
+public abstract class GPUInstruction extends Instruction {
 	public enum GPUINSTRUCTION_TYPE {
 		AggregateUnary,
 		AggregateBinary,
@@ -130,22 +129,21 @@ public abstract class GPUInstruction extends Instruction
 	public final static String MISC_TIMER_CUDNN_INIT =                     "nni";   // time spent in initializations for cudnn call
 	public final static String MISC_TIMER_CUDNN_CLEANUP =                  "nnc";   // time spent in cleanup for cudnn call
 
-
 	protected GPUINSTRUCTION_TYPE _gputype;
 	protected Operator _optr;
 
 	protected boolean _requiresLabelUpdate = false;
 
-	public GPUInstruction(String opcode, String istr) {
+	private GPUInstruction(String opcode, String istr) {
 		type = INSTRUCTION_TYPE.GPU;
 		instString = istr;
 
-		//prepare opcode and update requirement for repeated usage
+		// prepare opcode and update requirement for repeated usage
 		instOpcode = opcode;
 		_requiresLabelUpdate = super.requiresLabelUpdate();
 	}
 
-	public GPUInstruction(Operator op, String opcode, String istr) {
+	protected GPUInstruction(Operator op, String opcode, String istr) {
 		this(opcode, istr);
 		_optr = op;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MMTSJGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MMTSJGPUInstruction.java
@@ -36,32 +36,34 @@ import org.apache.sysml.runtime.matrix.data.LibMatrixCUDA;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.utils.GPUStatistics;
 
-public class MMTSJGPUInstruction extends GPUInstruction
-{
+public class MMTSJGPUInstruction extends GPUInstruction {
+	private MMTSJType _type = null;
+	CPOperand _input;
+	CPOperand _output;
 
-        private MMTSJType _type = null;
-        
-        CPOperand _input;
-        CPOperand _output;
-
-        /**
-         * MMTSJGPUInstruction constructor.
-         * 
-         * @param op	operator
-         * @param in1	input
-         * @param type	left/right, left-&gt; A' %*% A, right-&gt; A %*% A'
-         * @param out	output
-         * @param opcode the opcode
-         * @param istr ?
-         */
-        public MMTSJGPUInstruction(Operator op, CPOperand in1, MMTSJType type, CPOperand out,  String opcode, String istr)
-        {
-                super(op, opcode, istr);
-                _gputype = GPUINSTRUCTION_TYPE.MMTSJ;
-                _type = type;
-                _input = in1;
-                _output = out;
-        }
+	/**
+	 * MMTSJGPUInstruction constructor.
+	 * 
+	 * @param op
+	 *            operator
+	 * @param in1
+	 *            input
+	 * @param type
+	 *            left/right, left-&gt; A' %*% A, right-&gt; A %*% A'
+	 * @param out
+	 *            output
+	 * @param opcode
+	 *            the opcode
+	 * @param istr
+	 *            ?
+	 */
+	private MMTSJGPUInstruction(Operator op, CPOperand in1, MMTSJType type, CPOperand out, String opcode, String istr) {
+		super(op, opcode, istr);
+		_gputype = GPUINSTRUCTION_TYPE.MMTSJ;
+		_type = type;
+		_input = in1;
+		_output = out;
+	}
 
         /**
          * parse MMTSJ GPU instruction

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixAppendGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixAppendGPUInstruction.java
@@ -41,7 +41,8 @@ public class MatrixAppendGPUInstruction extends GPUInstruction {
 	CPOperand input1, input2;
 	AppendCPInstruction.AppendType type;
 
-	public MatrixAppendGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,  AppendCPInstruction.AppendType type, String opcode, String istr) {
+	private MatrixAppendGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			AppendCPInstruction.AppendType type, String opcode, String istr) {
 		super(op, opcode, istr);
 		this.output = out;
 		this.input1 = in1;

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixBuiltinGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixBuiltinGPUInstruction.java
@@ -28,8 +28,8 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.utils.GPUStatistics;
 
 public class MatrixBuiltinGPUInstruction extends BuiltinUnaryGPUInstruction {
-	
-	public MatrixBuiltinGPUInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr){
+
+	protected MatrixBuiltinGPUInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr) {
 		super(op, in, out, 1, opcode, instr);
 		_gputype = GPUINSTRUCTION_TYPE.BuiltinUnary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixIndexingGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixIndexingGPUInstruction.java
@@ -32,10 +32,12 @@ import org.apache.sysml.utils.GPUStatistics;
 
 public class MatrixIndexingGPUInstruction extends GPUInstruction {
 	CPOperand rowLower, rowUpper, colLower, colUpper;
-	CPOperand input1; CPOperand input2; CPOperand output;
-	
-	public MatrixIndexingGPUInstruction(Operator op, CPOperand in, 
-			CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr){
+	CPOperand input1;
+	CPOperand input2;
+	CPOperand output;
+
+	private MatrixIndexingGPUInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl,
+			CPOperand cu, CPOperand out, String opcode, String istr) {
 		super(op, opcode, istr);
 		_gputype = GPUINSTRUCTION_TYPE.MatrixIndexing;
 		rowLower = rl;
@@ -45,9 +47,9 @@ public class MatrixIndexingGPUInstruction extends GPUInstruction {
 		input1 = in;
 		output = out;
 	}
-	
-	public MatrixIndexingGPUInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, 
-			CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr){
+
+	private MatrixIndexingGPUInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl,
+			CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr) {
 		super(op, opcode, istr);
 		_gputype = GPUINSTRUCTION_TYPE.MatrixIndexing;
 		rowLower = rl;
@@ -58,7 +60,7 @@ public class MatrixIndexingGPUInstruction extends GPUInstruction {
 		input2 = rhsInput;
 		output = out;
 	}
-	
+
 	public static MatrixIndexingGPUInstruction parseInstruction ( String str ) throws DMLRuntimeException {
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
 		String opcode = parts[0];

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixArithmeticGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixArithmeticGPUInstruction.java
@@ -28,18 +28,13 @@ import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.utils.GPUStatistics;
 
-public class MatrixMatrixArithmeticGPUInstruction extends ArithmeticBinaryGPUInstruction
-{
-	
-	public MatrixMatrixArithmeticGPUInstruction(Operator op, 
-											   CPOperand in1, 
-											   CPOperand in2, 
-											   CPOperand out, 
-											   String opcode,
-											   String istr){
+public class MatrixMatrixArithmeticGPUInstruction extends ArithmeticBinaryGPUInstruction {
+
+	protected MatrixMatrixArithmeticGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) throws DMLRuntimeException {
 		GPUStatistics.incrementNoOfExecutedGPUInst();

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixAxpyGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixAxpyGPUInstruction.java
@@ -30,24 +30,17 @@ import org.apache.sysml.runtime.matrix.data.LibMatrixCUDA;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.utils.GPUStatistics;
 
-public class MatrixMatrixAxpyGPUInstruction extends ArithmeticBinaryGPUInstruction
-{
-	
+public class MatrixMatrixAxpyGPUInstruction extends ArithmeticBinaryGPUInstruction {
 	CPOperand constant = null;
 	int multiplier = 1;
-	public MatrixMatrixAxpyGPUInstruction(Operator op, 
-			   CPOperand in1, 
-			   CPOperand constant, 
-			   int multiplier,
-			   CPOperand in2, 
-			   CPOperand out, 
-			   String opcode,
-			   String istr){
+
+	private MatrixMatrixAxpyGPUInstruction(Operator op, CPOperand in1, CPOperand constant, int multiplier,
+			CPOperand in2, CPOperand out, String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		this.constant = constant;
 		this.multiplier = multiplier;
 	}
-	
+
 	public static MatrixMatrixAxpyGPUInstruction parseInstruction ( String str ) throws DMLRuntimeException {
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
 		InstructionUtils.checkNumFields ( parts, 4 );

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixBuiltinGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixBuiltinGPUInstruction.java
@@ -27,14 +27,13 @@ import org.apache.sysml.runtime.matrix.data.LibMatrixCUDA;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.utils.GPUStatistics;
 
-
 public class MatrixMatrixBuiltinGPUInstruction extends BuiltinBinaryGPUInstruction {
 
-  public MatrixMatrixBuiltinGPUInstruction(Operator op, CPOperand input1, CPOperand input2, CPOperand output, String opcode, String istr, int _arity) {
-    super(op, input1, input2, output, opcode, istr, _arity);
-    _gputype = GPUINSTRUCTION_TYPE.BuiltinUnary;
-
-  }
+	protected MatrixMatrixBuiltinGPUInstruction(Operator op, CPOperand input1, CPOperand input2, CPOperand output,
+			String opcode, String istr, int _arity) {
+		super(op, input1, input2, output, opcode, istr, _arity);
+		_gputype = GPUINSTRUCTION_TYPE.BuiltinUnary;
+	}
 
   @Override
   public void processInstruction(ExecutionContext ec) throws DMLRuntimeException {

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixRelationalBinaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixMatrixRelationalBinaryGPUInstruction.java
@@ -30,7 +30,7 @@ import org.apache.sysml.utils.GPUStatistics;
 
 public class MatrixMatrixRelationalBinaryGPUInstruction extends RelationalBinaryGPUInstruction {
 
-	public MatrixMatrixRelationalBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+	protected MatrixMatrixRelationalBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
 			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/RelationalBinaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/RelationalBinaryGPUInstruction.java
@@ -31,7 +31,8 @@ public abstract class RelationalBinaryGPUInstruction extends GPUInstruction {
 	protected CPOperand _input2;
 	protected CPOperand _output;
 
-	public RelationalBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
+	protected RelationalBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, opcode, istr);
 		_gputype = GPUINSTRUCTION_TYPE.RelationalBinary;
 		_input1 = in1;

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ReorgGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ReorgGPUInstruction.java
@@ -30,27 +30,31 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysml.utils.GPUStatistics;
 
+public class ReorgGPUInstruction extends GPUInstruction {
+	private CPOperand _input;
+	private CPOperand _output;
 
-public class ReorgGPUInstruction extends GPUInstruction
-{
- 	private CPOperand _input;
-    private CPOperand _output;
- 	/**
- 	 * for opcodes r'
- 	 * 
- 	 * @param op operator
- 	 * @param in input operand
- 	 * @param out output operand
- 	 * @param opcode the opcode
- 	 * @param istr instruction string
- 	 */
-	public ReorgGPUInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
+	/**
+	 * for opcodes r'
+	 * 
+	 * @param op
+	 *            operator
+	 * @param in
+	 *            input operand
+	 * @param out
+	 *            output operand
+	 * @param opcode
+	 *            the opcode
+	 * @param istr
+	 *            instruction string
+	 */
+	private ReorgGPUInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		super(op, opcode, istr);
 		_gputype = GPUINSTRUCTION_TYPE.Reorg;
 		_input = in;
-        _output = out;
+		_output = out;
 	}
-	
+
 	public static ReorgGPUInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ScalarMatrixArithmeticGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ScalarMatrixArithmeticGPUInstruction.java
@@ -31,15 +31,12 @@ import org.apache.sysml.runtime.matrix.operators.ScalarOperator;
 import org.apache.sysml.utils.GPUStatistics;
 
 public class ScalarMatrixArithmeticGPUInstruction extends ArithmeticBinaryGPUInstruction {
-	public ScalarMatrixArithmeticGPUInstruction(Operator op, 
-			   									CPOperand in1, 
-			   									CPOperand in2, 
-			   									CPOperand out, 
-			   									String opcode,
-			   									String istr){
+
+	protected ScalarMatrixArithmeticGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ScalarMatrixRelationalBinaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ScalarMatrixRelationalBinaryGPUInstruction.java
@@ -32,7 +32,7 @@ import org.apache.sysml.utils.GPUStatistics;
 
 public class ScalarMatrixRelationalBinaryGPUInstruction extends RelationalBinaryGPUInstruction {
 
-	public ScalarMatrixRelationalBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+	protected ScalarMatrixRelationalBinaryGPUInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
 			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/AggregateBinaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/AggregateBinaryInstruction.java
@@ -39,24 +39,21 @@ import org.apache.sysml.runtime.matrix.operators.AggregateBinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class AggregateBinaryInstruction extends BinaryMRInstructionBase implements IDistributedCacheConsumer
-{	
+public class AggregateBinaryInstruction extends BinaryMRInstructionBase implements IDistributedCacheConsumer {
 	private String _opcode = null;
-	
-	//optional argument for cpmm
+
+	// optional argument for cpmm
 	private MMCJType _aggType = MMCJType.AGG;
-	
-	//optional argument for mapmm
+
+	// optional argument for mapmm
 	private CacheType _cacheType = null;
 	private boolean _outputEmptyBlocks = true;
-	
-	public AggregateBinaryInstruction(Operator op, String opcode, byte in1, byte in2, byte out, String istr)
-	{
+
+	private AggregateBinaryInstruction(Operator op, String opcode, byte in1, byte in2, byte out, String istr) {
 		super(op, in1, in2, out);
 		mrtype = MRINSTRUCTION_TYPE.AggregateBinary;
 		instString = istr;
-		
+
 		_opcode = opcode;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/AggregateInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/AggregateInstruction.java
@@ -27,17 +27,14 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class AggregateInstruction extends UnaryMRInstructionBase {
 
-public class AggregateInstruction extends UnaryMRInstructionBase 
-{
-		
-	public AggregateInstruction(Operator op, byte in, byte out, String istr)
-	{
+	public AggregateInstruction(Operator op, byte in, byte out, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.Aggregate;
 		instString = istr;
 	}
-	
+
 	public static AggregateInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{	

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/AggregateUnaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/AggregateUnaryInstruction.java
@@ -33,18 +33,14 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class AggregateUnaryInstruction extends UnaryMRInstructionBase 
-{
-	
+public class AggregateUnaryInstruction extends UnaryMRInstructionBase {
 	private boolean _dropCorr = false;
-	
-	public AggregateUnaryInstruction(Operator op, byte in, byte out, boolean dropCorr, String istr)
-	{
+
+	protected AggregateUnaryInstruction(Operator op, byte in, byte out, boolean dropCorr, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.AggregateUnary;
 		instString = istr;
-		
+
 		_dropCorr = dropCorr;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/AppendGInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/AppendGInstruction.java
@@ -30,15 +30,13 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class AppendGInstruction extends AppendInstruction 
-{
-	private long _offset = -1; //cols of input1 
-	private long _offset2 = -1; //cols of input2
+public class AppendGInstruction extends AppendInstruction {
+	private long _offset = -1; // cols of input1
+	private long _offset2 = -1; // cols of input2
 	private long _len = -1;
-	
-	public AppendGInstruction(Operator op, byte in1, byte in2, long offset, long offset2, byte out, boolean cbind, String istr)
-	{
+
+	private AppendGInstruction(Operator op, byte in1, byte in2, long offset, long offset2, byte out, boolean cbind,
+			String istr) {
 		super(op, in1, in2, out, cbind, istr);
 		_offset = offset;
 		_offset2 = offset2;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/AppendInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/AppendInstruction.java
@@ -27,15 +27,12 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class AppendInstruction extends BinaryMRInstructionBase 
-{
+public class AppendInstruction extends BinaryMRInstructionBase {
 	protected boolean _cbind = true;
 
-	public AppendInstruction(Operator op, byte in1, byte in2, byte out, boolean cbind, String istr)
-	{
+	protected AppendInstruction(Operator op, byte in1, byte in2, byte out, boolean cbind, String istr) {
 		super(op, in1, in2, out);
-		instString = istr;	
+		instString = istr;
 		mrtype = MRINSTRUCTION_TYPE.Append;
 		_cbind = cbind;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/AppendMInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/AppendMInstruction.java
@@ -33,17 +33,15 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.mapred.MRBaseForCommonInstructions;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class AppendMInstruction extends AppendInstruction implements IDistributedCacheConsumer {
+	private long _offset = -1;
 
-public class AppendMInstruction extends AppendInstruction implements IDistributedCacheConsumer
-{	
-	private long _offset = -1; 
-	
-	public AppendMInstruction(Operator op, byte in1, byte in2, long offset, CacheType type, byte out, boolean cbind, String istr)
-	{
+	private AppendMInstruction(Operator op, byte in1, byte in2, long offset, CacheType type, byte out, boolean cbind,
+			String istr) {
 		super(op, in1, in2, out, cbind, istr);
 		_offset = offset;
 	}
-	
+
 	public static AppendMInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/AppendRInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/AppendRInstruction.java
@@ -27,10 +27,8 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class AppendRInstruction extends AppendInstruction 
-{
-	public AppendRInstruction(Operator op, byte in1, byte in2, byte out, boolean cbind, String istr)
-	{
+public class AppendRInstruction extends AppendInstruction {
+	private AppendRInstruction(Operator op, byte in1, byte in2, byte out, boolean cbind, String istr) {
 		super(op, in1, in2, out, cbind, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/BinUaggChainInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/BinUaggChainInstruction.java
@@ -32,27 +32,25 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 
-public class BinUaggChainInstruction extends UnaryInstruction 
-{
-	
-	//operators
+public class BinUaggChainInstruction extends UnaryInstruction {
+	// operators
 	private BinaryOperator _bOp = null;
 	private AggregateUnaryOperator _uaggOp = null;
-	
-	//reused intermediates  
+
+	// reused intermediates
 	private MatrixIndexes _tmpIx = null;
 	private MatrixValue _tmpVal = null;
 
-	public BinUaggChainInstruction(BinaryOperator bop, AggregateUnaryOperator uaggop, byte in1, byte out, String istr)
-	{
+	private BinUaggChainInstruction(BinaryOperator bop, AggregateUnaryOperator uaggop, byte in1, byte out,
+			String istr) {
 		super(null, in1, out, istr);
-		
+
 		_bOp = bop;
 		_uaggOp = uaggop;
-		
+
 		_tmpIx = new MatrixIndexes();
 		_tmpVal = new MatrixBlock();
-		
+
 		mrtype = MRINSTRUCTION_TYPE.BinUaggChain;
 		instString = istr;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/BinaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/BinaryInstruction.java
@@ -29,17 +29,14 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class BinaryInstruction extends BinaryMRInstructionBase {
 
-public class BinaryInstruction extends BinaryMRInstructionBase 
-{
-	
-	public BinaryInstruction(Operator op, byte in1, byte in2, byte out, String istr)
-	{
+	protected BinaryInstruction(Operator op, byte in1, byte in2, byte out, String istr) {
 		super(op, in1, in2, out);
 		mrtype = MRINSTRUCTION_TYPE.ArithmeticBinary;
 		instString = istr;
 	}
-	
+
 	public static BinaryInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{	

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/BinaryMInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/BinaryMInstruction.java
@@ -34,17 +34,15 @@ import org.apache.sysml.runtime.matrix.mapred.MRBaseForCommonInstructions;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class BinaryMInstruction extends BinaryMRInstructionBase implements IDistributedCacheConsumer
-{	
+public class BinaryMInstruction extends BinaryMRInstructionBase implements IDistributedCacheConsumer {
 	private VectorType _vectorType = null;
-	
-	public BinaryMInstruction(Operator op, byte in1, byte in2, CacheType ctype, VectorType vtype, byte out, String istr)
-	{
+
+	private BinaryMInstruction(Operator op, byte in1, byte in2, CacheType ctype, VectorType vtype, byte out,
+			String istr) {
 		super(op, in1, in2, out);
 		mrtype = MRINSTRUCTION_TYPE.ArithmeticBinary;
 		instString = istr;
-		
+
 		_vectorType = vtype;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/BinaryMRInstructionBase.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/BinaryMRInstructionBase.java
@@ -21,18 +21,15 @@ package org.apache.sysml.runtime.instructions.mr;
 
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public abstract class BinaryMRInstructionBase extends MRInstruction 
-{
-	
+public abstract class BinaryMRInstructionBase extends MRInstruction {
 	public byte input1, input2;
-	
-	public BinaryMRInstructionBase(Operator op, byte in1, byte in2, byte out)
-	{
+
+	protected BinaryMRInstructionBase(Operator op, byte in1, byte in2, byte out) {
 		super(op, out);
-		input1=in1;
-		input2=in2;
+		input1 = in1;
+		input2 = in2;
 	}
-	
+
 	@Override
 	public byte[] getInputIndexes() {
 		return new byte[]{input1, input2};

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/CM_N_COVInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/CM_N_COVInstruction.java
@@ -31,17 +31,14 @@ import org.apache.sysml.runtime.matrix.operators.COVOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.CMOperator.AggregateOperationTypes;
 
+public class CM_N_COVInstruction extends UnaryMRInstructionBase {
 
-public class CM_N_COVInstruction extends UnaryMRInstructionBase 
-{
-	
-	public CM_N_COVInstruction(Operator op, byte in, byte out, String istr)
-	{
+	private CM_N_COVInstruction(Operator op, byte in, byte out, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.CM_N_COV;
 		instString = istr;
 	}
-	
+
 	public static CM_N_COVInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{	

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/CSVReblockInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/CSVReblockInstruction.java
@@ -23,21 +23,19 @@ import org.apache.sysml.parser.DataExpression;
 import org.apache.sysml.runtime.instructions.Instruction;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class CSVReblockInstruction extends ReblockInstruction 
-{
-	
-	public String  delim     = DataExpression.DEFAULT_DELIM_DELIMITER;
+public class CSVReblockInstruction extends ReblockInstruction {
+	public String delim = DataExpression.DEFAULT_DELIM_DELIMITER;
 	public boolean hasHeader = DataExpression.DEFAULT_DELIM_HAS_HEADER_ROW;
-	public boolean fill      = DataExpression.DEFAULT_DELIM_FILL;
-	public double  fillValue = DataExpression.DEFAULT_DELIM_FILL_VALUE;
+	public boolean fill = DataExpression.DEFAULT_DELIM_FILL;
+	public double fillValue = DataExpression.DEFAULT_DELIM_FILL_VALUE;
 
-	public CSVReblockInstruction(Operator op, byte in, byte out, int br,
-			int bc, boolean hasHeader, String delim, boolean fll, double mv, String istr) {
+	private CSVReblockInstruction(Operator op, byte in, byte out, int br, int bc, boolean hasHeader, String delim,
+			boolean fll, double mv, String istr) {
 		super(op, in, out, br, bc, false, istr);
-		this.delim=delim;
-		this.fill=fll;
-		this.fillValue=mv;
-		this.hasHeader=hasHeader;
+		this.delim = delim;
+		this.fill = fll;
+		this.fillValue = mv;
+		this.hasHeader = hasHeader;
 	}
 
 	public Instruction clone(byte in) 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/CSVWriteInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/CSVWriteInstruction.java
@@ -27,13 +27,11 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class CSVWriteInstruction extends UnaryMRInstructionBase{
+public class CSVWriteInstruction extends UnaryMRInstructionBase {
+	public String delim = DataExpression.DEFAULT_DELIM_DELIMITER;
+	public String header = null;// if null or empty string, then no header
+	public boolean sparse = DataExpression.DEFAULT_DELIM_SPARSE;
 
-	
-	public String delim= DataExpression.DEFAULT_DELIM_DELIMITER;
-	public String header=null;//if null or empty string, then no header
-	public boolean sparse=DataExpression.DEFAULT_DELIM_SPARSE;
-	
 	public CSVWriteInstruction(Operator op, byte in, byte out, String del, String hdr, boolean sps, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.CSVWrite;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/CombineBinaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/CombineBinaryInstruction.java
@@ -26,17 +26,15 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class CombineBinaryInstruction extends BinaryMRInstructionBase
-{
-	
+public class CombineBinaryInstruction extends BinaryMRInstructionBase {
 	/*
 	 * combinebinary:::0:DOUBLE:::1:INT:::2:INT
 	 */
-	private boolean secondInputIsWeight=true;
-	public CombineBinaryInstruction(Operator op, boolean isWeight, byte in1, byte in2, byte out, String istr) {
+	private boolean secondInputIsWeight = true;
+
+	private CombineBinaryInstruction(Operator op, boolean isWeight, byte in1, byte in2, byte out, String istr) {
 		super(op, in1, in2, out);
-		secondInputIsWeight=isWeight;
+		secondInputIsWeight = isWeight;
 		mrtype = MRINSTRUCTION_TYPE.CombineBinary;
 		instString = istr;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/CombineTernaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/CombineTernaryInstruction.java
@@ -26,12 +26,9 @@ import org.apache.sysml.runtime.matrix.data.MatrixValue;
 import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 
+public class CombineTernaryInstruction extends TernaryInstruction {
 
-public class CombineTernaryInstruction extends TernaryInstruction
-{
-	
-	public CombineTernaryInstruction(OperationTypes op, byte in1, byte in2,
-			byte in3, byte out, String istr) {
+	private CombineTernaryInstruction(OperationTypes op, byte in1, byte in2, byte in3, byte out, String istr) {
 		super(op, in1, in2, in3, out, -1, -1, istr);
 		mrtype = MRINSTRUCTION_TYPE.CombineTernary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/CombineUnaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/CombineUnaryInstruction.java
@@ -26,14 +26,12 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class CombineUnaryInstruction extends UnaryMRInstructionBase {
 
-public class CombineUnaryInstruction extends UnaryMRInstructionBase
-{
-	
 	/*
 	 * combineunary:::0:DOUBLE:::1:DOUBLE
 	 */
-	public CombineUnaryInstruction(Operator op, byte in, byte out, String istr) {
+	private CombineUnaryInstruction(Operator op, byte in, byte out, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.CombineUnary;
 		instString = istr;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/CumulativeAggregateInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/CumulativeAggregateInstruction.java
@@ -33,17 +33,13 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class CumulativeAggregateInstruction extends AggregateUnaryInstruction 
-{
-	
+public class CumulativeAggregateInstruction extends AggregateUnaryInstruction {
 	private MatrixCharacteristics _mcIn = null;
-	
-	public CumulativeAggregateInstruction(Operator op, byte in, byte out, String istr)
-	{
+
+	private CumulativeAggregateInstruction(Operator op, byte in, byte out, String istr) {
 		super(op, in, out, true, istr);
 	}
-	
+
 	public void setMatrixCharacteristics( MatrixCharacteristics mcIn )
 	{
 		_mcIn = mcIn;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/CumulativeOffsetInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/CumulativeOffsetInstruction.java
@@ -31,35 +31,28 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
-
-public class CumulativeOffsetInstruction extends BinaryInstruction 
-{
-	
+public class CumulativeOffsetInstruction extends BinaryInstruction {
 	private BinaryOperator _bop = null;
 	private UnaryOperator _uop = null;
-	
-	public CumulativeOffsetInstruction(byte in1, byte in2, byte out, String opcode, String istr)
-	{
+
+	private CumulativeOffsetInstruction(byte in1, byte in2, byte out, String opcode, String istr) {
 		super(null, in1, in2, out, istr);
 
-		if( "bcumoffk+".equals(opcode) ) {
+		if ("bcumoffk+".equals(opcode)) {
 			_bop = new BinaryOperator(Plus.getPlusFnObject());
 			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucumk+"));
-		}
-		else if( "bcumoff*".equals(opcode) ){
+		} else if ("bcumoff*".equals(opcode)) {
 			_bop = new BinaryOperator(Multiply.getMultiplyFnObject());
-			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucum*"));	
-		}
-		else if( "bcumoffmin".equals(opcode) ){
+			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucum*"));
+		} else if ("bcumoffmin".equals(opcode)) {
 			_bop = new BinaryOperator(Builtin.getBuiltinFnObject("min"));
-			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummin"));	
-		}
-		else if( "bcumoffmax".equals(opcode) ){
+			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummin"));
+		} else if ("bcumoffmax".equals(opcode)) {
 			_bop = new BinaryOperator(Builtin.getBuiltinFnObject("max"));
-			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummax"));	
+			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummax"));
 		}
 	}
-	
+
 	public static CumulativeOffsetInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/CumulativeSplitInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/CumulativeSplitInstruction.java
@@ -30,15 +30,12 @@ import org.apache.sysml.runtime.matrix.data.MatrixValue;
 import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 
-public class CumulativeSplitInstruction extends UnaryInstruction 
-{
-	
+public class CumulativeSplitInstruction extends UnaryInstruction {
 	private MatrixCharacteristics _mcIn = null;
 	private long _lastRowBlockIndex = -1;
 	private double _initValue = 0;
-	
-	public CumulativeSplitInstruction(byte in, byte out, double init, String istr)
-	{
+
+	private CumulativeSplitInstruction(byte in, byte out, double init, String istr) {
 		super(null, in, out, istr);
 		_initValue = init;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/DataGenMRInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/DataGenMRInstruction.java
@@ -22,9 +22,7 @@ package org.apache.sysml.runtime.instructions.mr;
 import org.apache.sysml.hops.Hop.DataGenMethod;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public abstract class DataGenMRInstruction extends MRInstruction 
-{
-	
+public abstract class DataGenMRInstruction extends MRInstruction {
 	protected DataGenMethod method;
 	protected byte input;
 	protected long rows;
@@ -32,19 +30,19 @@ public abstract class DataGenMRInstruction extends MRInstruction
 	protected int rowsInBlock;
 	protected int colsInBlock;
 	protected String baseDir;
-	
-	public DataGenMRInstruction(Operator op, DataGenMethod mthd, byte in, byte out, long r, long c, int rpb, int cpb, String dir)
-	{
+
+	protected DataGenMRInstruction(Operator op, DataGenMethod mthd, byte in, byte out, long r, long c, int rpb, int cpb,
+			String dir) {
 		super(op, out);
 		method = mthd;
-		input=in;
+		input = in;
 		rows = r;
 		cols = c;
 		rowsInBlock = rpb;
 		colsInBlock = cpb;
 		baseDir = dir;
 	}
-	
+
 	public DataGenMethod getDataGenMethod() {
 		return method;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/DataPartitionMRInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/DataPartitionMRInstruction.java
@@ -27,14 +27,12 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
  * Dummy instruction for cost estimation of data partition mr.
  * 
  */
-public class DataPartitionMRInstruction extends UnaryInstruction 
-{
-	
-	public DataPartitionMRInstruction(Operator op, byte in, byte out, String istr)
-	{
+public class DataPartitionMRInstruction extends UnaryInstruction {
+
+	private DataPartitionMRInstruction(Operator op, byte in, byte out, String istr) {
 		super(op, in, out, istr);
 	}
-	
+
 	public static DataPartitionMRInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/GroupedAggregateInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/GroupedAggregateInstruction.java
@@ -32,18 +32,16 @@ import org.apache.sysml.runtime.matrix.operators.CMOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.CMOperator.AggregateOperationTypes;
 
-
-public class GroupedAggregateInstruction extends UnaryMRInstructionBase
-{
+public class GroupedAggregateInstruction extends UnaryMRInstructionBase {
 	private boolean _weights = false;
 	private int _ngroups = -1;
 	private long _bclen = -1;
-	
-	public GroupedAggregateInstruction(Operator op, byte in, byte out, boolean weights, int ngroups, String istr) {
+
+	private GroupedAggregateInstruction(Operator op, byte in, byte out, boolean weights, int ngroups, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.GroupedAggregate;
 		instString = istr;
-		
+
 		_weights = weights;
 		_ngroups = ngroups;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/GroupedAggregateMInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/GroupedAggregateMInstruction.java
@@ -37,13 +37,10 @@ import org.apache.sysml.runtime.matrix.mapred.MRBaseForCommonInstructions;
 import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class GroupedAggregateMInstruction extends BinaryMRInstructionBase implements IDistributedCacheConsumer
-{	
+public class GroupedAggregateMInstruction extends BinaryMRInstructionBase implements IDistributedCacheConsumer {
 	private int _ngroups = -1;
-	
-	public GroupedAggregateMInstruction(Operator op, byte in1, byte in2, byte out, int ngroups, String istr)
-	{
+
+	private GroupedAggregateMInstruction(Operator op, byte in1, byte in2, byte out, int ngroups, String istr) {
 		super(op, in1, in2, out);
 		_ngroups = ngroups;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/MMTSJMRInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/MMTSJMRInstruction.java
@@ -30,17 +30,14 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MMTSJMRInstruction extends UnaryInstruction
-{	
-	
+public class MMTSJMRInstruction extends UnaryInstruction {
 	private MMTSJType _type = null;
 
-	public MMTSJMRInstruction(Operator op, byte in, MMTSJType type, byte out, String istr)
-	{
+	private MMTSJMRInstruction(Operator op, byte in, MMTSJType type, byte out, String istr) {
 		super(op, in, out, istr);
 		mrtype = MRINSTRUCTION_TYPE.MMTSJ;
 		instString = istr;
-		
+
 		_type = type;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/MRInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/MRInstruction.java
@@ -27,22 +27,21 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public abstract class MRInstruction extends Instruction {
 
-public abstract class MRInstruction extends Instruction 
-{
-	
-	public enum MRINSTRUCTION_TYPE { INVALID, Append, Aggregate, ArithmeticBinary, ArithmeticBinary2, AggregateBinary, AggregateUnary, 
-		Rand, Seq, CSVReblock, CSVWrite, 
-		Reblock, Reorg, Replicate, Unary, CombineBinary, CombineUnary, CombineTernary, PickByCount, Partition,
-		Ternary, Quaternary, CM_N_COV, MapGroupedAggregate, GroupedAggregate, RangeReIndex, ZeroOut, MMTSJ, PMMJ, MatrixReshape, ParameterizedBuiltin, Sort, MapMultChain,
-		CumsumAggregate, CumsumSplit, CumsumOffset, BinUaggChain, UaggOuterChain, RemoveEmpty}; 
-	
-	
+	public enum MRINSTRUCTION_TYPE {
+		INVALID, Append, Aggregate, ArithmeticBinary, ArithmeticBinary2, AggregateBinary, AggregateUnary, Rand,
+		Seq, CSVReblock, CSVWrite, Reblock, Reorg, Replicate, Unary, CombineBinary, CombineUnary, CombineTernary,
+		PickByCount, Partition, Ternary, Quaternary, CM_N_COV, MapGroupedAggregate, GroupedAggregate, RangeReIndex,
+		ZeroOut, MMTSJ, PMMJ, MatrixReshape, ParameterizedBuiltin, Sort, MapMultChain, CumsumAggregate, CumsumSplit,
+		CumsumOffset, BinUaggChain, UaggOuterChain, RemoveEmpty
+	};
+
 	protected MRINSTRUCTION_TYPE mrtype;
 	protected Operator optr;
 	public byte output;
-	
-	public MRInstruction (Operator op, byte out) {
+
+	protected MRInstruction(Operator op, byte out) {
 		type = INSTRUCTION_TYPE.MAPREDUCE;
 		optr = op;
 		output = out;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/MapMultChainInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/MapMultChainInstruction.java
@@ -32,33 +32,32 @@ import org.apache.sysml.runtime.matrix.mapred.DistributedCacheInput;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.mapred.MRBaseForCommonInstructions;
 
-public class MapMultChainInstruction extends MRInstruction implements IDistributedCacheConsumer
-{
+public class MapMultChainInstruction extends MRInstruction implements IDistributedCacheConsumer {
 	private ChainType _chainType = null;
-	
 	private byte _input1 = -1;
 	private byte _input2 = -1;
-	private byte _input3 = -1;	
-	
+	private byte _input3 = -1;
+
 	/**
 	 * Two matrix inputs - type XtXv
 	 * 
-	 * @param type chain type
-	 * @param in1 input byte 1
-	 * @param in2 input byte 2
-	 * @param out output byte
-	 * @param istr instruction string
+	 * @param type
+	 *            chain type
+	 * @param in1
+	 *            input byte 1
+	 * @param in2
+	 *            input byte 2
+	 * @param out
+	 *            output byte
+	 * @param istr
+	 *            instruction string
 	 */
-	public MapMultChainInstruction(ChainType type, byte in1, byte in2, byte out, String istr)
-	{
+	private MapMultChainInstruction(ChainType type, byte in1, byte in2, byte out, String istr) {
 		super(null, out);
-		
 		_chainType = type;
-		
 		_input1 = in1;
 		_input2 = in2;
 		_input3 = -1;
-		
 		mrtype = MRINSTRUCTION_TYPE.MapMultChain;
 		instString = istr;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/MatrixReshapeMRInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/MatrixReshapeMRInstruction.java
@@ -31,25 +31,23 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class MatrixReshapeMRInstruction extends UnaryInstruction
-{	
+public class MatrixReshapeMRInstruction extends UnaryInstruction {
 	private boolean _byrow = false;
-	
 	private MatrixCharacteristics _mcIn = null;
 	private MatrixCharacteristics _mcOut = null;
-	
-	//MB: cache should be integrated with tempValues, but for n blocks
+
+	// MB: cache should be integrated with tempValues, but for n blocks
 	private ArrayList<IndexedMatrixValue> _cache = null;
-	
-	public MatrixReshapeMRInstruction(Operator op, byte in, long rows, long cols, boolean byrow, byte out, String istr)
-	{
+
+	private MatrixReshapeMRInstruction(Operator op, byte in, long rows, long cols, boolean byrow, byte out,
+			String istr) {
 		super(op, in, out, istr);
 		mrtype = MRINSTRUCTION_TYPE.MMTSJ;
 		instString = istr;
 		_mcOut = new MatrixCharacteristics(rows, cols, -1, -1);
 		_byrow = byrow;
 	}
-	
+
 	public void setMatrixCharacteristics( MatrixCharacteristics mcIn, MatrixCharacteristics mcOut )
 	{
 		_mcIn = mcIn;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/PMMJMRInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/PMMJMRInstruction.java
@@ -34,24 +34,21 @@ import org.apache.sysml.runtime.matrix.mapred.MRBaseForCommonInstructions;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class PMMJMRInstruction extends BinaryMRInstructionBase implements IDistributedCacheConsumer
-{	
-	
+public class PMMJMRInstruction extends BinaryMRInstructionBase implements IDistributedCacheConsumer {
 	private long _rlen = -1;
 	private boolean _outputEmptyBlocks = true;
-	
-	
-	public PMMJMRInstruction(Operator op, byte in1, byte in2, byte out, long nrow, CacheType ctype, boolean outputEmpty, String istr)
-	{
+
+	private PMMJMRInstruction(Operator op, byte in1, byte in2, byte out, long nrow, CacheType ctype,
+			boolean outputEmpty, String istr) {
 		super(op, in1, in2, out);
 		instString = istr;
-		
+
 		_rlen = nrow;
 		_outputEmptyBlocks = outputEmpty;
-		
-		//NOTE: cache type only used by distributed cache input
+
+		// NOTE: cache type only used by distributed cache input
 	}
-	
+
 	public long getNumRows() {
 		return _rlen;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/ParameterizedBuiltinMRInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/ParameterizedBuiltinMRInstruction.java
@@ -37,31 +37,30 @@ import org.apache.sysml.runtime.util.UtilFunctions;
  * Supported opcodes: replace.
  * 
  */
-public class ParameterizedBuiltinMRInstruction extends UnaryInstruction
-{	
+public class ParameterizedBuiltinMRInstruction extends UnaryInstruction {
 	String _opcode = null;
-	
-	//replace-specific attributes
+
+	// replace-specific attributes
 	private double _pattern;
 	private double _replace;
-	
-	//rexpand-specific attributes
+
+	// rexpand-specific attributes
 	private double _max;
 	private boolean _dirRows;
 	private boolean _cast;
 	private boolean _ignore;
-	
-	public ParameterizedBuiltinMRInstruction(Operator op, byte in, double pattern, double replace, byte out, String opcode, String istr)
-	{
+
+	private ParameterizedBuiltinMRInstruction(Operator op, byte in, double pattern, double replace, byte out,
+			String opcode, String istr) {
 		super(op, in, out, istr);
 		instString = istr;
 		_opcode = opcode;
 		_pattern = pattern;
 		_replace = replace;
 	}
-	
-	public ParameterizedBuiltinMRInstruction(Operator op, byte in, double max, boolean dirRows, boolean cast, boolean ignore, byte out, String opcode, String istr)
-	{
+
+	private ParameterizedBuiltinMRInstruction(Operator op, byte in, double max, boolean dirRows, boolean cast,
+			boolean ignore, byte out, String opcode, String istr) {
 		super(op, in, out, istr);
 		instString = istr;
 		_opcode = opcode;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/PickByCountInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/PickByCountInstruction.java
@@ -27,43 +27,41 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class PickByCountInstruction extends MRInstruction {
 
-public class PickByCountInstruction extends MRInstruction 
-{
-	
 	public byte input1; // used for both valuepick and rangepick
 	public byte input2; // used only for valuepick
 	public double cst; // used only for rangepick
-	public boolean isValuePick=true;
-	
+	public boolean isValuePick = true;
+
 	/*
-	 *  Constructor for valuepick
-	 *  valuepick:::0:DOUBLE:::1:DOUBLE:::2:DOUBLE
-	 *  0 is data matrix, 1 is the quantile matrix, 2 will have the resulting picked data items 
+	 * Constructor for valuepick valuepick:::0:DOUBLE:::1:DOUBLE:::2:DOUBLE 0 is
+	 * data matrix, 1 is the quantile matrix, 2 will have the resulting picked
+	 * data items
 	 */
-	public PickByCountInstruction(Operator op, byte _in1, byte _in2, byte out, String istr) {
+	private PickByCountInstruction(Operator op, byte _in1, byte _in2, byte out, String istr) {
 		super(op, out);
 		input1 = _in1;
 		input2 = _in2;
 		cst = 0;
 		mrtype = MRINSTRUCTION_TYPE.PickByCount;
 		instString = istr;
-		isValuePick=true;
+		isValuePick = true;
 	}
 
 	/*
-	 *  Constructor for rangepick
-	 *  rangepick:::0:DOUBLE:::0.25:DOUBLE:::1:DOUBLE
-	 *  0 is data matrix, 0.25 is the quantile that needs to be removed from both ends in the PDF, 
-	 *  1 will have the resulting picked data items between [Q_1-Q_3]
+	 * Constructor for rangepick rangepick:::0:DOUBLE:::0.25:DOUBLE:::1:DOUBLE 0
+	 * is data matrix, 0.25 is the quantile that needs to be removed from both
+	 * ends in the PDF, 1 will have the resulting picked data items between
+	 * [Q_1-Q_3]
 	 */
-	public PickByCountInstruction(Operator op, byte _in1, double _cst, byte out, String istr) {
+	private PickByCountInstruction(Operator op, byte _in1, double _cst, byte out, String istr) {
 		super(op, out);
 		input1 = _in1;
 		cst = _cst;
 		mrtype = MRINSTRUCTION_TYPE.PickByCount;
 		instString = istr;
-		isValuePick=false;
+		isValuePick = false;
 	}
 
 	public static PickByCountInstruction parseInstruction ( String str ) 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/PlusMultInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/PlusMultInstruction.java
@@ -28,10 +28,8 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class PlusMultInstruction extends BinaryInstruction 
-{
-	public PlusMultInstruction(Operator op, byte in1, byte in2, byte out, String istr) {
+public class PlusMultInstruction extends BinaryInstruction {
+	private PlusMultInstruction(Operator op, byte in1, byte in2, byte out, String istr) {
 		super(op, in1, in2, out, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/QuaternaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/QuaternaryInstruction.java
@@ -47,31 +47,30 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.QuaternaryOperator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 
-public class QuaternaryInstruction extends MRInstruction implements IDistributedCacheConsumer
-{	
+public class QuaternaryInstruction extends MRInstruction implements IDistributedCacheConsumer {
 	private byte _input1 = -1;
 	private byte _input2 = -1;
-	private byte _input3 = -1;	
+	private byte _input3 = -1;
 	private byte _input4 = -1;
-	
+
 	private boolean _cacheU = false;
 	private boolean _cacheV = false;
 
-	public QuaternaryInstruction(Operator op, byte in1, byte in2, byte in3, byte in4, byte out, boolean cacheU, boolean cacheV, String istr)
-	{
+	private QuaternaryInstruction(Operator op, byte in1, byte in2, byte in3, byte in4, byte out, boolean cacheU,
+			boolean cacheV, String istr) {
 		super(op, out);
 		mrtype = MRINSTRUCTION_TYPE.Quaternary;
 		instString = istr;
-		
+
 		_input1 = in1;
 		_input2 = in2;
 		_input3 = in3;
 		_input4 = in4;
-		
+
 		_cacheU = cacheU;
 		_cacheV = cacheV;
 	}
-	
+
 	public byte getInput1() {
 		return _input1;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/RandInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/RandInstruction.java
@@ -27,19 +27,18 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class RandInstruction extends DataGenMRInstruction
-{
+public class RandInstruction extends DataGenMRInstruction {
 	private double minValue;
 	private double maxValue;
 	private double sparsity;
 	private String probabilityDensityFunction;
 	private String pdfParams;
-	
-	private long seed=0;
-	
-	public RandInstruction ( Operator op, byte in, byte out, long rows, long cols, int rpb, int cpb, double minValue, double maxValue,
-				double sparsity, long seed, String probabilityDensityFunction, String params, String baseDir, String istr ) {
+
+	private long seed = 0;
+
+	private RandInstruction(Operator op, byte in, byte out, long rows, long cols, int rpb, int cpb, double minValue,
+			double maxValue, double sparsity, long seed, String probabilityDensityFunction, String params,
+			String baseDir, String istr) {
 		super(op, DataGenMethod.RAND, in, out, rows, cols, rpb, cpb, baseDir);
 		mrtype = MRINSTRUCTION_TYPE.Rand;
 		this.minValue = minValue;
@@ -50,7 +49,7 @@ public class RandInstruction extends DataGenMRInstruction
 		this.pdfParams = params;
 		instString = istr;
 	}
-	
+
 	public String getPdfParams() {
 		return pdfParams;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/RangeBasedReIndexInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/RangeBasedReIndexInstruction.java
@@ -33,15 +33,14 @@ import org.apache.sysml.runtime.matrix.operators.ReIndexOperator;
 import org.apache.sysml.runtime.util.IndexRange;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-
-public class RangeBasedReIndexInstruction extends UnaryMRInstructionBase
-{
+public class RangeBasedReIndexInstruction extends UnaryMRInstructionBase {
 	private IndexRange _ixrange = null;
-	private boolean _forLeft = false;	
+	private boolean _forLeft = false;
 	private long _rlenLhs = -1;
 	private long _clenLhs = -1;
-	
-	public RangeBasedReIndexInstruction(Operator op, byte in, byte out, IndexRange rng, boolean forleft, long rlen, long clen, String istr) {
+
+	private RangeBasedReIndexInstruction(Operator op, byte in, byte out, IndexRange rng, boolean forleft, long rlen,
+			long clen, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.RangeReIndex;
 		instString = istr;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/ReblockInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/ReblockInstruction.java
@@ -26,22 +26,19 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class ReblockInstruction extends UnaryMRInstructionBase 
-{
-	
+public class ReblockInstruction extends UnaryMRInstructionBase {
 	public int brlen;
 	public int bclen;
 	public boolean outputEmptyBlocks;
-	
-	public ReblockInstruction (Operator op, byte in, byte out, int br, int bc, boolean emptyBlocks, String istr) {
+
+	protected ReblockInstruction(Operator op, byte in, byte out, int br, int bc, boolean emptyBlocks, String istr) {
 		super(op, in, out);
-		brlen=br;
-		bclen=bc;
+		brlen = br;
+		bclen = bc;
 		outputEmptyBlocks = emptyBlocks;
 		instString = istr;
 	}
-	
+
 	public static ReblockInstruction parseInstruction(String str) 
 	{
 		Operator op = null;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/RemoveEmptyMRInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/RemoveEmptyMRInstruction.java
@@ -35,23 +35,18 @@ import org.apache.sysml.runtime.util.UtilFunctions;
  * Supported optcodes: rmempty.
  * 
  */
-public class RemoveEmptyMRInstruction extends BinaryInstruction
-{	
-	
-	
-	private long    _len   = -1;
+public class RemoveEmptyMRInstruction extends BinaryInstruction {
+	private long _len = -1;
 	private boolean _rmRows = true;
-	
-	
-	public RemoveEmptyMRInstruction(Operator op, byte in1, byte in2, long len, boolean rmRows, byte out, String istr)
-	{
+
+	private RemoveEmptyMRInstruction(Operator op, byte in1, byte in2, long len, boolean rmRows, byte out, String istr) {
 		super(op, in1, in2, out, istr);
 		instString = istr;
-		
+
 		_len = len;
 		_rmRows = rmRows;
 	}
-	
+
 	public boolean isRemoveRows()
 	{
 		return _rmRows;

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/ReorgInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/ReorgInstruction.java
@@ -35,21 +35,18 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 
-
-public class ReorgInstruction extends UnaryMRInstructionBase 
-{
-	
-	//required for diag (size-based type, load-balance-aware output of empty blocks)
+public class ReorgInstruction extends UnaryMRInstructionBase {
+	// required for diag (size-based type, load-balance-aware output of empty
+	// blocks)
 	private MatrixCharacteristics _mcIn = null;
 	private boolean _outputEmptyBlocks = true;
-	
-	public ReorgInstruction(ReorgOperator op, byte in, byte out, String istr)
-	{
+
+	private ReorgInstruction(ReorgOperator op, byte in, byte out, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.Reorg;
 		instString = istr;
 	}
-	
+
 	public void setInputMatrixCharacteristics( MatrixCharacteristics in )
 	{
 		_mcIn = in; 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/ReplicateInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/ReplicateInstruction.java
@@ -29,18 +29,15 @@ import org.apache.sysml.runtime.matrix.data.MatrixValue;
 import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 
-public class ReplicateInstruction extends UnaryMRInstructionBase 
-{
-	
+public class ReplicateInstruction extends UnaryMRInstructionBase {
 	private boolean _repCols = true;
-	private long _lenM = -1; //clen/rlen
-	
-	public ReplicateInstruction(byte in, byte out, boolean repCols, long lenM, String istr)
-	{
+	private long _lenM = -1; // clen/rlen
+
+	private ReplicateInstruction(byte in, byte out, boolean repCols, long lenM, String istr) {
 		super(null, in, out);
 		mrtype = MRINSTRUCTION_TYPE.Reorg;
 		instString = istr;
-		
+
 		_repCols = repCols;
 		_lenM = lenM;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/ScalarInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/ScalarInstruction.java
@@ -31,17 +31,14 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.ScalarOperator;
 
+public class ScalarInstruction extends UnaryMRInstructionBase {
 
-public class ScalarInstruction extends UnaryMRInstructionBase 
-{
-	
-	public ScalarInstruction(ScalarOperator op, byte in, byte out, String istr)
-	{
+	private ScalarInstruction(ScalarOperator op, byte in, byte out, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.ArithmeticBinary;
 		instString = istr;
-		
-		//value dependent safe-safeness (trigger re-evaluation sparse-safe)
+
+		// value dependent safe-safeness (trigger re-evaluation sparse-safe)
 		op.setConstant(op.getConstant());
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/SeqInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/SeqInstruction.java
@@ -27,16 +27,13 @@ import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class SeqInstruction extends DataGenMRInstruction
-{
-	
+public class SeqInstruction extends DataGenMRInstruction {
 	public double fromValue;
 	public double toValue;
 	public double incrValue;
-	
-	public SeqInstruction ( Operator op, byte in, byte out, long rows, long cols, int rpb, int cpb, double fromValue, double toValue,
-				double incrValue, String baseDir, String istr ) {
+
+	private SeqInstruction(Operator op, byte in, byte out, long rows, long cols, int rpb, int cpb, double fromValue,
+			double toValue, double incrValue, String baseDir, String istr) {
 		super(op, DataGenMethod.SEQ, in, out, rows, cols, rpb, cpb, baseDir);
 		mrtype = MRINSTRUCTION_TYPE.Seq;
 		this.fromValue = fromValue;
@@ -44,7 +41,7 @@ public class SeqInstruction extends DataGenMRInstruction
 		this.incrValue = incrValue;
 		instString = istr;
 	}
-	
+
 	public static SeqInstruction parseInstruction(String str) throws DMLRuntimeException 
 	{
 		InstructionUtils.checkNumFields ( str, 10 );

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/TernaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/TernaryInstruction.java
@@ -32,12 +32,9 @@ import org.apache.sysml.runtime.matrix.data.OperationsOnMatrixValues;
 import org.apache.sysml.runtime.matrix.mapred.CachedValueMap;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 
-
-public class TernaryInstruction extends MRInstruction 
-{
-	
+public class TernaryInstruction extends MRInstruction {
 	private OperationTypes _op;
-	
+
 	public byte input1;
 	public byte input2;
 	public byte input3;
@@ -48,17 +45,25 @@ public class TernaryInstruction extends MRInstruction
 	/**
 	 * Single matrix input
 	 * 
-	 * @param op operation type
-	 * @param in1 input 1 (byte)
-	 * @param scalar_in2 input 2 (double)
-	 * @param scalar_in3 input 3 (double)
-	 * @param out output
-	 * @param outputDim1 output dimension 1
-	 * @param outputDim2 output dimension 2
-	 * @param istr instruction string
+	 * @param op
+	 *            operation type
+	 * @param in1
+	 *            input 1 (byte)
+	 * @param scalar_in2
+	 *            input 2 (double)
+	 * @param scalar_in3
+	 *            input 3 (double)
+	 * @param out
+	 *            output
+	 * @param outputDim1
+	 *            output dimension 1
+	 * @param outputDim2
+	 *            output dimension 2
+	 * @param istr
+	 *            instruction string
 	 */
-	public TernaryInstruction(OperationTypes op, byte in1, double scalar_in2, double scalar_in3, byte out, long outputDim1, long outputDim2, String istr)
-	{
+	private TernaryInstruction(OperationTypes op, byte in1, double scalar_in2, double scalar_in3, byte out,
+			long outputDim1, long outputDim2, String istr) {
 		super(null, out);
 		mrtype = MRINSTRUCTION_TYPE.Ternary;
 		_op = op;
@@ -69,21 +74,29 @@ public class TernaryInstruction extends MRInstruction
 		_outputDim2 = outputDim2;
 		instString = istr;
 	}
-	
+
 	/**
 	 * Two matrix inputs
 	 * 
-	 * @param op operation type
-	 * @param in1 input 1 (byte)
-	 * @param in2 input 2 (byte)
-	 * @param scalar_in3 input 3 (double)
-	 * @param out output
-	 * @param outputDim1 output dimension 1
-	 * @param outputDim2 output dimension 2
-	 * @param istr instruction string
+	 * @param op
+	 *            operation type
+	 * @param in1
+	 *            input 1 (byte)
+	 * @param in2
+	 *            input 2 (byte)
+	 * @param scalar_in3
+	 *            input 3 (double)
+	 * @param out
+	 *            output
+	 * @param outputDim1
+	 *            output dimension 1
+	 * @param outputDim2
+	 *            output dimension 2
+	 * @param istr
+	 *            instruction string
 	 */
-	public TernaryInstruction(OperationTypes op, byte in1, byte in2, double scalar_in3, byte out, long outputDim1, long outputDim2, String istr)
-	{
+	private TernaryInstruction(OperationTypes op, byte in1, byte in2, double scalar_in3, byte out, long outputDim1,
+			long outputDim2, String istr) {
 		super(null, out);
 		mrtype = MRINSTRUCTION_TYPE.Ternary;
 		_op = op;
@@ -94,21 +107,29 @@ public class TernaryInstruction extends MRInstruction
 		_outputDim2 = outputDim2;
 		instString = istr;
 	}
-	
+
 	/**
-	 * Two matrix input 
+	 * Two matrix input
 	 * 
-	 * @param op operation type
-	 * @param in1 input 1 (byte)
-	 * @param scalar_in2 input 2 (double)
-	 * @param in3 input 3 (byte)
-	 * @param out output
-	 * @param outputDim1 output dimension 1
-	 * @param outputDim2 output dimension 2
-	 * @param istr instruction string
+	 * @param op
+	 *            operation type
+	 * @param in1
+	 *            input 1 (byte)
+	 * @param scalar_in2
+	 *            input 2 (double)
+	 * @param in3
+	 *            input 3 (byte)
+	 * @param out
+	 *            output
+	 * @param outputDim1
+	 *            output dimension 1
+	 * @param outputDim2
+	 *            output dimension 2
+	 * @param istr
+	 *            instruction string
 	 */
-	public TernaryInstruction(OperationTypes op, byte in1, double scalar_in2, byte in3, byte out, long outputDim1, long outputDim2, String istr)
-	{
+	private TernaryInstruction(OperationTypes op, byte in1, double scalar_in2, byte in3, byte out, long outputDim1,
+			long outputDim2, String istr) {
 		super(null, out);
 		mrtype = MRINSTRUCTION_TYPE.Ternary;
 		_op = op;
@@ -119,21 +140,29 @@ public class TernaryInstruction extends MRInstruction
 		_outputDim2 = outputDim2;
 		instString = istr;
 	}
-	
+
 	/**
 	 * Three matrix inputs
 	 * 
-	 * @param op operation type
-	 * @param in1 input 1 (byte)
-	 * @param in2 input 2 (byte)
-	 * @param in3 input 3 (byte)
-	 * @param out output
-	 * @param outputDim1 output dimension 1
-	 * @param outputDim2 output dimension 2
-	 * @param istr instruction string
+	 * @param op
+	 *            operation type
+	 * @param in1
+	 *            input 1 (byte)
+	 * @param in2
+	 *            input 2 (byte)
+	 * @param in3
+	 *            input 3 (byte)
+	 * @param out
+	 *            output
+	 * @param outputDim1
+	 *            output dimension 1
+	 * @param outputDim2
+	 *            output dimension 2
+	 * @param istr
+	 *            instruction string
 	 */
-	public TernaryInstruction(OperationTypes op, byte in1, byte in2, byte in3, byte out, long outputDim1, long outputDim2, String istr)
-	{
+	protected TernaryInstruction(OperationTypes op, byte in1, byte in2, byte in3, byte out, long outputDim1,
+			long outputDim2, String istr) {
 		super(null, out);
 		mrtype = MRINSTRUCTION_TYPE.Ternary;
 		_op = op;
@@ -144,7 +173,7 @@ public class TernaryInstruction extends MRInstruction
 		_outputDim2 = outputDim2;
 		instString = istr;
 	}
-	
+
 	public long getOutputDim1() {
 		return _outputDim1;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/UaggOuterChainInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/UaggOuterChainInstruction.java
@@ -42,31 +42,30 @@ import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 
-public class UaggOuterChainInstruction extends BinaryInstruction implements IDistributedCacheConsumer
-{	
-	//operators
+public class UaggOuterChainInstruction extends BinaryInstruction implements IDistributedCacheConsumer {
+	// operators
 	private AggregateUnaryOperator _uaggOp = null;
 	private AggregateOperator _aggOp = null;
 	private BinaryOperator _bOp = null;
-	
-	//reused intermediates  
+
+	// reused intermediates
 	private MatrixValue _tmpVal1 = null;
 	private MatrixValue _tmpVal2 = null;
-	
+
 	private double[] _bv = null;
 	private int[] _bvi = null;
 
-	public UaggOuterChainInstruction(BinaryOperator bop, AggregateUnaryOperator uaggop, AggregateOperator aggop, byte in1, byte in2, byte out, String istr)
-	{
+	private UaggOuterChainInstruction(BinaryOperator bop, AggregateUnaryOperator uaggop, AggregateOperator aggop,
+			byte in1, byte in2, byte out, String istr) {
 		super(null, in1, in2, out, istr);
-		
+
 		_uaggOp = uaggop;
 		_aggOp = aggop;
 		_bOp = bop;
-			
+
 		_tmpVal1 = new MatrixBlock();
 		_tmpVal2 = new MatrixBlock();
-		
+
 		mrtype = MRINSTRUCTION_TYPE.UaggOuterChain;
 		instString = istr;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/UnaryInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/UnaryInstruction.java
@@ -31,17 +31,14 @@ import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
+public class UnaryInstruction extends UnaryMRInstructionBase {
 
-public class UnaryInstruction extends UnaryMRInstructionBase 
-{
-	
-	public UnaryInstruction(Operator op, byte in, byte out, String istr)
-	{
+	public UnaryInstruction(Operator op, byte in, byte out, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.Unary;
 		instString = istr;
 	}
-	
+
 	public static UnaryInstruction parseInstruction ( String str ) throws DMLRuntimeException {
 		
 		String opcode = InstructionUtils.getOpCode(str);

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/UnaryMRInstructionBase.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/UnaryMRInstructionBase.java
@@ -21,17 +21,14 @@ package org.apache.sysml.runtime.instructions.mr;
 
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public abstract class UnaryMRInstructionBase extends MRInstruction 
-{
-	
+public abstract class UnaryMRInstructionBase extends MRInstruction {
 	public byte input;
-	
-	public UnaryMRInstructionBase(Operator op, byte in, byte out)
-	{
+
+	protected UnaryMRInstructionBase(Operator op, byte in, byte out) {
 		super(op, out);
-		input=in;
+		input = in;
 	}
-	
+
 	@Override
 	public byte[] getInputIndexes() {
 		return new byte[]{input};

--- a/src/main/java/org/apache/sysml/runtime/instructions/mr/ZeroOutInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/mr/ZeroOutInstruction.java
@@ -36,20 +36,18 @@ import org.apache.sysml.runtime.util.UtilFunctions;
  * ZeroOut with complementary=false is to zero out a subregion inside a matrix
  * ZeroOut with complementary=true is to select a subregion inside a matrix (zero out regions outside the selected range)
  */
-public class ZeroOutInstruction extends UnaryMRInstructionBase
-{
-		
-	public IndexRange indexRange=null;
-	private IndexRange tempRange=new IndexRange(-1, -1, -1, -1);
-	public boolean complementary=false;
-	
-	public ZeroOutInstruction(Operator op, byte in, byte out, IndexRange rng, String istr) {
+public class ZeroOutInstruction extends UnaryMRInstructionBase {
+	public IndexRange indexRange = null;
+	private IndexRange tempRange = new IndexRange(-1, -1, -1, -1);
+	public boolean complementary = false;
+
+	private ZeroOutInstruction(Operator op, byte in, byte out, IndexRange rng, String istr) {
 		super(op, in, out);
 		mrtype = MRINSTRUCTION_TYPE.ZeroOut;
 		instString = istr;
-		indexRange=rng;
+		indexRange = rng;
 	}
-	
+
 	public static ZeroOutInstruction parseInstruction ( String str ) throws DMLRuntimeException {
 		
 		InstructionUtils.checkNumFields ( str, 6 );

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/AggregateTernarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/AggregateTernarySPInstruction.java
@@ -39,11 +39,10 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.AggregateTernaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class AggregateTernarySPInstruction extends ComputationSPInstruction
-{
-	public AggregateTernarySPInstruction(Operator op, CPOperand in1, CPOperand in2, 
-		CPOperand in3, CPOperand out, String opcode, String istr )
-	{
+public class AggregateTernarySPInstruction extends ComputationSPInstruction {
+
+	private AggregateTernarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.AggregateTernary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/AggregateUnarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/AggregateUnarySPInstruction.java
@@ -43,13 +43,12 @@ import org.apache.sysml.runtime.matrix.data.OperationsOnMatrixValues;
 import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
 
-public class AggregateUnarySPInstruction extends UnarySPInstruction
-{
-	
+public class AggregateUnarySPInstruction extends UnarySPInstruction {
 	private SparkAggType _aggtype = null;
 	private AggregateOperator _aop = null;
-	
-	public AggregateUnarySPInstruction(AggregateUnaryOperator auop, AggregateOperator aop, CPOperand in, CPOperand out, SparkAggType aggtype, String opcode, String istr){
+
+	protected AggregateUnarySPInstruction(AggregateUnaryOperator auop, AggregateOperator aop, CPOperand in,
+			CPOperand out, SparkAggType aggtype, String opcode, String istr) {
 		super(auop, in, out, opcode, istr);
 		_aggtype = aggtype;
 		_aop = aop;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendGAlignedSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendGAlignedSPInstruction.java
@@ -36,17 +36,16 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 
-public class AppendGAlignedSPInstruction extends BinarySPInstruction
-{
+public class AppendGAlignedSPInstruction extends BinarySPInstruction {
 	private boolean _cbind = true;
-	
-	public AppendGAlignedSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, boolean cbind, String opcode, String istr)
-	{
+
+	private AppendGAlignedSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			boolean cbind, String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.GAppend;
 		_cbind = cbind;
 	}
-	
+
 	public static AppendGAlignedSPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendGSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendGSPInstruction.java
@@ -42,17 +42,16 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class AppendGSPInstruction extends BinarySPInstruction
-{
+public class AppendGSPInstruction extends BinarySPInstruction {
 	private boolean _cbind = true;
-	
-	public AppendGSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand offset2, CPOperand out, boolean cbind, String opcode, String istr)
-	{
+
+	private AppendGSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand offset2,
+			CPOperand out, boolean cbind, String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.GAppend;
 		_cbind = cbind;
 	}
-	
+
 	public static AppendGSPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{	

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendMSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendMSPInstruction.java
@@ -27,15 +27,14 @@ import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 
-public abstract class AppendMSPInstruction extends BinarySPInstruction
-{
+public abstract class AppendMSPInstruction extends BinarySPInstruction {
 	protected CPOperand _offset = null;
 	protected boolean _cbind = true;
-	
-	public AppendMSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand out, boolean cbind, String opcode, String istr)
-	{
+
+	protected AppendMSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand out,
+			boolean cbind, String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
-		_sptype = SPINSTRUCTION_TYPE.MAppend;			
+		_sptype = SPINSTRUCTION_TYPE.MAppend;
 		_offset = offset;
 		_cbind = cbind;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendRSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/AppendRSPInstruction.java
@@ -26,13 +26,11 @@ import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 
-
-public abstract class AppendRSPInstruction extends BinarySPInstruction
-{
+public abstract class AppendRSPInstruction extends BinarySPInstruction {
 	protected boolean _cbind = true;
-	
-	public AppendRSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean cbind, String opcode, String istr)
-	{
+
+	AppendRSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean cbind, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.RAppend;
 		_cbind = cbind;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/ArithmeticBinarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/ArithmeticBinarySPInstruction.java
@@ -28,11 +28,10 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public abstract class ArithmeticBinarySPInstruction extends BinarySPInstruction 
-{
-		
-	public ArithmeticBinarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr)
-	{
+public abstract class ArithmeticBinarySPInstruction extends BinarySPInstruction {
+
+	ArithmeticBinarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.ArithmeticBinary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/BinUaggChainSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/BinUaggChainSPInstruction.java
@@ -32,19 +32,15 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 
-
-public class BinUaggChainSPInstruction extends UnarySPInstruction 
-{
-	
-	//operators
+public class BinUaggChainSPInstruction extends UnarySPInstruction {
+	// operators
 	private BinaryOperator _bOp = null;
 	private AggregateUnaryOperator _uaggOp = null;
-	
-	public BinUaggChainSPInstruction(CPOperand in, CPOperand out, BinaryOperator bop, AggregateUnaryOperator uaggop, String opcode, String istr )
-	{
+
+	private BinUaggChainSPInstruction(CPOperand in, CPOperand out, BinaryOperator bop, AggregateUnaryOperator uaggop,
+			String opcode, String istr) {
 		super(null, in, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.BinUaggChain;
-		
 		_bOp = bop;
 		_uaggOp = uaggop;
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/BinarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/BinarySPInstruction.java
@@ -42,10 +42,10 @@ import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ScalarOperator;
 
-public abstract class BinarySPInstruction extends ComputationSPInstruction
-{
-	
-	public BinarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr ){
+public abstract class BinarySPInstruction extends ComputationSPInstruction {
+
+	protected BinarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/BuiltinBinarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/BuiltinBinarySPInstruction.java
@@ -32,11 +32,10 @@ import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.RightScalarOperator;
 
-public abstract class BuiltinBinarySPInstruction extends BinarySPInstruction 
-{
-	
-	public BuiltinBinarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr )
-	{
+public abstract class BuiltinBinarySPInstruction extends BinarySPInstruction {
+
+	protected BuiltinBinarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.BuiltinBinary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/BuiltinUnarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/BuiltinUnarySPInstruction.java
@@ -28,12 +28,9 @@ import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
+public abstract class BuiltinUnarySPInstruction extends UnarySPInstruction {
 
-public abstract class BuiltinUnarySPInstruction extends UnarySPInstruction 
-{
-	
-	public BuiltinUnarySPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr )
-	{
+	protected BuiltinUnarySPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.BuiltinUnary;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CSVReblockSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CSVReblockSPInstruction.java
@@ -42,8 +42,7 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class CSVReblockSPInstruction extends UnarySPInstruction 
-{
+public class CSVReblockSPInstruction extends UnarySPInstruction {
 	private int _brlen;
 	private int _bclen;
 	private boolean _hasHeader;
@@ -51,10 +50,8 @@ public class CSVReblockSPInstruction extends UnarySPInstruction
 	private boolean _fill;
 	private double _fillValue;
 
-	public CSVReblockSPInstruction(Operator op, CPOperand in, CPOperand out,
-			int br, int bc, boolean hasHeader, String delim, boolean fill,
-			double fillValue, String opcode, String instr) 
-	{
+	protected CSVReblockSPInstruction(Operator op, CPOperand in, CPOperand out, int br, int bc, boolean hasHeader,
+			String delim, boolean fill, double fillValue, String opcode, String instr) {
 		super(op, in, out, opcode, instr);
 		_brlen = br;
 		_bclen = bc;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CastSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CastSPInstruction.java
@@ -37,14 +37,13 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
+public class CastSPInstruction extends UnarySPInstruction {
 
-public class CastSPInstruction extends UnarySPInstruction
-{
-	public CastSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
+	private CastSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.Cast;
 	}
-	
+
 	public static CastSPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CentralMomentSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CentralMomentSPInstruction.java
@@ -41,12 +41,10 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.CMOperator;
 import org.apache.sysml.runtime.matrix.operators.CMOperator.AggregateOperationTypes;
 
-public class CentralMomentSPInstruction extends UnarySPInstruction
-{
-	
-	public CentralMomentSPInstruction(CMOperator op, CPOperand in1, CPOperand in2, 
-			CPOperand in3, CPOperand out, String opcode, String str)
-	{
+public class CentralMomentSPInstruction extends UnarySPInstruction {
+
+	private CentralMomentSPInstruction(CMOperator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String str) {
 		super(op, in1, in2, in3, out, opcode, str);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CheckpointSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CheckpointSPInstruction.java
@@ -43,19 +43,17 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.data.SparseBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-
-public class CheckpointSPInstruction extends UnarySPInstruction
-{
-	//default storage level
+public class CheckpointSPInstruction extends UnarySPInstruction {
+	// default storage level
 	private StorageLevel _level = null;
-	
-	public CheckpointSPInstruction(Operator op, CPOperand in, CPOperand out, StorageLevel level, String opcode, String istr) {
+
+	private CheckpointSPInstruction(Operator op, CPOperand in, CPOperand out, StorageLevel level, String opcode,
+			String istr) {
 		super(op, in, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.Checkpoint;
-		
 		_level = level;
 	}
-	
+
 	public static CheckpointSPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CompressionSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CompressionSPInstruction.java
@@ -31,10 +31,9 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class CompressionSPInstruction extends UnarySPInstruction {
 
-public class CompressionSPInstruction extends UnarySPInstruction
-{
-	public CompressionSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr){
+	private CompressionSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.Reorg;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/ComputationSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/ComputationSPInstruction.java
@@ -30,12 +30,11 @@ import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
 public abstract class ComputationSPInstruction extends SPInstruction {
-	
-
 	public CPOperand output;
 	public CPOperand input1, input2, input3;
-	
-	public ComputationSPInstruction ( Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr ) {
+
+	protected ComputationSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, opcode, istr);
 		input1 = in1;
 		input2 = in2;
@@ -43,7 +42,8 @@ public abstract class ComputationSPInstruction extends SPInstruction {
 		output = out;
 	}
 
-	public ComputationSPInstruction ( Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, String opcode, String istr ) {
+	protected ComputationSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String istr) {
 		super(op, opcode, istr);
 		input1 = in1;
 		input2 = in2;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/ConvolutionSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/ConvolutionSPInstruction.java
@@ -53,18 +53,16 @@ import scala.Tuple2;
 
 public class ConvolutionSPInstruction extends UnarySPInstruction {
 	private CPOperand _in2;
-	private CPOperand _in3; 
+	private CPOperand _in3;
 	private ArrayList<CPOperand> _input_shape;
 	private ArrayList<CPOperand> _filter_shape;
 	private ArrayList<CPOperand> _stride = new ArrayList<CPOperand>();
 	private ArrayList<CPOperand> _padding = new ArrayList<CPOperand>();
 
-	public ConvolutionSPInstruction(CPOperand in, CPOperand out, String opcode,
-			String istr, ArrayList<CPOperand> stride,
-			ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
+	private ConvolutionSPInstruction(CPOperand in, CPOperand out, String opcode, String istr,
+			ArrayList<CPOperand> stride, ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
 			ArrayList<CPOperand> filter_shape) {
-		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out,
-				opcode, istr);
+		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.Convolution;
 		_stride = stride;
 		_padding = padding;
@@ -72,12 +70,10 @@ public class ConvolutionSPInstruction extends UnarySPInstruction {
 		_filter_shape = filter_shape;
 	}
 
-	public ConvolutionSPInstruction(CPOperand in, CPOperand in2, CPOperand out,
-			String opcode, String istr, ArrayList<CPOperand> stride,
-			ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
+	private ConvolutionSPInstruction(CPOperand in, CPOperand in2, CPOperand out, String opcode, String istr,
+			ArrayList<CPOperand> stride, ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
 			ArrayList<CPOperand> filter_shape) {
-		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out,
-				opcode, istr);
+		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out, opcode, istr);
 		_in2 = in2;
 		_sptype = SPINSTRUCTION_TYPE.Convolution;
 		_stride = stride;
@@ -86,12 +82,10 @@ public class ConvolutionSPInstruction extends UnarySPInstruction {
 		_filter_shape = filter_shape;
 	}
 
-	public ConvolutionSPInstruction(CPOperand in, CPOperand in2, CPOperand in3,
-			CPOperand out, String opcode, String istr,
-			ArrayList<CPOperand> stride, ArrayList<CPOperand> padding,
-			ArrayList<CPOperand> input_shape, ArrayList<CPOperand> filter_shape) {
-		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out,
-				opcode, istr);
+	private ConvolutionSPInstruction(CPOperand in, CPOperand in2, CPOperand in3, CPOperand out, String opcode,
+			String istr, ArrayList<CPOperand> stride, ArrayList<CPOperand> padding, ArrayList<CPOperand> input_shape,
+			ArrayList<CPOperand> filter_shape) {
+		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out, opcode, istr);
 		_in2 = in2;
 		_in3 = in3;
 		_sptype = SPINSTRUCTION_TYPE.Convolution;
@@ -101,10 +95,8 @@ public class ConvolutionSPInstruction extends UnarySPInstruction {
 		_filter_shape = filter_shape;
 	}
 
-	public ConvolutionSPInstruction(CPOperand in, CPOperand in2, CPOperand out,
-			String opcode, String istr) {
-		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out,
-				opcode, istr);
+	private ConvolutionSPInstruction(CPOperand in, CPOperand in2, CPOperand out, String opcode, String istr) {
+		super(new ReorgOperator(SwapIndex.getSwapIndexFnObject()), in, out, opcode, istr);
 		_in2 = in2;
 		_sptype = SPINSTRUCTION_TYPE.Convolution;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CovarianceSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CovarianceSPInstruction.java
@@ -39,18 +39,15 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.COVOperator;
 
-public class CovarianceSPInstruction extends BinarySPInstruction
-{
-	
-	public CovarianceSPInstruction(COVOperator op, CPOperand in, CPOperand in2, CPOperand out, 
-			                      String opcode, String istr)
-	{
+public class CovarianceSPInstruction extends BinarySPInstruction {
+
+	private CovarianceSPInstruction(COVOperator op, CPOperand in, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in, in2, out, opcode, istr);
 	}
-	
-	public CovarianceSPInstruction(COVOperator op, CPOperand in, CPOperand in2, CPOperand in3, CPOperand out, 
-            String opcode, String istr)
-	{
+
+	private CovarianceSPInstruction(COVOperator op, CPOperand in, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String istr) {
 		super(op, in, in2, out, opcode, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CpmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CpmmSPInstruction.java
@@ -49,13 +49,11 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
  * this would result in a degree of parallelism of 1.	
  * 
  */
-public class CpmmSPInstruction extends BinarySPInstruction 
-{
-	
+public class CpmmSPInstruction extends BinarySPInstruction {
 	private SparkAggType _aggtype;
-	
-	public CpmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, SparkAggType aggtype, String opcode, String istr )
-	{
+
+	private CpmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, SparkAggType aggtype,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.CPMM;
 		_aggtype = aggtype;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CumulativeAggregateSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CumulativeAggregateSPInstruction.java
@@ -37,13 +37,12 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.data.OperationsOnMatrixValues;
 import org.apache.sysml.runtime.matrix.operators.AggregateUnaryOperator;
 
-public class CumulativeAggregateSPInstruction extends AggregateUnarySPInstruction 
-{
-	
-	public CumulativeAggregateSPInstruction(AggregateUnaryOperator op, CPOperand in1, CPOperand out, String opcode, String istr )
-	{
+public class CumulativeAggregateSPInstruction extends AggregateUnarySPInstruction {
+
+	private CumulativeAggregateSPInstruction(AggregateUnaryOperator op, CPOperand in1, CPOperand out, String opcode,
+			String istr) {
 		super(op, null, in1, out, null, opcode, istr);
-		_sptype = SPINSTRUCTION_TYPE.CumsumAggregate;		
+		_sptype = SPINSTRUCTION_TYPE.CumsumAggregate;
 	}
 
 	public static CumulativeAggregateSPInstruction parseInstruction( String str ) 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/CumulativeOffsetSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/CumulativeOffsetSPInstruction.java
@@ -43,36 +43,30 @@ import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
-
-public class CumulativeOffsetSPInstruction extends BinarySPInstruction 
-{
-
+public class CumulativeOffsetSPInstruction extends BinarySPInstruction {
 	private BinaryOperator _bop = null;
 	private UnaryOperator _uop = null;
 	private double _initValue = 0;
-	
-	public CumulativeOffsetSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, double init, String opcode, String istr)
-	{
+
+	private CumulativeOffsetSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, double init,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.CumsumOffset;
-		
-		if( "bcumoffk+".equals(opcode) ) {
+
+		if ("bcumoffk+".equals(opcode)) {
 			_bop = new BinaryOperator(Plus.getPlusFnObject());
 			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucumk+"));
-		}
-		else if( "bcumoff*".equals(opcode) ){
+		} else if ("bcumoff*".equals(opcode)) {
 			_bop = new BinaryOperator(Multiply.getMultiplyFnObject());
-			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucum*"));	
-		}
-		else if( "bcumoffmin".equals(opcode) ){
+			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucum*"));
+		} else if ("bcumoffmin".equals(opcode)) {
 			_bop = new BinaryOperator(Builtin.getBuiltinFnObject("min"));
-			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummin"));	
-		}
-		else if( "bcumoffmax".equals(opcode) ){
+			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummin"));
+		} else if ("bcumoffmax".equals(opcode)) {
 			_bop = new BinaryOperator(Builtin.getBuiltinFnObject("max"));
-			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummax"));	
+			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummax"));
 		}
-		
+
 		_initValue = init;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameAppendMSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameAppendMSPInstruction.java
@@ -36,13 +36,13 @@ import org.apache.sysml.runtime.instructions.spark.data.PartitionedBroadcast;
 import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class FrameAppendMSPInstruction extends AppendMSPInstruction
-{
-	public FrameAppendMSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand out, boolean cbind, String opcode, String istr)
-	{
+public class FrameAppendMSPInstruction extends AppendMSPInstruction {
+
+	protected FrameAppendMSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand out,
+			boolean cbind, String opcode, String istr) {
 		super(op, in1, in2, offset, out, cbind, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec)
 		throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameAppendRSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameAppendRSPInstruction.java
@@ -34,13 +34,13 @@ import org.apache.sysml.runtime.instructions.spark.utils.FrameRDDAggregateUtils;
 import org.apache.sysml.runtime.matrix.data.FrameBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class FrameAppendRSPInstruction extends AppendRSPInstruction
-{
-	public FrameAppendRSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean cbind, String opcode, String istr)
-	{
+public class FrameAppendRSPInstruction extends AppendRSPInstruction {
+
+	protected FrameAppendRSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean cbind,
+			String opcode, String istr) {
 		super(op, in1, in2, out, cbind, opcode, istr);
 	}
-		
+
 	@Override
 	public void processInstruction(ExecutionContext ec)
 		throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameIndexingSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/FrameIndexingSPInstruction.java
@@ -47,35 +47,31 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.IndexRange;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class FrameIndexingSPInstruction  extends IndexingSPInstruction
-{
-	
-	/*
-	 * This class implements the frame indexing functionality inside Spark.  
-	 * Example instructions: 
-	 *     rangeReIndex:mVar1:Var2:Var3:Var4:Var5:mVar6
-	 *         input=mVar1, output=mVar6, 
-	 *         bounds = (Var2,Var3,Var4,Var5)
-	 *         rowindex_lower: Var2, rowindex_upper: Var3 
-	 *         colindex_lower: Var4, colindex_upper: Var5
-	 *     leftIndex:mVar1:mVar2:Var3:Var4:Var5:Var6:mVar7
-	 *         triggered by "mVar1[Var3:Var4, Var5:Var6] = mVar2"
-	 *         the result is stored in mVar7
-	 *  
-	 */
-	public FrameIndexingSPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, 
-			                          CPOperand out, SparkAggType aggtype, String opcode, String istr)
-	{
+/**
+ * This class implements the frame indexing functionality inside Spark.  
+ * Example instructions: 
+ *     rangeReIndex:mVar1:Var2:Var3:Var4:Var5:mVar6
+ *         input=mVar1, output=mVar6, 
+ *         bounds = (Var2,Var3,Var4,Var5)
+ *         rowindex_lower: Var2, rowindex_upper: Var3 
+ *         colindex_lower: Var4, colindex_upper: Var5
+ *     leftIndex:mVar1:mVar2:Var3:Var4:Var5:Var6:mVar7
+ *         triggered by "mVar1[Var3:Var4, Var5:Var6] = mVar2"
+ *         the result is stored in mVar7
+ *  
+ */
+public class FrameIndexingSPInstruction extends IndexingSPInstruction {
+
+	protected FrameIndexingSPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl,
+			CPOperand cu, CPOperand out, SparkAggType aggtype, String opcode, String istr) {
 		super(op, in, rl, ru, cl, cu, out, aggtype, opcode, istr);
 	}
-	
-	public FrameIndexingSPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, 
-			                          CPOperand out, String opcode, String istr)
-	{
+
+	protected FrameIndexingSPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl,
+			CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, String opcode, String istr) {
 		super(op, lhsInput, rhsInput, rl, ru, cl, cu, out, opcode, istr);
 	}
-	
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec)
 			throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/IndexingSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/IndexingSPInstruction.java
@@ -28,28 +28,25 @@ import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 
-public abstract class IndexingSPInstruction  extends UnarySPInstruction
-{
-	
-	/*
-	 * This class implements the matrix indexing functionality inside Spark.  
-	 * Example instructions: 
-	 *     rangeReIndex:mVar1:Var2:Var3:Var4:Var5:mVar6
-	 *         input=mVar1, output=mVar6, 
-	 *         bounds = (Var2,Var3,Var4,Var5)
-	 *         rowindex_lower: Var2, rowindex_upper: Var3 
-	 *         colindex_lower: Var4, colindex_upper: Var5
-	 *     leftIndex:mVar1:mVar2:Var3:Var4:Var5:Var6:mVar7
-	 *         triggered by "mVar1[Var3:Var4, Var5:Var6] = mVar2"
-	 *         the result is stored in mVar7
-	 *  
-	 */
+/**
+ * This class implements the matrix indexing functionality inside Spark.  
+ * Example instructions: 
+ *     rangeReIndex:mVar1:Var2:Var3:Var4:Var5:mVar6
+ *         input=mVar1, output=mVar6, 
+ *         bounds = (Var2,Var3,Var4,Var5)
+ *         rowindex_lower: Var2, rowindex_upper: Var3 
+ *         colindex_lower: Var4, colindex_upper: Var5
+ *     leftIndex:mVar1:mVar2:Var3:Var4:Var5:Var6:mVar7
+ *         triggered by "mVar1[Var3:Var4, Var5:Var6] = mVar2"
+ *         the result is stored in mVar7
+ *  
+ */
+public abstract class IndexingSPInstruction extends UnarySPInstruction {
 	protected CPOperand rowLower, rowUpper, colLower, colUpper;
 	protected SparkAggType _aggType = null;
-	
-	public IndexingSPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, 
-			                          CPOperand out, SparkAggType aggtype, String opcode, String istr)
-	{
+
+	IndexingSPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu,
+			CPOperand out, SparkAggType aggtype, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
 		rowLower = rl;
 		rowUpper = ru;
@@ -58,17 +55,16 @@ public abstract class IndexingSPInstruction  extends UnarySPInstruction
 
 		_aggType = aggtype;
 	}
-	
-	public IndexingSPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, 
-			                          CPOperand out, String opcode, String istr)
-	{
+
+	IndexingSPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl, CPOperand ru, CPOperand cl,
+			CPOperand cu, CPOperand out, String opcode, String istr) {
 		super(op, lhsInput, rhsInput, out, opcode, istr);
 		rowLower = rl;
 		rowUpper = ru;
 		colLower = cl;
 		colUpper = cu;
 	}
-	
+
 	public static IndexingSPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{	

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MapmmChainSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MapmmChainSPInstruction.java
@@ -39,41 +39,35 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MapmmChainSPInstruction extends SPInstruction 
-{
-		
+public class MapmmChainSPInstruction extends SPInstruction {
 	private ChainType _chainType = null;
-	
 	private CPOperand _input1 = null;
 	private CPOperand _input2 = null;
-	private CPOperand _input3 = null;	
-	private CPOperand _output = null;	
-	
-	
-	public MapmmChainSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, 
-			                       ChainType type, String opcode, String istr )
-	{
+	private CPOperand _input3 = null;
+	private CPOperand _output = null;
+
+	private MapmmChainSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, ChainType type,
+			String opcode, String istr) {
 		super(op, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.MAPMMCHAIN;
-		
+
 		_input1 = in1;
 		_input2 = in2;
 		_output = out;
-		
+
 		_chainType = type;
 	}
-	
-	public MapmmChainSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, 
-                                   ChainType type, String opcode, String istr )
-	{
+
+	private MapmmChainSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			ChainType type, String opcode, String istr) {
 		super(op, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.MAPMMCHAIN;
-		
+
 		_input1 = in1;
 		_input2 = in2;
 		_input3 = in3;
 		_output = out;
-		
+
 		_chainType = type;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MapmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MapmmSPInstruction.java
@@ -55,18 +55,16 @@ import org.apache.sysml.runtime.matrix.operators.AggregateBinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MapmmSPInstruction extends BinarySPInstruction 
-{	
+public class MapmmSPInstruction extends BinarySPInstruction {
 	private CacheType _type = null;
 	private boolean _outputEmpty = true;
 	private SparkAggType _aggtype;
-	
-	public MapmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, CacheType type, 
-			boolean outputEmpty, SparkAggType aggtype, String opcode, String istr )
-	{
+
+	private MapmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, CacheType type,
+			boolean outputEmpty, SparkAggType aggtype, String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.MAPMM;
-		
+
 		_type = type;
 		_outputEmpty = outputEmpty;
 		_aggtype = aggtype;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixAppendMSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixAppendMSPInstruction.java
@@ -41,13 +41,13 @@ import org.apache.sysml.runtime.matrix.data.OperationsOnMatrixValues;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixAppendMSPInstruction extends AppendMSPInstruction
-{
-	public MatrixAppendMSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand out, boolean cbind, String opcode, String istr)
-	{
+public class MatrixAppendMSPInstruction extends AppendMSPInstruction {
+
+	protected MatrixAppendMSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand out,
+			boolean cbind, String opcode, String istr) {
 		super(op, in1, in2, offset, out, cbind, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec)
 		throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixAppendRSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixAppendRSPInstruction.java
@@ -32,13 +32,13 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixAppendRSPInstruction extends AppendRSPInstruction
-{
-	public MatrixAppendRSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean cbind, String opcode, String istr)
-	{
+public class MatrixAppendRSPInstruction extends AppendRSPInstruction {
+
+	protected MatrixAppendRSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean cbind,
+			String opcode, String istr) {
 		super(op, in1, in2, out, cbind, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec)
 		throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixBVectorArithmeticSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixBVectorArithmeticSPInstruction.java
@@ -25,24 +25,19 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixBVectorArithmeticSPInstruction extends ArithmeticBinarySPInstruction 
-{
-	
+public class MatrixBVectorArithmeticSPInstruction extends ArithmeticBinarySPInstruction {
 	private VectorType _vtype = null;
-	
-	public MatrixBVectorArithmeticSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, VectorType vtype, String opcode, String istr) 
-		throws DMLRuntimeException 
-	{
+
+	protected MatrixBVectorArithmeticSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			VectorType vtype, String opcode, String istr) throws DMLRuntimeException {
 		super(op, in1, in2, out, opcode, istr);
-		
 		_vtype = vtype;
-		
-		//sanity check opcodes
-		if (!( opcode.equalsIgnoreCase("map+") || opcode.equalsIgnoreCase("map-") || opcode.equalsIgnoreCase("map*")
-			 ||opcode.equalsIgnoreCase("map/") || opcode.equalsIgnoreCase("map%%") || opcode.equalsIgnoreCase("map%/%")
-			 ||opcode.equalsIgnoreCase("map^") || opcode.equalsIgnoreCase("map1-*")) )
-		{
-			throw new DMLRuntimeException("Unknown opcode in MatrixBVectorArithmeticSPInstruction: " + toString());		
+		// sanity check opcodes
+		if (!(opcode.equalsIgnoreCase("map+") || opcode.equalsIgnoreCase("map-") || opcode.equalsIgnoreCase("map*")
+				|| opcode.equalsIgnoreCase("map/") || opcode.equalsIgnoreCase("map%%")
+				|| opcode.equalsIgnoreCase("map%/%") || opcode.equalsIgnoreCase("map^")
+				|| opcode.equalsIgnoreCase("map1-*"))) {
+			throw new DMLRuntimeException("Unknown opcode in MatrixBVectorArithmeticSPInstruction: " + toString());
 		}
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixBVectorBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixBVectorBuiltinSPInstruction.java
@@ -26,21 +26,15 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixBVectorBuiltinSPInstruction extends BuiltinBinarySPInstruction 
-{
-	
+public class MatrixBVectorBuiltinSPInstruction extends BuiltinBinarySPInstruction {
 	private VectorType _vtype = null;
-	
-	public MatrixBVectorBuiltinSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, VectorType vtype, String opcode, String istr) 
-		throws DMLRuntimeException 
-	{
+
+	protected MatrixBVectorBuiltinSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			VectorType vtype, String opcode, String istr) throws DMLRuntimeException {
 		super(op, in1, in2, out, opcode, istr);
-		
 		_vtype = vtype;
-		
-		//sanity check opcodes
-		if(!( opcode.equalsIgnoreCase("mapmax") || opcode.equalsIgnoreCase("mapmin")) ) 
-		{
+		// sanity check opcodes
+		if (!(opcode.equalsIgnoreCase("mapmax") || opcode.equalsIgnoreCase("mapmin"))) {
 			throw new DMLRuntimeException("Unknown opcode in MatrixBVectorBuiltinSPInstruction: " + toString());
 		}
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixBVectorRelationalSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixBVectorRelationalSPInstruction.java
@@ -26,22 +26,17 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixBVectorRelationalSPInstruction extends RelationalBinarySPInstruction 
-{
-	
+public class MatrixBVectorRelationalSPInstruction extends RelationalBinarySPInstruction {
 	private VectorType _vtype = null;
-	
-	public MatrixBVectorRelationalSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, VectorType vtype, String opcode, String istr) 
-		throws DMLRuntimeException
-	{
+
+	protected MatrixBVectorRelationalSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			VectorType vtype, String opcode, String istr) throws DMLRuntimeException {
 		super(op, in1, in2, out, opcode, istr);
-	
 		_vtype = vtype;
-		
-		//sanity check opcodes
-		if(!( opcode.equalsIgnoreCase("map==") || opcode.equalsIgnoreCase("map!=") || opcode.equalsIgnoreCase("map<")
-			||opcode.equalsIgnoreCase("map>") || opcode.equalsIgnoreCase("map<=") || opcode.equalsIgnoreCase("map>=")) ) 
-		{
+		// sanity check opcodes
+		if (!(opcode.equalsIgnoreCase("map==") || opcode.equalsIgnoreCase("map!=") || opcode.equalsIgnoreCase("map<")
+				|| opcode.equalsIgnoreCase("map>") || opcode.equalsIgnoreCase("map<=")
+				|| opcode.equalsIgnoreCase("map>="))) {
 			throw new DMLRuntimeException("Unknown opcode in MatrixBVectorRelationalSPInstruction: " + toString());
 		}
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixBuiltinSPInstruction.java
@@ -30,10 +30,9 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
-public class MatrixBuiltinSPInstruction extends BuiltinUnarySPInstruction
-{
-	
-	public MatrixBuiltinSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr) {
+public class MatrixBuiltinSPInstruction extends BuiltinUnarySPInstruction {
+
+	protected MatrixBuiltinSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr) {
 		super(op, in, out, opcode, instr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixIndexingSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixIndexingSPInstruction.java
@@ -71,24 +71,21 @@ import org.apache.sysml.runtime.util.UtilFunctions;
  *         the result is stored in mVar7
  *  
  */
-public class MatrixIndexingSPInstruction  extends IndexingSPInstruction
-{
+public class MatrixIndexingSPInstruction extends IndexingSPInstruction {
 	private final LixCacheType _type;
 
-	public MatrixIndexingSPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, 
-			                          CPOperand out, SparkAggType aggtype, String opcode, String istr)
-	{
+	protected MatrixIndexingSPInstruction(Operator op, CPOperand in, CPOperand rl, CPOperand ru, CPOperand cl,
+			CPOperand cu, CPOperand out, SparkAggType aggtype, String opcode, String istr) {
 		super(op, in, rl, ru, cl, cu, out, aggtype, opcode, istr);
 		_type = LixCacheType.NONE;
 	}
-	
-	public MatrixIndexingSPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl, CPOperand ru, CPOperand cl, CPOperand cu, 
-			                          CPOperand out, LixCacheType type, String opcode, String istr)
-	{
+
+	protected MatrixIndexingSPInstruction(Operator op, CPOperand lhsInput, CPOperand rhsInput, CPOperand rl,
+			CPOperand ru, CPOperand cl, CPOperand cu, CPOperand out, LixCacheType type, String opcode, String istr) {
 		super(op, lhsInput, rhsInput, rl, ru, cl, cu, out, opcode, istr);
 		_type = type;
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec)
 			throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixMatrixArithmeticSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixMatrixArithmeticSPInstruction.java
@@ -24,23 +24,20 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixMatrixArithmeticSPInstruction extends ArithmeticBinarySPInstruction
-{
-	
-	public MatrixMatrixArithmeticSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) 
-		throws DMLRuntimeException
-	{
+public class MatrixMatrixArithmeticSPInstruction extends ArithmeticBinarySPInstruction {
+
+	protected MatrixMatrixArithmeticSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) throws DMLRuntimeException {
 		super(op, in1, in2, out, opcode, istr);
-		
-		//sanity check opcodes
-		if ( !(  opcode.equalsIgnoreCase("+") || opcode.equalsIgnoreCase("-") || opcode.equalsIgnoreCase("*")
-			  || opcode.equalsIgnoreCase("/") || opcode.equalsIgnoreCase("%%") || opcode.equalsIgnoreCase("%/%")
-			  || opcode.equalsIgnoreCase("^") || opcode.equalsIgnoreCase("1-*") ) ) 
-		{
+
+		// sanity check opcodes
+		if (!(opcode.equalsIgnoreCase("+") || opcode.equalsIgnoreCase("-") || opcode.equalsIgnoreCase("*")
+				|| opcode.equalsIgnoreCase("/") || opcode.equalsIgnoreCase("%%") || opcode.equalsIgnoreCase("%/%")
+				|| opcode.equalsIgnoreCase("^") || opcode.equalsIgnoreCase("1-*"))) {
 			throw new DMLRuntimeException("Unknown opcode in MatrixMatrixArithmeticSPInstruction: " + toString());
-		}		
+		}
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixMatrixBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixMatrixBuiltinSPInstruction.java
@@ -24,14 +24,13 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixMatrixBuiltinSPInstruction extends BuiltinBinarySPInstruction
-{
-	
-	public MatrixMatrixBuiltinSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr)
-	{
+public class MatrixMatrixBuiltinSPInstruction extends BuiltinBinarySPInstruction {
+
+	protected MatrixMatrixBuiltinSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixMatrixRelationalSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixMatrixRelationalSPInstruction.java
@@ -24,23 +24,19 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
+public class MatrixMatrixRelationalSPInstruction extends RelationalBinarySPInstruction {
 
-public class MatrixMatrixRelationalSPInstruction extends RelationalBinarySPInstruction 
-{
-	
-	public MatrixMatrixRelationalSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) 
-		throws DMLRuntimeException
-	{
+	protected MatrixMatrixRelationalSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) throws DMLRuntimeException {
 		super(op, in1, in2, out, opcode, istr);
-		
-		//sanity check opcodes
-		if (!( opcode.equalsIgnoreCase("==") || opcode.equalsIgnoreCase("!=") || opcode.equalsIgnoreCase("<")
-			|| opcode.equalsIgnoreCase(">") || opcode.equalsIgnoreCase("<=") || opcode.equalsIgnoreCase(">="))) 
-		{
-			throw new DMLRuntimeException("Unknown opcode in MatrixMatrixRelationalSPInstruction: " + toString());	
-		} 
+
+		// sanity check opcodes
+		if (!(opcode.equalsIgnoreCase("==") || opcode.equalsIgnoreCase("!=") || opcode.equalsIgnoreCase("<")
+				|| opcode.equalsIgnoreCase(">") || opcode.equalsIgnoreCase("<=") || opcode.equalsIgnoreCase(">="))) {
+			throw new DMLRuntimeException("Unknown opcode in MatrixMatrixRelationalSPInstruction: " + toString());
+		}
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixReshapeSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixReshapeSPInstruction.java
@@ -42,18 +42,17 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.mapred.IndexedMatrixValue;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixReshapeSPInstruction extends UnarySPInstruction
-{	
-	
+public class MatrixReshapeSPInstruction extends UnarySPInstruction {
+
 	private CPOperand _opRows = null;
 	private CPOperand _opCols = null;
 	private CPOperand _opByRow = null;
-	
-	public MatrixReshapeSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand in4, CPOperand out, String opcode, String istr)
-	{
+
+	private MatrixReshapeSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand in4,
+			CPOperand out, String opcode, String istr) {
 		super(op, in1, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.MatrixReshape;
-		
+
 		_opRows = in2;
 		_opCols = in3;
 		_opByRow = in4;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixScalarArithmeticSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixScalarArithmeticSPInstruction.java
@@ -24,13 +24,13 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixScalarArithmeticSPInstruction extends ArithmeticBinarySPInstruction
-{
-	
-	public MatrixScalarArithmeticSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
+public class MatrixScalarArithmeticSPInstruction extends ArithmeticBinarySPInstruction {
+
+	protected MatrixScalarArithmeticSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixScalarBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixScalarBuiltinSPInstruction.java
@@ -24,14 +24,13 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixScalarBuiltinSPInstruction extends BuiltinBinarySPInstruction
-{
-	
-	public MatrixScalarBuiltinSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String instr)
-	{
+public class MatrixScalarBuiltinSPInstruction extends BuiltinBinarySPInstruction {
+
+	protected MatrixScalarBuiltinSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String instr) {
 		super(op, in1, in2, out, opcode, instr);
 	}
-	
+
 	@Override 
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixScalarRelationalSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MatrixScalarRelationalSPInstruction.java
@@ -24,11 +24,10 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class MatrixScalarRelationalSPInstruction extends RelationalBinarySPInstruction  
-{
-	
-	public MatrixScalarRelationalSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr)
-	{
+public class MatrixScalarRelationalSPInstruction extends RelationalBinarySPInstruction {
+
+	protected MatrixScalarRelationalSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/MultiReturnParameterizedBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/MultiReturnParameterizedBuiltinSPInstruction.java
@@ -67,12 +67,11 @@ import org.apache.sysml.runtime.transform.meta.TfOffsetMap;
 
 import scala.Tuple2;
 
-
-public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPInstruction 
-{
+public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPInstruction {
 	protected ArrayList<CPOperand> _outputs;
-	
-	public MultiReturnParameterizedBuiltinSPInstruction(Operator op, CPOperand input1, CPOperand input2, ArrayList<CPOperand> outputs, String opcode, String istr ) {
+
+	private MultiReturnParameterizedBuiltinSPInstruction(Operator op, CPOperand input1, CPOperand input2,
+			ArrayList<CPOperand> outputs, String opcode, String istr) {
 		super(op, input1, input2, outputs.get(0), opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.MultiReturnBuiltin;
 		_outputs = outputs;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/PMapmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/PMapmmSPInstruction.java
@@ -55,13 +55,10 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
  * not integrated in automatic operator selection yet.
  * 
  */
-public class PMapmmSPInstruction extends BinarySPInstruction 
-{
-	private static final int NUM_ROWBLOCKS=4;
-	
-	public PMapmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, 
-			                    String opcode, String istr )
-	{
+public class PMapmmSPInstruction extends BinarySPInstruction {
+	private static final int NUM_ROWBLOCKS = 4;
+
+	private PMapmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.MAPMM;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/ParameterizedBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/ParameterizedBuiltinSPInstruction.java
@@ -83,16 +83,13 @@ import org.apache.sysml.runtime.transform.meta.TfOffsetMap;
 import org.apache.sysml.runtime.util.DataConverter;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-
-public class ParameterizedBuiltinSPInstruction  extends ComputationSPInstruction 
-{	
-	protected HashMap<String,String> params;
-	
-	//removeEmpty-specific attributes
+public class ParameterizedBuiltinSPInstruction extends ComputationSPInstruction {
+	protected HashMap<String, String> params;
+	// removeEmpty-specific attributes
 	private boolean _bRmEmptyBC = false;
-	
-	public ParameterizedBuiltinSPInstruction(Operator op, HashMap<String,String> paramsMap, CPOperand out, String opcode, String istr, boolean bRmEmptyBC )
-	{
+
+	private ParameterizedBuiltinSPInstruction(Operator op, HashMap<String, String> paramsMap, CPOperand out,
+			String opcode, String istr, boolean bRmEmptyBC) {
 		super(op, null, null, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.ParameterizedBuiltin;
 		params = paramsMap;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/PlusMultSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/PlusMultSPInstruction.java
@@ -30,21 +30,18 @@ import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.instructions.cp.ScalarObject;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 
-public class PlusMultSPInstruction extends  ArithmeticBinarySPInstruction
-{
-	public PlusMultSPInstruction(BinaryOperator op, CPOperand in1, CPOperand in2, 
-			CPOperand in3, CPOperand out, String opcode, String str) throws DMLRuntimeException 
-	{
+public class PlusMultSPInstruction extends ArithmeticBinarySPInstruction {
+	private PlusMultSPInstruction(BinaryOperator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String str) throws DMLRuntimeException {
 		super(op, in1, in2, out, opcode, str);
-		input3= in3;
-		
-		//sanity check opcodes
-		if ( !(  opcode.equalsIgnoreCase("+*") || opcode.equalsIgnoreCase("-*")  ) ) 
-		{
+		input3 = in3;
+
+		// sanity check opcodes
+		if (!(opcode.equalsIgnoreCase("+*") || opcode.equalsIgnoreCase("-*"))) {
 			throw new DMLRuntimeException("Unknown opcode in PlusMultSPInstruction: " + toString());
-		}		
+		}
 	}
-	
+
 	public static PlusMultSPInstruction parseInstruction(String str) throws DMLRuntimeException
 	{
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/PmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/PmmSPInstruction.java
@@ -48,17 +48,14 @@ import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class PmmSPInstruction extends BinarySPInstruction 
-{
-	
+public class PmmSPInstruction extends BinarySPInstruction {
 	private CacheType _type = null;
 	private CPOperand _nrow = null;
-	
-	public PmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, CPOperand nrow,
-			                CacheType type, String opcode, String istr )
-	{
+
+	private PmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, CPOperand nrow, CacheType type,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
-		_sptype = SPINSTRUCTION_TYPE.PMM;		
+		_sptype = SPINSTRUCTION_TYPE.PMM;
 		_type = type;
 		_nrow = nrow;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/QuantilePickSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/QuantilePickSPInstruction.java
@@ -42,20 +42,21 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class QuantilePickSPInstruction extends BinarySPInstruction
-{
+public class QuantilePickSPInstruction extends BinarySPInstruction {
 	private OperationTypes _type = null;
-	
-	public QuantilePickSPInstruction(Operator op, CPOperand in, CPOperand out, OperationTypes type, boolean inmem, String opcode, String istr){
+
+	private QuantilePickSPInstruction(Operator op, CPOperand in, CPOperand out, OperationTypes type, boolean inmem,
+			String opcode, String istr) {
 		this(op, in, null, out, type, inmem, opcode, istr);
 	}
-	
-	public QuantilePickSPInstruction(Operator op, CPOperand in, CPOperand in2, CPOperand out,  OperationTypes type, boolean inmem, String opcode, String istr){
+
+	private QuantilePickSPInstruction(Operator op, CPOperand in, CPOperand in2, CPOperand out, OperationTypes type,
+			boolean inmem, String opcode, String istr) {
 		super(op, in, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.QPick;
-		
+
 		_type = type;
-		//inmem ignored here
+		// inmem ignored here
 	}
 
 	public static QuantilePickSPInstruction parseInstruction ( String str ) 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/QuantileSortSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/QuantileSortSPInstruction.java
@@ -36,27 +36,26 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 
-public class QuantileSortSPInstruction extends UnarySPInstruction
-{
-	
-	/*
-	 * This class supports two variants of sort operation on a 1-dimensional input matrix. 
-	 * The two variants are <code> weighted </code> and <code> unweighted </code>.
-	 * Example instructions: 
-	 *     sort:mVar1:mVar2 (input=mVar1, output=mVar2)
-	 *     sort:mVar1:mVar2:mVar3 (input=mVar1, weights=mVar2, output=mVar3)
-	 *  
-	 */
-	
-	public QuantileSortSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr){
+/**
+ * This class supports two variants of sort operation on a 1-dimensional input matrix. 
+ * The two variants are <code> weighted </code> and <code> unweighted </code>.
+ * Example instructions: 
+ *     sort:mVar1:mVar2 (input=mVar1, output=mVar2)
+ *     sort:mVar1:mVar2:mVar3 (input=mVar1, weights=mVar2, output=mVar3)
+ *  
+ */
+public class QuantileSortSPInstruction extends UnarySPInstruction {
+
+	private QuantileSortSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		this(op, in, null, out, opcode, istr);
 	}
-	
-	public QuantileSortSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr){
+
+	private QuantileSortSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.QSort;
 	}
-	
+
 	public static QuantileSortSPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException {
 		CPOperand in1 = new CPOperand("", ValueType.UNKNOWN, DataType.UNKNOWN);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/QuaternarySPInstruction.java
@@ -19,7 +19,6 @@
 
 package org.apache.sysml.runtime.instructions.spark;
 
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -60,19 +59,17 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.QuaternaryOperator;
 
-public class QuaternarySPInstruction extends ComputationSPInstruction 
-{
-	
+public class QuaternarySPInstruction extends ComputationSPInstruction {
 	private CPOperand _input4 = null;
 	private boolean _cacheU = false;
 	private boolean _cacheV = false;
-	
-	public QuaternarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand in4, CPOperand out, boolean cacheU, boolean cacheV, String opcode, String str)
-	{
+
+	private QuaternarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand in4,
+			CPOperand out, boolean cacheU, boolean cacheV, String opcode, String str) {
 		super(op, in1, in2, in3, out, opcode, str);
 		_sptype = SPINSTRUCTION_TYPE.Quaternary;
 		_input4 = in4;
-		
+
 		_cacheU = cacheU;
 		_cacheV = cacheV;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/RandSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/RandSPInstruction.java
@@ -66,13 +66,12 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.util.UtilFunctions;
 import org.apache.sysml.utils.Statistics;
 
-public class RandSPInstruction extends UnarySPInstruction
-{
-	//internal configuration
+public class RandSPInstruction extends UnarySPInstruction {
+	// internal configuration
 	private static final long INMEMORY_NUMBLOCKS_THRESHOLD = 1024 * 1024;
-	
+
 	private DataGenMethod method = DataGenMethod.INVALID;
-	
+
 	private long rows;
 	private long cols;
 	private int rowsInBlock;
@@ -82,21 +81,20 @@ public class RandSPInstruction extends UnarySPInstruction
 	private double sparsity;
 	private String pdf;
 	private String pdfParams;
-	private long seed=0;
+	private long seed = 0;
 	private String dir;
 	private double seq_from;
-	private double seq_to; 
+	private double seq_to;
 	private double seq_incr;
-	
-	//sample specific attributes
+
+	// sample specific attributes
 	private boolean replace;
 
-	public RandSPInstruction (Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, long rows, long cols, 
+	private RandSPInstruction(Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, long rows, long cols,
 			int rpb, int cpb, double minValue, double maxValue, double sparsity, long seed, String dir,
-			String probabilityDensityFunction, String pdfParams, String opcode, String istr) 
-	{
+			String probabilityDensityFunction, String pdfParams, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
-		
+
 		this.method = mthd;
 		this.rows = rows;
 		this.cols = cols;
@@ -112,10 +110,8 @@ public class RandSPInstruction extends UnarySPInstruction
 
 	}
 
-	public RandSPInstruction(Operator op, DataGenMethod mthd, CPOperand in, CPOperand out,
-			long rows, long cols, int rpb, int cpb, double seqFrom,
-			double seqTo, double seqIncr, String opcode, String istr) 
-	{
+	private RandSPInstruction(Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, long rows, long cols,
+			int rpb, int cpb, double seqFrom, double seqTo, double seqIncr, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
 		this.method = mthd;
 		this.rows = rows;
@@ -127,10 +123,8 @@ public class RandSPInstruction extends UnarySPInstruction
 		this.seq_incr = seqIncr;
 	}
 
-	public RandSPInstruction(Operator op, DataGenMethod mthd, CPOperand in,
-			CPOperand out, long rows, long cols, int rpb, int cpb,
-			double maxValue, boolean replace, long seed, String opcode,
-			String istr) {
+	private RandSPInstruction(Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, long rows, long cols,
+			int rpb, int cpb, double maxValue, boolean replace, long seed, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
 
 		this.method = mthd;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/ReblockSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/ReblockSPInstruction.java
@@ -46,21 +46,19 @@ import org.apache.sysml.runtime.matrix.data.MatrixCell;
 import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class ReblockSPInstruction extends UnarySPInstruction 
-{
-	private int brlen; 
+public class ReblockSPInstruction extends UnarySPInstruction {
+	private int brlen;
 	private int bclen;
 	private boolean outputEmptyBlocks;
-	
-	public ReblockSPInstruction(Operator op, CPOperand in, CPOperand out, int br, int bc, boolean emptyBlocks,
-			String opcode, String instr) 
-	{
+
+	private ReblockSPInstruction(Operator op, CPOperand in, CPOperand out, int br, int bc, boolean emptyBlocks,
+			String opcode, String instr) {
 		super(op, in, out, opcode, instr);
-		brlen=br;
-		bclen=bc;
+		brlen = br;
+		bclen = bc;
 		outputEmptyBlocks = emptyBlocks;
 	}
-	
+
 	public static ReblockSPInstruction parseInstruction(String str)  throws DMLRuntimeException 
 	{
 		String parts[] = InstructionUtils.getInstructionPartsWithValueType(str);

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/RelationalBinarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/RelationalBinarySPInstruction.java
@@ -29,13 +29,13 @@ import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
 public abstract class RelationalBinarySPInstruction extends BinarySPInstruction {
-	
-	public RelationalBinarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr )
-	{
+
+	protected RelationalBinarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.RelationalBinary;
 	}
-	
+
 	public static RelationalBinarySPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/ReorgSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/ReorgSPInstruction.java
@@ -54,21 +54,20 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class ReorgSPInstruction extends UnarySPInstruction
-{
-	
-	//sort-specific attributes (to enable variable attributes)
- 	private CPOperand _col = null;
- 	private CPOperand _desc = null;
- 	private CPOperand _ixret = null;
- 	private boolean _bSortIndInMem = false;
-	 	
-	public ReorgSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr){
+public class ReorgSPInstruction extends UnarySPInstruction {
+	// sort-specific attributes (to enable variable attributes)
+	private CPOperand _col = null;
+	private CPOperand _desc = null;
+	private CPOperand _ixret = null;
+	private boolean _bSortIndInMem = false;
+
+	private ReorgSPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		super(op, in, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.Reorg;
 	}
-	
-	public ReorgSPInstruction(Operator op, CPOperand in, CPOperand col, CPOperand desc, CPOperand ixret, CPOperand out, String opcode, boolean bSortIndInMem, String istr){
+
+	private ReorgSPInstruction(Operator op, CPOperand in, CPOperand col, CPOperand desc, CPOperand ixret, CPOperand out,
+			String opcode, boolean bSortIndInMem, String istr) {
 		this(op, in, out, opcode, istr);
 		_col = col;
 		_desc = desc;
@@ -76,7 +75,7 @@ public class ReorgSPInstruction extends UnarySPInstruction
 		_sptype = SPINSTRUCTION_TYPE.Reorg;
 		_bSortIndInMem = bSortIndInMem;
 	}
-	
+
 	public static ReorgSPInstruction parseInstruction ( String str ) 
 		throws DMLRuntimeException 
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/RmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/RmmSPInstruction.java
@@ -48,13 +48,11 @@ import org.apache.sysml.runtime.matrix.operators.AggregateBinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public class RmmSPInstruction extends BinarySPInstruction 
-{
-	
-	public RmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr )
-	{
+public class RmmSPInstruction extends BinarySPInstruction {
+
+	private RmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
-		_sptype = SPINSTRUCTION_TYPE.RMM;		
+		_sptype = SPINSTRUCTION_TYPE.RMM;
 	}
 
 	public static RmmSPInstruction parseInstruction( String str ) 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/SPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/SPInstruction.java
@@ -27,9 +27,8 @@ import org.apache.sysml.runtime.instructions.SPInstructionParser;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.utils.Statistics;
 
-public abstract class SPInstruction extends Instruction 
-{
-	
+public abstract class SPInstruction extends Instruction {
+
 	public enum SPINSTRUCTION_TYPE { 
 		MAPMM, MAPMMCHAIN, CPMM, RMM, TSMM, TSMM2, PMM, ZIPMM, PMAPMM, //matrix multiplication instructions  
 		MatrixIndexing, Reorg, ArithmeticBinary, RelationalBinary, AggregateUnary, AggregateTernary, Reblock, CSVReblock, 
@@ -40,26 +39,25 @@ public abstract class SPInstruction extends Instruction
 		Write, SpoofFused, INVALID, 
 		Convolution
 	};
-	
+
 	protected SPINSTRUCTION_TYPE _sptype;
 	protected Operator _optr;
-	
 	protected boolean _requiresLabelUpdate = false;
-	
-	public SPInstruction(String opcode, String istr) {
+
+	protected SPInstruction(String opcode, String istr) {
 		type = INSTRUCTION_TYPE.SPARK;
 		instString = istr;
 		instOpcode = opcode;
-		
-		//update requirement for repeated usage
+
+		// update requirement for repeated usage
 		_requiresLabelUpdate = super.requiresLabelUpdate();
 	}
-	
-	public SPInstruction(Operator op, String opcode, String istr) {
+
+	protected SPInstruction(Operator op, String opcode, String istr) {
 		this(opcode, istr);
 		_optr = op;
 	}
-	
+
 	public SPINSTRUCTION_TYPE getSPInstructionType() {
 		return _sptype;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/SpoofSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/SpoofSPInstruction.java
@@ -66,14 +66,14 @@ import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 
 import scala.Tuple2;
 
-public class SpoofSPInstruction extends SPInstruction
-{
+public class SpoofSPInstruction extends SPInstruction {
 	private final Class<?> _class;
 	private final byte[] _classBytes;
 	private final CPOperand[] _in;
 	private final CPOperand _out;
-	
-	public SpoofSPInstruction(Class<?> cls, byte[] classBytes, CPOperand[] in, CPOperand out, String opcode, String str) {
+
+	private SpoofSPInstruction(Class<?> cls, byte[] classBytes, CPOperand[] in, CPOperand out, String opcode,
+			String str) {
 		super(opcode, str);
 		_class = cls;
 		_classBytes = classBytes;
@@ -81,7 +81,7 @@ public class SpoofSPInstruction extends SPInstruction
 		_in = in;
 		_out = out;
 	}
-	
+
 	public static SpoofSPInstruction parseInstruction(String str) 
 		throws DMLRuntimeException
 	{

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/TernarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/TernarySPInstruction.java
@@ -53,20 +53,17 @@ import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
 import org.apache.sysml.runtime.util.LongLongDoubleHashMap.LLDoubleEntry;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
-public class TernarySPInstruction extends ComputationSPInstruction
-{
-	
+public class TernarySPInstruction extends ComputationSPInstruction {
 	private String _outDim1;
 	private String _outDim2;
-	private boolean _dim1Literal; 
+	private boolean _dim1Literal;
 	private boolean _dim2Literal;
 	private boolean _isExpand;
 	private boolean _ignoreZeros;
-	
-	public TernarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, 
-							 String outputDim1, boolean dim1Literal,String outputDim2, boolean dim2Literal, 
-							 boolean isExpand, boolean ignoreZeros, String opcode, String istr )
-	{
+
+	private TernarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String outputDim1, boolean dim1Literal, String outputDim2, boolean dim2Literal, boolean isExpand,
+			boolean ignoreZeros, String opcode, String istr) {
 		super(op, in1, in2, in3, out, opcode, istr);
 		_outDim1 = outputDim1;
 		_dim1Literal = dim1Literal;

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/Tsmm2SPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/Tsmm2SPInstruction.java
@@ -53,14 +53,12 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 
 import scala.Tuple2;
 
-public class Tsmm2SPInstruction extends UnarySPInstruction 
-{
+public class Tsmm2SPInstruction extends UnarySPInstruction {
 	private MMTSJType _type = null;
-	
-	public Tsmm2SPInstruction(Operator op, CPOperand in1, CPOperand out, MMTSJType type, String opcode, String istr )
-	{
+
+	private Tsmm2SPInstruction(Operator op, CPOperand in1, CPOperand out, MMTSJType type, String opcode, String istr) {
 		super(op, in1, out, opcode, istr);
-		_sptype = SPINSTRUCTION_TYPE.TSMM2;		
+		_sptype = SPINSTRUCTION_TYPE.TSMM2;
 		_type = type;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/TsmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/TsmmSPInstruction.java
@@ -36,15 +36,12 @@ import org.apache.sysml.runtime.matrix.operators.Operator;
 
 import scala.Tuple2;
 
-public class TsmmSPInstruction extends UnarySPInstruction 
-{
-	
+public class TsmmSPInstruction extends UnarySPInstruction {
 	private MMTSJType _type = null;
-	
-	public TsmmSPInstruction(Operator op, CPOperand in1, CPOperand out, MMTSJType type, String opcode, String istr )
-	{
+
+	private TsmmSPInstruction(Operator op, CPOperand in1, CPOperand out, MMTSJType type, String opcode, String istr) {
 		super(op, in1, out, opcode, istr);
-		_sptype = SPINSTRUCTION_TYPE.TSMM;		
+		_sptype = SPINSTRUCTION_TYPE.TSMM;
 		_type = type;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/UaggOuterChainSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/UaggOuterChainSPInstruction.java
@@ -61,22 +61,21 @@ import org.apache.sysml.runtime.util.DataConverter;
  * 1. Array of type double: Matrix B is sorted at driver level and passed to every task for cases where operations are handled with special cases. e.g. &lt;, RowSum
  * 2. PartitionedMatrixBlock:  Any operations not implemented through this change goes through generic process, In that case, task takes Matrix B, in partitioned form and operate on it.
  */
-public class UaggOuterChainSPInstruction extends BinarySPInstruction 
-{
-	//operators
+public class UaggOuterChainSPInstruction extends BinarySPInstruction {
+	// operators
 	private AggregateUnaryOperator _uaggOp = null;
 	private AggregateOperator _aggOp = null;
 	private BinaryOperator _bOp = null;
 
-	public UaggOuterChainSPInstruction(BinaryOperator bop, AggregateUnaryOperator uaggop, AggregateOperator aggop, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr )
-	{
+	private UaggOuterChainSPInstruction(BinaryOperator bop, AggregateUnaryOperator uaggop, AggregateOperator aggop,
+			CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
 		super(bop, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.UaggOuterChain;
-		
+
 		_uaggOp = uaggop;
 		_aggOp = aggop;
 		_bOp = bop;
-			
+
 		_sptype = SPINSTRUCTION_TYPE.UaggOuterChain;
 		instString = istr;
 	}

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/UnarySPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/UnarySPInstruction.java
@@ -24,21 +24,19 @@ import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.instructions.cp.CPOperand;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 
-public abstract class UnarySPInstruction extends ComputationSPInstruction
-{
-	
-	public UnarySPInstruction(Operator op, CPOperand in, CPOperand out,
-			String opcode, String instr) {
-		this (op, in, null, null, out, opcode, instr);
+public abstract class UnarySPInstruction extends ComputationSPInstruction {
+
+	protected UnarySPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr) {
+		this(op, in, null, null, out, opcode, instr);
 	}
 
-	public UnarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
-			String opcode, String instr) {
-		this (op, in1, in2, null, out, opcode, instr);
+	protected UnarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String instr) {
+		this(op, in1, in2, null, out, opcode, instr);
 	}
 
-	public UnarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
-			String opcode, String instr) {
+	protected UnarySPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out, String opcode,
+			String instr) {
 		super(op, in1, in2, in3, out, opcode, instr);
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/WriteSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/WriteSPInstruction.java
@@ -49,20 +49,19 @@ import org.apache.sysml.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysml.runtime.matrix.data.OutputInfo;
 import org.apache.sysml.runtime.util.MapReduceTool;
 
-public class WriteSPInstruction extends SPInstruction 
-{	
-	private CPOperand input1 = null; 
+public class WriteSPInstruction extends SPInstruction {
+	private CPOperand input1 = null;
 	private CPOperand input2 = null;
 	private CPOperand input3 = null;
 	private CPOperand input4 = null;
 	private FileFormatProperties formatProperties;
 
-	public WriteSPInstruction(CPOperand in1, CPOperand in2, CPOperand in3, String opcode, String str) {
+	private WriteSPInstruction(CPOperand in1, CPOperand in2, CPOperand in3, String opcode, String str) {
 		super(opcode, str);
 		input1 = in1;
 		input2 = in2;
 		input3 = in3;
-		
+
 		formatProperties = null; // set in case of csv
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/spark/ZipmmSPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/spark/ZipmmSPInstruction.java
@@ -41,17 +41,15 @@ import org.apache.sysml.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.ReorgOperator;
 
-
-public class ZipmmSPInstruction extends BinarySPInstruction 
-{
-	//internal flag to apply left-transpose rewrite or not
+public class ZipmmSPInstruction extends BinarySPInstruction {
+	// internal flag to apply left-transpose rewrite or not
 	private boolean _tRewrite = true;
-	
-	public ZipmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean tRewrite, String opcode, String istr )
-	{
+
+	private ZipmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean tRewrite,
+			String opcode, String istr) {
 		super(op, in1, in2, out, opcode, istr);
 		_sptype = SPINSTRUCTION_TYPE.ZIPMM;
-		
+
 		_tRewrite = tRewrite;
 	}
 


### PR DESCRIPTION
Instructions are usually created using static parseInstruction methods.
Therefore, change constructor scopes to either private or protected
where appropriate to reflect this actual usage.