### PR TITLE
[SYSTEMML-1896] Update python tests to use getOrCreate

### DIFF
--- a/src/main/python/tests/test_matrix_agg_fn.py
+++ b/src/main/python/tests/test_matrix_agg_fn.py
@@ -34,7 +34,7 @@ import systemml as sml
 import numpy as np
 from scipy.stats import kurtosis, skew, moment
 from pyspark.context import SparkContext
-sc = SparkContext()
+sc = SparkContext.getOrCreate()
 
 dim = 5
 m1 = np.array(np.random.randint(100, size=dim*dim) + 1.01, dtype=np.double)

--- a/src/main/python/tests/test_matrix_binary_op.py
+++ b/src/main/python/tests/test_matrix_binary_op.py
@@ -33,7 +33,7 @@ import unittest
 import systemml as sml
 import numpy as np
 from pyspark.context import SparkContext
-sc = SparkContext()
+sc = SparkContext.getOrCreate()
 
 dim = 5
 m1 = np.array(np.random.randint(100, size=dim*dim) + 1.01, dtype=np.double)

--- a/src/main/python/tests/test_mlcontext.py
+++ b/src/main/python/tests/test_mlcontext.py
@@ -36,7 +36,7 @@ from pyspark.context import SparkContext
 
 from systemml import MLContext, dml, pydml
 
-sc = SparkContext()
+sc = SparkContext.getOrCreate()
 ml = MLContext(sc)
 
 class TestAPI(unittest.TestCase):

--- a/src/main/python/tests/test_mllearn_df.py
+++ b/src/main/python/tests/test_mllearn_df.py
@@ -33,7 +33,6 @@ sys.path.insert(0, path)
 import unittest
 
 import numpy as np
-from pyspark.context import SparkContext
 from pyspark.ml import Pipeline
 from pyspark.ml.feature import HashingTF, Tokenizer
 from pyspark.sql import SparkSession
@@ -44,7 +43,6 @@ from sklearn import linear_model
 from sklearn.metrics import accuracy_score, r2_score
 from systemml.mllearn import LinearRegression, LogisticRegression, NaiveBayes, SVM
 
-sc = SparkContext()
 sparkSession = SparkSession.builder.getOrCreate()
 
 # Currently not integrated with JUnit test

--- a/src/main/python/tests/test_mllearn_numpy.py
+++ b/src/main/python/tests/test_mllearn_numpy.py
@@ -33,7 +33,6 @@ sys.path.insert(0, path)
 import unittest
 
 import numpy as np
-from pyspark.context import SparkContext
 from pyspark.ml import Pipeline
 from pyspark.ml.feature import HashingTF, Tokenizer
 from pyspark.sql import SparkSession
@@ -44,9 +43,7 @@ from sklearn.metrics import accuracy_score, r2_score
 from systemml.mllearn import LinearRegression, LogisticRegression, NaiveBayes, SVM
 from sklearn import linear_model
 
-sc = SparkContext()
 sparkSession = SparkSession.builder.getOrCreate()
-import os
 
 def writeColVector(X, fileName):
 	fileName = os.path.join(os.getcwd(), fileName)


### PR DESCRIPTION
Updated python tests to use SparkContext.getOrCreate() or SparkSession.builder.getOrCreate() to avoid "Cannot run multiple SparkContexts at once" error observed in some environments running scripts under src/main/python/tests with spark-submit.