### PR TITLE
[MINOR] Enable systemml to be imported in the pyspark workers

### DIFF
--- a/src/main/python/systemml/mlcontext.py
+++ b/src/main/python/systemml/mlcontext.py
@@ -44,7 +44,6 @@ from .converters import *
 from .classloader import *
 
 _loadedSystemML = False
-_initializedSparkSession = False
 def _get_spark_context():
     """
     Internal method to get already initialized SparkContext.  Developers should always use
@@ -345,14 +344,6 @@ class Matrix(object):
             DataFrames are unordered), followed by columns of doubles
             for each column in the matrix.
         """
-        # -----------------------------------------------------------------------------------
-        # Avoids race condition between locking of metastore_db of Scala SparkSession and PySpark SparkSession.
-        # This is done at toDF() rather than import level to avoid creation of SparkSession in worker processes.
-        global _initializedSparkSession
-        if not _initializedSparkSession:
-            _initializedSparkSession = True
-            SparkSession.builder.getOrCreate().createDataFrame(pd.DataFrame(np.array([[1,2],[3,4]])))
-        # -----------------------------------------------------------------------------------
         jdf = self._java_matrix.toDF()
         df = _java2py(self._sc, jdf)
         return df


### PR DESCRIPTION
- Moved the race condition avoidance logic to toDF method instead of import level. This avoids creation of dataframe in pyspark workers.

@asurve @bertholdreinwald can you please review this PR  ?