### PR TITLE
[SYSTEMML-540] Support sparse im2col

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/CSRPointer.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/CSRPointer.java
@@ -185,13 +185,19 @@ public class CSRPointer {
 	 * @param rowPtr integer array of row pointers
 	 * @param colInd integer array of column indices
 	 * @param values double array of non zero values
+	 * @throws DMLRuntimeException if error occurs
 	 */
-	public static void copyToDevice(CSRPointer dest, int rows, long nnz, int[] rowPtr, int[] colInd, double[] values) {
+	public static void copyToDevice(CSRPointer dest, int rows, long nnz, int[] rowPtr, int[] colInd, double[] values) throws DMLRuntimeException {
 		CSRPointer r = dest;
 		long t0 = 0;
 		if (DMLScript.STATISTICS)
 			t0 = System.nanoTime();
 		r.nnz = nnz;
+		if(rows < 0) throw new DMLRuntimeException("Incorrect input parameter: rows=" + rows);
+		if(nnz < 0) throw new DMLRuntimeException("Incorrect input parameter: nnz=" + nnz);
+		if(rowPtr.length < rows + 1) throw new DMLRuntimeException("The length of rowPtr needs to be greater than or equal to " + (rows + 1));
+		if(colInd.length < nnz) throw new DMLRuntimeException("The length of colInd needs to be greater than or equal to " + nnz);
+		if(values.length < nnz) throw new DMLRuntimeException("The length of values needs to be greater than or equal to " + nnz);
 		cudaMemcpy(r.rowPtr, Pointer.to(rowPtr), getIntSizeOf(rows + 1), cudaMemcpyHostToDevice);
 		cudaMemcpy(r.colInd, Pointer.to(colInd), getIntSizeOf(nnz), cudaMemcpyHostToDevice);
 		cudaMemcpy(r.val, Pointer.to(values), getDoubleSizeOf(nnz), cudaMemcpyHostToDevice);

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNConv2dBackwardFilterHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNConv2dBackwardFilterHelper.java
@@ -84,7 +84,6 @@ public class LibMatrixDNNConv2dBackwardFilterHelper {
 			int PQ = _params.P*_params.Q; int K = _params.K; int CRS = _params.C*_params.R*_params.S;
 			MatrixBlock dout = _params.input2;
 			MatrixBlock im2ColOutBlock = new MatrixBlock(CRS, PQ, false);
-			im2ColOutBlock.allocateDenseBlock();
 			MatrixBlock dout_reshaped = new MatrixBlock(PQ, K, false);
 			dout_reshaped.allocateDenseBlock();
 			LibMatrixDNNIm2ColHelper.Im2colWorker im2ColWorker = LibMatrixDNNIm2ColHelper.Im2colWorker.getWorker( _params.input1, im2ColOutBlock, _params, true);

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNConv2dHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNConv2dHelper.java
@@ -48,7 +48,6 @@ public class LibMatrixDNNConv2dHelper {
 			int PQ = _params.P*_params.Q; int K = _params.K;
 			int RS = _params.R*_params.S;
 			MatrixBlock im2ColOutBlock = new MatrixBlock(RS, PQ, false);
-			im2ColOutBlock.allocateDenseBlock();
 			LibMatrixDNNIm2ColHelper.Im2colWorker im2ColWorker = LibMatrixDNNIm2ColHelper.Im2colWorker.getWorker( _params.input1, im2ColOutBlock, _params, false);
 			long time1 = 0; long time2 = 0;
 			for(int n = _rl; n < _ru; n++)  {
@@ -129,7 +128,6 @@ public class LibMatrixDNNConv2dHelper {
 		public Long call() throws Exception {
 			int PQ = _params.P*_params.Q; int K = _params.K; int CRS = _params.C*_params.R*_params.S;
 			MatrixBlock im2ColOutBlock = new MatrixBlock(CRS, PQ, false);
-			im2ColOutBlock.allocateDenseBlock();
 			LibMatrixDNNIm2ColHelper.Im2colWorker im2ColWorker = LibMatrixDNNIm2ColHelper.Im2colWorker.getWorker( _params.input1, im2ColOutBlock, _params, true);
 			long time1 = 0; long time2 = 0;
 			for(int n = _rl; n < _ru; n++)  {

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.sysml.runtime.DMLRuntimeException;
 
 /**
  * This class contains the different implementation of im2col operation
@@ -48,7 +47,8 @@ public class LibMatrixDNNIm2ColHelper {
 				}
 				else {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorkerAllChannels operator to perform im2col.");
-					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true);
+					long worstCaseNNZ = params.R*params.S*input.getNonZeros();
+					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true, worstCaseNNZ);
 					im2ColOutBlock.allocateSparseRowsBlock();
 					return new SparseIm2colWorkerAllChannels(input, im2ColOutBlock, params);
 				}
@@ -68,7 +68,8 @@ public class LibMatrixDNNIm2ColHelper {
 				}
 				else {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorker operator to perform im2col.");
-					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true);
+					long worstCaseNNZ = params.R*params.S*input.getNonZeros();
+					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true, worstCaseNNZ);
 					im2ColOutBlock.allocateSparseRowsBlock();
 					return new SparseIm2colWorker(input, im2ColOutBlock, params);
 				}
@@ -263,7 +264,7 @@ public class LibMatrixDNNIm2ColHelper {
 	 * Performing sparse im2col for all channels for a given row n of the input matrix.
 	 */
 	static class SparseIm2colWorkerAllChannels implements Im2colWorker {
-		MatrixBlock input;  MatrixBlock output;
+		MatrixBlock input;  MatrixBlock output; Im2colSparseMetadata meta;
 		int CRS; int S; int R; int P; int Q; int H; int W; int RS; int HW;
 		int stride_h; int stride_w; int pad_h; int pad_w;
 		public SparseIm2colWorkerAllChannels(MatrixBlock input, MatrixBlock im2ColOutBlock, ConvolutionParameters params) {
@@ -275,6 +276,7 @@ public class LibMatrixDNNIm2ColHelper {
 			this.H = params.H; this.W = params.W; this.R = params.R; this.S = params.S; this.P = params.P; this.Q = params.Q;
 			this.stride_h = params.stride_h; this.stride_w = params.stride_w;
 			this.pad_h = params.pad_h; this.pad_w = params.pad_w;
+			meta = new Im2colSparseMetadata(CRS);
 			if(!input.isInSparseFormat()) 
 				throw new RuntimeException("Incorrect operator selection. Expected dense input for SparseIm2colWorkerAllChannels");
 		}
@@ -287,6 +289,7 @@ public class LibMatrixDNNIm2ColHelper {
 		@Override
 		public void execute(int n) {
 			if( !input.sparseBlock.isEmpty(n) ) {
+				meta.reset();
 				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);
@@ -304,19 +307,33 @@ public class LibMatrixDNNIm2ColHelper {
 					int wInput = chw % W; 
 					
 					appendInputValueToIm2colOutput(output, cInput, hInput, wInput, avals[j], 
-							R, S, P, Q, stride_h, stride_w, pad_h, pad_w);
+							R, S, P, Q, stride_h, stride_w, pad_h, pad_w, meta);
 				}
-				output.sortSparseRows();
+				if(meta.sortRows)
+					output.sortSparseRows();
+				output.setNonZeros(meta.nnz);
 			}
-			else
+			else {
 				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
-			
-			try {
-				output.recomputeNonZeros();
-				output.examSparsity();
-			} catch (DMLRuntimeException e) {
-				throw new RuntimeException(e);
+				output.setNonZeros(0);
 			}
+		}
+	}
+	
+	/**
+	 * This class stores metadata for maintaining sparse output of im2col.
+	 */
+	private static class Im2colSparseMetadata {
+		public int [] lastIndexPerRow;
+		public int nnz;
+		public boolean sortRows;
+		public Im2colSparseMetadata(int numRows) {
+			lastIndexPerRow = new int[numRows];
+		}
+		public void reset() {
+			Arrays.fill(lastIndexPerRow, 0);
+			sortRows = false;
+			nnz = 0;
 		}
 	}
 	
@@ -336,9 +353,12 @@ public class LibMatrixDNNIm2ColHelper {
 	 * @param stride_w stride width
 	 * @param pad_h pad height
 	 * @param pad_w pad width
+	 * @param meta computes meta information for the given sparse block
 	 */
 	private static void appendInputValueToIm2colOutput(MatrixBlock output, int cInput, int hInput, int wInput, double value, 
-			int R, int S, int P, int Q, int stride_h, int stride_w, int pad_h, int pad_w) {
+			int R, int S, int P, int Q, int stride_h, int stride_w, int pad_h, int pad_w, Im2colSparseMetadata meta) {
+		if(value == 0) 
+			return;
 		int RS = R*S;
 		// For the given h,w index, insert avals[j] into respective r,s,p,q locations
 		for(int r = 0; r < R; r++) {
@@ -352,6 +372,10 @@ public class LibMatrixDNNIm2ColHelper {
 					if(0 <= q && q < Q && (wInput - s + pad_w) % stride_w == 0) {
 						// chw -> [crs, pq]
 						output.appendValue(outRowIndex, p*Q + q, value);
+						meta.nnz++;
+						if(meta.lastIndexPerRow[outRowIndex] > p*Q + q)
+							meta.sortRows = true;
+						meta.lastIndexPerRow[outRowIndex] = p*Q + q;
 					}
 				}
 			}
@@ -362,7 +386,7 @@ public class LibMatrixDNNIm2ColHelper {
 	 * Performing sparse im2col for a given channel c and for a given row n of the input matrix.
 	 */
 	static class SparseIm2colWorker implements Im2colWorker {
-		MatrixBlock input; MatrixBlock output;
+		MatrixBlock input; MatrixBlock output; Im2colSparseMetadata meta;
 		int CRS; int S; int R; int P; int Q; int H; int W; int HW; int RS;
 		int stride_h; int stride_w; int pad_h; int pad_w; double [] temp;
 		public SparseIm2colWorker(MatrixBlock input, MatrixBlock im2ColOutBlock, ConvolutionParameters params) {
@@ -375,6 +399,7 @@ public class LibMatrixDNNIm2ColHelper {
 			this.stride_h = params.stride_h; this.stride_w = params.stride_w;
 			this.pad_h = params.pad_h; this.pad_w = params.pad_w;
 			temp = new double[input.getNumColumns()];
+			meta = new Im2colSparseMetadata(CRS);
 		}
 		
 		@Override
@@ -385,6 +410,7 @@ public class LibMatrixDNNIm2ColHelper {
 		@Override
 		public void execute(int n, int cInput) {
 			if( !input.sparseBlock.isEmpty(n) ) {
+				meta.reset();
 				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);
@@ -402,19 +428,16 @@ public class LibMatrixDNNIm2ColHelper {
 						int wInput = chw % W; 
 						
 						appendInputValueToIm2colOutput(output, cInput, hInput, wInput, avals[j], 
-								R, S, P, Q, stride_h, stride_w, pad_h, pad_w);
+								R, S, P, Q, stride_h, stride_w, pad_h, pad_w, meta);
 					}
 				}
-				output.sortSparseRows();
+				if(meta.sortRows)
+					output.sortSparseRows();
+				output.setNonZeros(meta.nnz);
 			}
-			else
+			else {
 				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
-			
-			try {
-				output.recomputeNonZeros();
-				output.examSparsity();
-			} catch (DMLRuntimeException e) {
-				throw new RuntimeException(e);
+				output.setNonZeros(0);
 			}
 		}
 		

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -49,7 +49,7 @@ public class LibMatrixDNNIm2ColHelper {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorkerAllChannels operator to perform im2col.");
 					double sparsity = Math.min(MatrixBlock.SPARSITY_TURN_POINT, (input.getNonZeros()*2.0) / (input.getNumRows()*input.getNumColumns()));
 					initializeSparseIm2ColBlock(im2ColOutBlock, (long)Math.ceil(params.P*params.Q*sparsity));
-					return new SparseIm2colWorkerAllChannels(input, im2ColOutBlock, params);
+					return new SparseSparseIm2colWorkerAllChannels(input, im2ColOutBlock, params);
 				}
 			}
 			else {
@@ -69,7 +69,7 @@ public class LibMatrixDNNIm2ColHelper {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorker operator to perform im2col.");
 					double sparsity = Math.min(MatrixBlock.SPARSITY_TURN_POINT, (input.getNonZeros()*2.0) / (input.getNumRows()*input.getNumColumns()));
 					initializeSparseIm2ColBlock(im2ColOutBlock, (long)Math.ceil(params.P*params.Q*sparsity));
-					return new SparseIm2colWorker(input, im2ColOutBlock, params);
+					return new SparseSparseIm2colWorker(input, im2ColOutBlock, params);
 				}
 			}
 		}
@@ -275,11 +275,11 @@ public class LibMatrixDNNIm2ColHelper {
 	/**
 	 * Performing sparse im2col for all channels for a given row n of the input matrix.
 	 */
-	static class SparseIm2colWorkerAllChannels implements Im2colWorker {
+	static class SparseSparseIm2colWorkerAllChannels implements Im2colWorker {
 		MatrixBlock input;  MatrixBlock output; Im2colSparseMetadata meta;
 		int CRS; int S; int R; int P; int Q; int H; int W; int RS; int HW;
 		int stride_h; int stride_w; int pad_h; int pad_w;
-		public SparseIm2colWorkerAllChannels(MatrixBlock input, MatrixBlock im2ColOutBlock, ConvolutionParameters params) {
+		public SparseSparseIm2colWorkerAllChannels(MatrixBlock input, MatrixBlock im2ColOutBlock, ConvolutionParameters params) {
 			this.input = input;
 			this.output = im2ColOutBlock;
 			this.CRS = params.C * params.R * params.S;
@@ -396,11 +396,11 @@ public class LibMatrixDNNIm2ColHelper {
 	/**
 	 * Performing sparse im2col for a given channel c and for a given row n of the input matrix.
 	 */
-	static class SparseIm2colWorker implements Im2colWorker {
+	static class SparseSparseIm2colWorker implements Im2colWorker {
 		MatrixBlock input; MatrixBlock output; Im2colSparseMetadata meta;
 		int CRS; int S; int R; int P; int Q; int H; int W; int HW; int RS;
 		int stride_h; int stride_w; int pad_h; int pad_w; double [] temp;
-		public SparseIm2colWorker(MatrixBlock input, MatrixBlock im2ColOutBlock, ConvolutionParameters params) {
+		public SparseSparseIm2colWorker(MatrixBlock input, MatrixBlock im2ColOutBlock, ConvolutionParameters params) {
 			this.input = input;
 			this.output = im2ColOutBlock;
 			this.CRS = params.C * params.R * params.S;

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -342,15 +342,17 @@ public class LibMatrixDNNIm2ColHelper {
 		int RS = R*S;
 		// For the given h,w index, insert avals[j] into respective r,s,p,q locations
 		for(int r = 0; r < R; r++) {
-			for(int s = 0; s < S; s++) {
-				int outRowIndex = cInput*RS + r*S + s;
-				// Only append value if h == hInput, where h = (r - pad_h) + p*stride_h and 0 <= p < P
-				// Therefore, p = (hInput - r + pad_h)  / stride_h. Use the same logic for q.
-				int p = (hInput - r + pad_h)  / stride_h;
-				int q = (wInput - s + pad_w)  / stride_w;
-				if(0 <= p && p < P && 0 <= q && q < Q) {
-					// chw -> [crs, pq]
-					output.appendValue(outRowIndex, p*Q + q, value);
+			// Only append value if h == hInput, where h = (r - pad_h) + p*stride_h and 0 <= p < P
+			// Therefore, p = (hInput - r + pad_h)  / stride_h. Use the same logic for q.
+			int p = (hInput - r + pad_h)  / stride_h;
+			if(0 <= p && p < P && (hInput - r + pad_h) % stride_h == 0) {
+				for(int s = 0; s < S; s++) {
+					int outRowIndex = cInput*RS + r*S + s;
+					int q = (wInput - s + pad_w)  / stride_w;
+					if(0 <= q && q < Q && (wInput - s + pad_w) % stride_w == 0) {
+						// chw -> [crs, pq]
+						output.appendValue(outRowIndex, p*Q + q, value);
+					}
 				}
 			}
 		}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.sysml.runtime.DMLRuntimeException;
 
 /**
  * This class contains the different implementation of im2col operation
@@ -305,10 +306,16 @@ public class LibMatrixDNNIm2ColHelper {
 							R, S, P, Q, stride_h, stride_w, pad_h, pad_w);
 				}
 				output.sortSparseRows();
-				output.recomputeNonZeros();
 			}
 			else
 				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
+			
+			try {
+				output.recomputeNonZeros();
+				output.examSparsity();
+			} catch (DMLRuntimeException e) {
+				throw new RuntimeException(e);
+			}
 		}
 	}
 	
@@ -400,10 +407,16 @@ public class LibMatrixDNNIm2ColHelper {
 					}
 				}
 				output.sortSparseRows();
-				output.recomputeNonZeros();
 			}
 			else
 				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
+			
+			try {
+				output.recomputeNonZeros();
+				output.examSparsity();
+			} catch (DMLRuntimeException e) {
+				throw new RuntimeException(e);
+			}
 		}
 		
 	}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -345,13 +345,13 @@ public class LibMatrixDNNIm2ColHelper {
 				int outRowIndex = cInput*RS + r*S + s;
 				int h = r - pad_h;
 				// And copy it to outputArray[i] (taking care of padding & striding)
-				for (int p = P; p > 0; p--, h += stride_h) {
+				for (int p = P-1; p > 0; p--, h += stride_h) {
 					if (h == hInput) {
 						int w = s - pad_w;
-						for (int q = Q; q > 0; q--, w += stride_w) {
+						for (int q = Q-1; q > 0; q--, w += stride_w) {
 							if (w == wInput) {
 								// chw -> [crs, pq]
-								output.appendValue(outRowIndex, p*P + q, value);
+								output.appendValue(outRowIndex, p*Q + q, value);
 							}
 						}
 					}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -47,7 +47,7 @@ public class LibMatrixDNNIm2ColHelper {
 				}
 				else {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorkerAllChannels operator to perform im2col.");
-					double sparsity = Math.min(1, (input.getNonZeros()*2.0) / (input.getNumRows()*input.getNumColumns()));
+					double sparsity = Math.min(MatrixBlock.SPARSITY_TURN_POINT, (input.getNonZeros()*2.0) / (input.getNumRows()*input.getNumColumns()));
 					initializeSparseIm2ColBlock(im2ColOutBlock, (long)Math.ceil(params.P*params.Q*sparsity));
 					return new SparseIm2colWorkerAllChannels(input, im2ColOutBlock, params);
 				}
@@ -67,7 +67,7 @@ public class LibMatrixDNNIm2ColHelper {
 				}
 				else {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorker operator to perform im2col.");
-					double sparsity = Math.min(1, (input.getNonZeros()*2.0) / (input.getNumRows()*input.getNumColumns()));
+					double sparsity = Math.min(MatrixBlock.SPARSITY_TURN_POINT, (input.getNonZeros()*2.0) / (input.getNumRows()*input.getNumColumns()));
 					initializeSparseIm2ColBlock(im2ColOutBlock, (long)Math.ceil(params.P*params.Q*sparsity));
 					return new SparseIm2colWorker(input, im2ColOutBlock, params);
 				}
@@ -302,6 +302,7 @@ public class LibMatrixDNNIm2ColHelper {
 		public void execute(int n) {
 			if( !input.sparseBlock.isEmpty(n) ) {
 				meta.reset();
+				input.sparseBlock.reset();
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);
 				int[] aix = input.sparseBlock.indexes(n);
@@ -421,6 +422,7 @@ public class LibMatrixDNNIm2ColHelper {
 		public void execute(int n, int cInput) {
 			if( !input.sparseBlock.isEmpty(n) ) {
 				meta.reset();
+				input.sparseBlock.reset();
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);
 				int[] aix = input.sparseBlock.indexes(n);

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -47,8 +47,8 @@ public class LibMatrixDNNIm2ColHelper {
 				}
 				else {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorkerAllChannels operator to perform im2col.");
-					long worstCaseNNZ = params.R*params.S*input.getNonZeros();
-					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true, worstCaseNNZ);
+					// long worstCaseNNZ = params.R*params.S*input.getNonZeros();
+					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true);
 					im2ColOutBlock.allocateSparseRowsBlock();
 					return new SparseIm2colWorkerAllChannels(input, im2ColOutBlock, params);
 				}
@@ -68,8 +68,8 @@ public class LibMatrixDNNIm2ColHelper {
 				}
 				else {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorker operator to perform im2col.");
-					long worstCaseNNZ = params.R*params.S*input.getNonZeros();
-					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true, worstCaseNNZ);
+					// long worstCaseNNZ = params.R*params.S*input.getNonZeros();
+					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true);
 					im2ColOutBlock.allocateSparseRowsBlock();
 					return new SparseIm2colWorker(input, im2ColOutBlock, params);
 				}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -353,52 +353,33 @@ public class LibMatrixDNNIm2ColHelper {
 		int RS = R*S;
 		// For the given h,w index, insert avals[j] into respective r,s,p,q locations
 		
-//		// Constraints: for(int r = 0; r < R; r++) { if(0 <= p && p < P && (hInput - r + pad_h) % stride_h == 0) { ... } }
-//		// Constraint 1: p >= 0 and p = (hInput - r + pad_h)  / stride_h
-//		// Therefore,  r <= hInput + pad_h 
-//		// Constraint 2: p < P and p = (hInput - r + pad_h)  / stride_h
-//		// Therefore,  hInput + pad_h - P*stride_h < r
-//		// Math.max(0, hInput + pad_h - P*stride_h + 1) <= r <= Math.min(R-1, hInput + pad_h)
-//		int rMin = Math.max(0, hInput + pad_h - P*stride_h + 1);
-//		int rMax = Math.min(R-1, hInput + pad_h);
-//		int sMin = Math.max(0, wInput + pad_w - Q*stride_w + 1);
-//		int sMax = Math.min(S-1, wInput + pad_w);
-//		// Constraint 3: (hInput - r + pad_h) % stride_h == 0
-//		while((hInput - rMin + pad_h) % stride_h != 0 && rMin <= rMax) rMin++;
-//		while((wInput - sMin + pad_w) % stride_w != 0 && sMin <= sMax) sMin++;	
-//		
-//		for(int r = rMin; r <= rMax; r++) {
-//			// Only append value if h == hInput, where h = (r - pad_h) + p*stride_h and 0 <= p < P
-//			// Therefore, p = (hInput - r + pad_h)  / stride_h. Use the same logic for q.
-//			int p = (hInput - r + pad_h)  / stride_h;
-//			for(int s = sMin; s <= sMax; s++) {
-//				int outRowIndex = cInput*RS + r*S + s;
-//				int q = (wInput - s + pad_w)  / stride_w;
-//				// chw -> [crs, pq]
-//				output.appendValue(outRowIndex, p*Q + q, value);
-//				// Since the chw are appended in sorted order, no need to sort the output rows
-//				// if(meta.lastIndexPerRow[outRowIndex] > p*Q + q) meta.sortRows = true;
-//				// meta.lastIndexPerRow[outRowIndex] = p*Q + q;
-//			}
-//		}
+		// Constraints: for(int r = 0; r < R; r++) { if(0 <= p && p < P && (hInput - r + pad_h) % stride_h == 0) { ... } }
+		// Constraint 1: p >= 0 and p = (hInput - r + pad_h)  / stride_h
+		// Therefore,  r <= hInput + pad_h 
+		// Constraint 2: p < P and p = (hInput - r + pad_h)  / stride_h
+		// Therefore,  hInput + pad_h - P*stride_h < r
+		// Math.max(0, hInput + pad_h - P*stride_h + 1) <= r <= Math.min(R-1, hInput + pad_h)
+		int rMin = Math.max(0, hInput + pad_h - P*stride_h + 1);
+		int rMax = Math.min(R-1, hInput + pad_h);
+		int sMin = Math.max(0, wInput + pad_w - Q*stride_w + 1);
+		int sMax = Math.min(S-1, wInput + pad_w);
+		// Constraint 3: (hInput - r + pad_h) % stride_h == 0
+		while((hInput - rMin + pad_h) % stride_h != 0 && rMin <= rMax) rMin++;
+		while((wInput - sMin + pad_w) % stride_w != 0 && sMin <= sMax) sMin++;	
 		
-		// For the given h,w index, insert avals[j] into respective r,s,p,q locations
-		for(int r = 0; r < R; r++) {
+		for(int r = rMin; r <= rMax; r += stride_h) {
 			// Only append value if h == hInput, where h = (r - pad_h) + p*stride_h and 0 <= p < P
 			// Therefore, p = (hInput - r + pad_h)  / stride_h. Use the same logic for q.
-			int p = (hInput - r + pad_h)  / stride_h;
-			if(0 <= p && p < P && (hInput - r + pad_h) % stride_h == 0) {
-				for(int s = 0; s < S; s++) {
-					int outRowIndex = cInput*RS + r*S + s;
-					int q = (wInput - s + pad_w)  / stride_w;
-					if(0 <= q && q < Q && (wInput - s + pad_w) % stride_w == 0) {
-						// chw -> [crs, pq]
-						output.appendValue(outRowIndex, p*Q + q, value);
-						// Since the chw are appended in sorted order, no need to sort the output rows
-						// if(meta.lastIndexPerRow[outRowIndex] > p*Q + q) meta.sortRows = true;
-						// meta.lastIndexPerRow[outRowIndex] = p*Q + q;
-					}
-				}
+			final int p = (hInput - r + pad_h)  / stride_h;
+			final int pQ = p*Q;
+			final int outRowIndex = cInput*RS + r*S;
+			for(int s = sMin; s <= sMax; s += stride_w) {
+				int q = (wInput - s + pad_w)  / stride_w;
+				// chw -> [crs, pq]
+				output.appendValue(outRowIndex + s, pQ + q, value);
+				// Since the chw are appended in sorted order, no need to sort the output rows
+				// if(meta.lastIndexPerRow[outRowIndex + s] > p*Q + q) meta.sortRows = true;
+				// meta.lastIndexPerRow[outRowIndex + s] = p*Q + q;
 			}
 		}
 	}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -344,18 +344,13 @@ public class LibMatrixDNNIm2ColHelper {
 		for(int r = 0; r < R; r++) {
 			for(int s = 0; s < S; s++) {
 				int outRowIndex = cInput*RS + r*S + s;
-				int h = r - pad_h;
-				// And copy it to outputArray[i] (taking care of padding & striding)
-				for (int p = 0; p < P; p++, h += stride_h) {
-					if (h == hInput) {
-						int w = s - pad_w;
-						for (int q = 0; q < Q; q++, w += stride_w) {
-							if (w == wInput) {
-								// chw -> [crs, pq]
-								output.appendValue(outRowIndex, p*Q + q, value);
-							}
-						}
-					}
+				// Only append value if h == hInput, where h = (r - pad_h) + p*stride_h and 0 <= p < P
+				// Therefore, p = (hInput - r + pad_h)  / stride_h. Use the same logic for q.
+				int p = (hInput - r + pad_h)  / stride_h;
+				int q = (wInput - s + pad_w)  / stride_w;
+				if(0 <= p && p < P && 0 <= q && q < Q) {
+					// chw -> [crs, pq]
+					output.appendValue(outRowIndex, p*Q + q, value);
 				}
 			}
 		}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -305,7 +305,10 @@ public class LibMatrixDNNIm2ColHelper {
 							R, S, P, Q, stride_h, stride_w, pad_h, pad_w);
 				}
 				output.sortSparseRows();
+				output.recomputeNonZeros();
 			}
+			else
+				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
 		}
 	}
 	
@@ -397,7 +400,10 @@ public class LibMatrixDNNIm2ColHelper {
 					}
 				}
 				output.sortSparseRows();
+				output.recomputeNonZeros();
 			}
+			else
+				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
 		}
 		
 	}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -47,6 +47,8 @@ public class LibMatrixDNNIm2ColHelper {
 				}
 				else {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorkerAllChannels operator to perform im2col.");
+					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true);
+					im2ColOutBlock.allocateSparseRowsBlock();
 					return new SparseIm2colWorkerAllChannels(input, im2ColOutBlock, params);
 				}
 			}
@@ -65,6 +67,8 @@ public class LibMatrixDNNIm2ColHelper {
 				}
 				else {
 					if(LOG.isTraceEnabled()) LOG.trace("Using SparseIm2colWorker operator to perform im2col.");
+					im2ColOutBlock.reset(im2ColOutBlock.getNumRows(), im2ColOutBlock.getNumColumns(), true);
+					im2ColOutBlock.allocateSparseRowsBlock();
 					return new SparseIm2colWorker(input, im2ColOutBlock, params);
 				}
 			}
@@ -281,7 +285,6 @@ public class LibMatrixDNNIm2ColHelper {
 
 		@Override
 		public void execute(int n) {
-			output.allocateSparseRowsBlock();
 			if( !input.sparseBlock.isEmpty(n) ) {
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);
@@ -373,7 +376,6 @@ public class LibMatrixDNNIm2ColHelper {
 
 		@Override
 		public void execute(int n, int cInput) {
-			output.allocateSparseRowsBlock();
 			if( !input.sparseBlock.isEmpty(n) ) {
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -287,6 +287,7 @@ public class LibMatrixDNNIm2ColHelper {
 		@Override
 		public void execute(int n) {
 			if( !input.sparseBlock.isEmpty(n) ) {
+				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);
 				int[] aix = input.sparseBlock.indexes(n);
@@ -345,10 +346,10 @@ public class LibMatrixDNNIm2ColHelper {
 				int outRowIndex = cInput*RS + r*S + s;
 				int h = r - pad_h;
 				// And copy it to outputArray[i] (taking care of padding & striding)
-				for (int p = P-1; p > 0; p--, h += stride_h) {
+				for (int p = 0; p < P; p++, h += stride_h) {
 					if (h == hInput) {
 						int w = s - pad_w;
-						for (int q = Q-1; q > 0; q--, w += stride_w) {
+						for (int q = 0; q < Q; q++, w += stride_w) {
 							if (w == wInput) {
 								// chw -> [crs, pq]
 								output.appendValue(outRowIndex, p*Q + q, value);
@@ -387,6 +388,7 @@ public class LibMatrixDNNIm2ColHelper {
 		@Override
 		public void execute(int n, int cInput) {
 			if( !input.sparseBlock.isEmpty(n) ) {
+				output.reset(output.getNumRows(), output.getNumColumns(), true, 0);
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);
 				int[] aix = input.sparseBlock.indexes(n);

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixDNNIm2ColHelper.java
@@ -302,7 +302,7 @@ public class LibMatrixDNNIm2ColHelper {
 		public void execute(int n) {
 			if( !input.sparseBlock.isEmpty(n) ) {
 				meta.reset();
-				input.sparseBlock.reset();
+				output.sparseBlock.reset();
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);
 				int[] aix = input.sparseBlock.indexes(n);
@@ -422,7 +422,7 @@ public class LibMatrixDNNIm2ColHelper {
 		public void execute(int n, int cInput) {
 			if( !input.sparseBlock.isEmpty(n) ) {
 				meta.reset();
-				input.sparseBlock.reset();
+				output.sparseBlock.reset();
 				int apos = input.sparseBlock.pos(n);
 				int alen = input.sparseBlock.size(n);
 				int[] aix = input.sparseBlock.indexes(n);

--- a/src/test/java/org/apache/sysml/test/gpu/GPUTests.java
+++ b/src/test/java/org/apache/sysml/test/gpu/GPUTests.java
@@ -139,7 +139,7 @@ public abstract class GPUTests extends AutomatedTestBase {
 		genMLC.close();
 		return in1;
 	}
-
+	
 	/**
 	 * Generates a random input matrix with a given size and sparsity
 	 *
@@ -152,6 +152,22 @@ public abstract class GPUTests extends AutomatedTestBase {
 	 * @return a random matrix with given size and sparsity
 	 */
 	protected Matrix generateInputMatrix(SparkSession spark, int m, int n, double min, double max, double sparsity, int seed) {
+		return generateInputMatrix(spark, m, n, min, max, sparsity, seed, false);
+	}
+
+	/**
+	 * Generates a random input matrix with a given size and sparsity
+	 *
+	 * @param spark    valid instance of {@link SparkSession}
+	 * @param m        number of rows
+	 * @param n        number of columns
+	 * @param min      min for RNG
+	 * @param max      max for RNG
+	 * @param sparsity sparsity (1 = completely dense, 0 = completely sparse)
+	 * @param performRounding performs rounding after generation of random matrix
+	 * @return a random matrix with given size and sparsity
+	 */
+	protected Matrix generateInputMatrix(SparkSession spark, int m, int n, double min, double max, double sparsity, int seed, boolean performRounding) {
 		// Generate a random matrix of size m * n
 		MLContext genMLC = new MLContext(spark);
 		String scriptStr;
@@ -160,6 +176,8 @@ public abstract class GPUTests extends AutomatedTestBase {
 		} else {
 			scriptStr = "in1 = rand(rows=" + m + ", cols=" + n + ", sparsity = " + sparsity + ", seed= " + seed
 					+ ", min=" + min + ", max=" + max + ")";
+			if(performRounding)
+				scriptStr += "; in1 = round(in1)";
 		}
 		Script generateScript = ScriptFactory.dmlFromString(scriptStr).out("in1");
 		Matrix in1 = genMLC.execute(generateScript).getMatrix("in1");

--- a/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
+++ b/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
@@ -87,7 +87,7 @@ public class NeuralNetworkOpTests extends GPUTests {
 	private final List<Integer> Rlst = Arrays.asList(3);
 	private final List<Integer> strideLst = Arrays.asList(1);
 	private final List<Integer> padLst = Arrays.asList(1);
-	private final List<Double> sparsitylst = Arrays.asList(1.0, 0.1, 0.3);
+	private final List<Double> sparsitylst = Arrays.asList(1.0, 0.1);
 
 	@Override
 	public void setUp() {
@@ -101,7 +101,6 @@ public class NeuralNetworkOpTests extends GPUTests {
 		return 1e-5;
 	}
 
-	@Ignore
 	@Test
 	public void testConv2d() {
 		String scriptStr = "O = conv2d(image, filter, padding=[padH, padW], stride=[strideH, strideW], input_shape=[N,C,H,W], filter_shape=[K,C,R,S])";
@@ -254,7 +253,6 @@ public class NeuralNetworkOpTests extends GPUTests {
 		clearGPUMemory();
 	}
 
-	@Ignore
 	@Test
 	public void testConv2dBackwardFilter() {
 		String scriptStr = "O = conv2d_backward_filter(image, dout, padding=[padH, padW], stride=[strideH, strideW], input_shape=[N,C,H,W], filter_shape=[K,C,R,S])";
@@ -338,7 +336,6 @@ public class NeuralNetworkOpTests extends GPUTests {
 		}
 	}
 
-	@Ignore
 	@Test
 	public void testConv2dBackwardData() {
 		String scriptStr = "O = conv2d_backward_data(filter, dout, padding=[padH, padW], stride=[strideH, strideW], input_shape=[N,C,H,W], filter_shape=[K,C,R,S])";
@@ -423,7 +420,6 @@ public class NeuralNetworkOpTests extends GPUTests {
 		}
 	}
 
-	@Ignore
 	@Test
 	public void testMaxPool() {
 		String scriptStr = "O = max_pool(image, padding=[padH, padW], stride=[strideH, strideW], input_shape=[N,C,H,W], pool_size=[R,S])";
@@ -501,7 +497,6 @@ public class NeuralNetworkOpTests extends GPUTests {
 		}
 	}
 
-	@Ignore
 	@Test
 	public void testMaxPoolBackward() {
 		String scriptStr = "O = max_pool_backward(image, dout, padding=[padH, padW], stride=[strideH, strideW], input_shape=[N,C,H,W], pool_size=[R,S])";

--- a/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
+++ b/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
@@ -24,9 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.apache.sysml.api.mlcontext.Matrix;
-import org.apache.sysml.runtime.DMLRuntimeException;
-import org.apache.sysml.runtime.instructions.gpu.context.GPUContext;
-import org.apache.sysml.runtime.instructions.gpu.context.GPUContextPool;
 import org.apache.sysml.runtime.util.ConvolutionUtils;
 import org.apache.sysml.test.utils.TestUtils;
 import org.junit.Assert;
@@ -44,6 +41,10 @@ import org.junit.Test;
  * <code>
  * mvn -Dit.test=org.apache.sysml.test.gpu.NeuralNetworkOpTests verify -PgpuTests
  * </code>
+ * 
+ * Note: generateInputMatrix(...) method in this test performs rounding of input matrix. This helps
+ * to test the correctness of our operators at logical level, but not the precision.
+ * 
  */
 public class NeuralNetworkOpTests extends GPUTests {
 

--- a/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
+++ b/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
@@ -87,7 +87,7 @@ public class NeuralNetworkOpTests extends GPUTests {
 	private final List<Integer> Rlst = Arrays.asList(3);
 	private final List<Integer> strideLst = Arrays.asList(1);
 	private final List<Integer> padLst = Arrays.asList(1);
-	private final List<Double> sparsitylst = Arrays.asList(1.0);
+	private final List<Double> sparsitylst = Arrays.asList(1.0, 0.1, 0.3);
 
 	@Override
 	public void setUp() {
@@ -146,9 +146,9 @@ public class NeuralNetworkOpTests extends GPUTests {
 												filterSizeInMB, N, K, P, Q, doutSizeInMB,
 												strideH, strideW, padH, padW);
 										Matrix image = generateInputMatrix(spark, (int) N,
-												(int) (C * H * W), -127, 127, sparsity, seed);
+												(int) (C * H * W), -127, 127, sparsity, seed, true);
 										Matrix filter = generateInputMatrix(spark, (int) K,
-												(int) (C * R * S), -127, 127, sparsity, seed);
+												(int) (C * R * S), -127, 127, sparsity, seed, true);
 										HashMap<String, Object> inputs = new HashMap<>();
 										inputs.put("N", N);
 										inputs.put("C", C);
@@ -231,8 +231,8 @@ public class NeuralNetworkOpTests extends GPUTests {
 		.format("conv2d, image[%d,%d,%d,%d](%.1fMB), filter[%d,%d,%d,%d](%.1f), dout[%d,%d,%d,%d](%.1fMB), stride[%d,%d], padding[%d,%d]",
 				N, C, H, W, imageSizeInMB, N, C, R, S, filterSizeInMB, N, K, P, Q, doutSizeInMB, strideH,
 				strideW, padH, padW);
-		Matrix image = generateInputMatrix(spark, (int) N, (int) (C * H * W), -1, 1, sparsity, seed);
-		Matrix filter = generateInputMatrix(spark, (int) K, (int) (C * R * S), -1, 1.0, sparsity, seed);
+		Matrix image = generateInputMatrix(spark, (int) N, (int) (C * H * W), -1, 1, sparsity, seed, true);
+		Matrix filter = generateInputMatrix(spark, (int) K, (int) (C * R * S), -1, 1.0, sparsity, seed, true);
 		HashMap<String, Object> inputs = new HashMap<>();
 		inputs.put("N", N);
 		inputs.put("C", C);
@@ -300,9 +300,9 @@ public class NeuralNetworkOpTests extends GPUTests {
 												filterSizeInMB, N, K, P, Q, doutSizeInMB,
 												strideH, strideW, padH, padW);
 										Matrix image = generateInputMatrix(spark, (int) N,
-												(int) (C * H * W), -127.0, 127, sparsity, seed);
+												(int) (C * H * W), -127.0, 127, sparsity, seed, true);
 										Matrix dout = generateInputMatrix(spark, (int) N,
-												(int) (K * P * Q), -127.0, 127, sparsity, seed);
+												(int) (K * P * Q), -127.0, 127, sparsity, seed, true);
 										HashMap<String, Object> inputs = new HashMap<>();
 										inputs.put("N", N);
 										inputs.put("C", C);
@@ -385,9 +385,9 @@ public class NeuralNetworkOpTests extends GPUTests {
 												strideH, strideW, padH, padW);
 
 										Matrix filter = generateInputMatrix(spark, (int) K,
-												(int) (C * R * S), -127.0, 127, sparsity, seed);
+												(int) (C * R * S), -127.0, 127, sparsity, seed, true);
 										Matrix dout = generateInputMatrix(spark, (int) N,
-												(int) (K * P * Q), -127.0, 127, sparsity, seed);
+												(int) (K * P * Q), -127.0, 127, sparsity, seed, true);
 										HashMap<String, Object> inputs = new HashMap<>();
 										inputs.put("N", N);
 										inputs.put("C", C);
@@ -468,7 +468,7 @@ public class NeuralNetworkOpTests extends GPUTests {
 											P, Q, doutSizeInMB, strideH, strideW, padH, padW);
 
 									Matrix image = generateInputMatrix(spark, (int) N,
-											(int) (C * H * W), -127.0, 127, sparsity, seed);
+											(int) (C * H * W), -127.0, 127, sparsity, seed, true);
 									HashMap<String, Object> inputs = new HashMap<>();
 									inputs.put("N", N);
 									inputs.put("C", C);
@@ -546,9 +546,9 @@ public class NeuralNetworkOpTests extends GPUTests {
 											P, Q, doutSizeInMB, strideH, strideW, padH, padW);
 
 									Matrix image = generateInputMatrix(spark, (int) N,
-											(int) (C * H * W), -127.0, 127, sparsity, seed);
+											(int) (C * H * W), -127.0, 127, sparsity, seed, true);
 									Matrix dout = generateInputMatrix(spark, (int) N, (int) (C * P * Q),
-											-127.0, 127, sparsity, seed);
+											-127.0, 127, sparsity, seed, true);
 									HashMap<String, Object> inputs = new HashMap<>();
 									inputs.put("N", N);
 									inputs.put("C", C);

--- a/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
+++ b/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
@@ -50,22 +50,22 @@ public class NeuralNetworkOpTests extends GPUTests {
 	private final static String TEST_NAME = "NeuralNetworkOpTests";
 	// The MAX_OP_SIZE is to take into consideration the memory available on the GPU as well as
 	// limits set by cudnn (operands need to be less than 2GB)
-	private static final double MAX_OP_SIZE;
+	private static final double MAX_OP_SIZE = 0.5 * 1024 * 1024 * 1024; // 0.5 GB (this HAS to be less than 2GB)
 
-	static {
-		double MAX = 0.5 * 1024 * 1024 * 1024; // 0.5 GB (this HAS to be less than 2GB)
-		try {
-			// Cap the maximum allowed operand size to 1/3rd of the usable GPU memory or MAX, whichever is lesser
-			List<GPUContext> gCtxs = GPUContextPool.reserveAllGPUContexts();
-			long availableMemory = gCtxs.get(0).getAvailableMemory();
-			double averageMemoryPerOperand = availableMemory / 3.0;
-			MAX_OP_SIZE = Math.min(averageMemoryPerOperand, MAX);
-			GPUContextPool.freeAllGPUContexts();
-		} catch (DMLRuntimeException e) {
-			throw new RuntimeException(e);
-		}
-
-	}
+//	static {
+//		double MAX = 0.5 * 1024 * 1024 * 1024; // 0.5 GB (this HAS to be less than 2GB)
+//		try {
+//			// Cap the maximum allowed operand size to 1/3rd of the usable GPU memory or MAX, whichever is lesser
+//			List<GPUContext> gCtxs = GPUContextPool.reserveAllGPUContexts();
+//			long availableMemory = gCtxs.get(0).getAvailableMemory();
+//			double averageMemoryPerOperand = availableMemory / 3.0;
+//			MAX_OP_SIZE = Math.min(averageMemoryPerOperand, MAX);
+//			GPUContextPool.freeAllGPUContexts();
+//		} catch (DMLRuntimeException e) {
+//			throw new RuntimeException(e);
+//		}
+//
+//	}
 
 	private final int seed = 42;
 

--- a/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
+++ b/src/test/java/org/apache/sysml/test/gpu/NeuralNetworkOpTests.java
@@ -83,11 +83,11 @@ public class NeuralNetworkOpTests extends GPUTests {
 	private final List<Integer> Nlst = Arrays.asList(32);
 	private final List<Integer> Clst = Arrays.asList(3);
 	private final List<Integer> Hlst = Arrays.asList(64);
-	private final List<Integer> Klst = Arrays.asList(20);
-	private final List<Integer> Rlst = Arrays.asList(3);
-	private final List<Integer> strideLst = Arrays.asList(1);
-	private final List<Integer> padLst = Arrays.asList(1);
-	private final List<Double> sparsitylst = Arrays.asList(1.0, 0.1);
+	private final List<Integer> Klst = Arrays.asList(3);
+	private final List<Integer> Rlst = Arrays.asList(3,5);
+	private final List<Integer> strideLst = Arrays.asList(1, 2);
+	private final List<Integer> padLst = Arrays.asList(0,1);
+	private final List<Double> sparsitylst = Arrays.asList(1.0, 0.1, 0.3);
 
 	@Override
 	public void setUp() {
@@ -421,6 +421,7 @@ public class NeuralNetworkOpTests extends GPUTests {
 	}
 
 	@Test
+	@Ignore
 	public void testMaxPool() {
 		String scriptStr = "O = max_pool(image, padding=[padH, padW], stride=[strideH, strideW], input_shape=[N,C,H,W], pool_size=[R,S])";
 
@@ -498,6 +499,7 @@ public class NeuralNetworkOpTests extends GPUTests {
 	}
 
 	@Test
+	@Ignore
 	public void testMaxPoolBackward() {
 		String scriptStr = "O = max_pool_backward(image, dout, padding=[padH, padW], stride=[strideH, strideW], input_shape=[N,C,H,W], pool_size=[R,S])";
 


### PR DESCRIPTION
Setup: 
driver memory = 50g
epoch = 1
input data sparsity = 0.04
1 layer CNN

Sparse im2col (PR https://github.com/apache/systemml/pull/645):
```
ITER=285 BEG=28401 END=28500 LOSS=1.7711532053127315
SystemML Statistics:
Total elapsed time:             181.846 sec.
Total compilation time:         2.271 sec.
Total execution time:           179.575 sec.
Number of compiled Spark inst:  30.
Number of executed Spark inst:  1.
Cache hits (Mem, WB, FS, HDFS): 38465/0/0/2.
Cache writes (WB, FS, HDFS):    18814/0/10.
Cache times (ACQr/m, RLS, EXP): 15.698/0.019/0.223/0.119 sec.
HOP DAGs recompiled (PRED, SB): 0/285.
HOP DAGs recompile time:        1.291 sec.
Spark ctx create time (lazy):   0.918 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         19.697 sec.
Total JVM GC count:             148.
Total JVM GC time:              9.465 sec.
LibMatrixDNN dense count (conv/bwdF/bwdD/im2col/maxBwd):        0/0/0/0/855.
LibMatrixDNN sparse count (conv/bwdF/bwdD/im2col/maxBwd):       855/855/0/0/0.
LibMatrixDNN conv(im2col/matmult), bwdF (im2col/matmult), bwdD (col2im/matmult) time:   410.420/108.838/388.879/94.633/0.000/0.000 sec.
Heavy hitter instructions:
  #  Instruction                     Time(s)  Count  Misc Timers
  1  conv2d_bias_add [78:2-78:2]      66.665    855 aqrs[0.001s,858], aqrd[0.002s,
                                                    1707], aqmd[0.003s,855], rlswr
                                                     [0.003s,0], rlsi[0.011s,2565]
  2  conv2d_backward_filter [125:2-   61.637    855 aqrd[0.001s,855], aqrs[0.001s,
     125:2]                                         855], aqmd[0.003s,855], rlswr[
                                                      0.004s,0], rlsi[0.008s,1710]
  3  rangeReIndex [51:6-51:12]        33.054    285 aqrs[15.510s,285], aqms[0.001s
                                                    ,285], rlsi[0.002s,285], rlswr
                                                                        [0.002s,0]
  4  uack+ [42:16-42:16]               5.572    855 aqms[0.002s,855], aqrd[0.002s,
                                                    855], rlsi[0.003s,855], rlswr[
                                                                         0.005s,0]
```

Current master:
```
ITER=285 BEG=28401 END=28500 LOSS=1.842284499494135
SystemML Statistics:
Total elapsed time:             636.197 sec.
Total compilation time:         2.212 sec.
Total execution time:           633.986 sec.
Number of compiled Spark inst:  30.
Number of executed Spark inst:  1.
Cache hits (Mem, WB, FS, HDFS): 38465/0/0/2.
Cache writes (WB, FS, HDFS):    18814/0/10.
Cache times (ACQr/m, RLS, EXP): 15.500/0.018/0.219/0.120 sec.
HOP DAGs recompiled (PRED, SB): 0/285.
HOP DAGs recompile time:        1.316 sec.
Spark ctx create time (lazy):   0.931 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         22.648 sec.
Total JVM GC count:             145.
Total JVM GC time:              10.122 sec.
LibMatrixDNN dense count (conv/bwdF/bwdD/im2col/maxBwd):        0/0/0/0/855.
LibMatrixDNN sparse count (conv/bwdF/bwdD/im2col/maxBwd):       855/855/0/0/0.
LibMatrixDNN conv(im2col/matmult), bwdF (im2col/matmult), bwdD (col2im/matmult) time:   2996.291/1068.738/2949.096/1554.732/0.000/0.000 sec.
Heavy hitter instructions:
  #  Instruction                     Time(s)  Count  Misc Timers
  1  conv2d_backward_filter [125:2-  297.714    855 aqrd[0.001s,855], aqrs[0.001s,
     126:81]                                        855], rlswr[0.004s,0], aqmd[0.
                                                      004s,855], rlsi[0.008s,1710]
  2  conv2d_bias_add [78:2-78:23]    283.484    855 aqrs[0.001s,858], aqrd[0.002s,
                                                    1707], aqmd[0.002s,855], rlswr
                                                     [0.003s,0], rlsi[0.010s,2565]
  3  rangeReIndex [51:6-51:6]         33.103    285 aqrs[15.288s,285], aqms[0.001s
                                                    ,285], rlsi[0.002s,285], rlswr
                                                                        [0.002s,0]
  4  maxpooling_backward [100:2-101    6.377    855 aqmd[0.001s,855], rlswr[0.002s
     :70]                                           ,0], aqrd[0.002s,1710], rlsi[0
                                                                       .003s,1710]
  5  uack+ [42:16-42:55]               5.615    855 aqms[0.002s,855], aqrd[0.002s,
                                                    855], rlsi[0.002s,855], rlswr[
                                                                         0.004s,0]
```

@prithvirajsen @bertholdreinwald 