### PR TITLE
[SYSTEMML-445] Add optimization flag for lazy cudafree and also refactor locks

### DIFF
--- a/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
@@ -204,6 +204,13 @@ public class OptimizerUtils
 	 * 
 	 */
 	public static final boolean ALLOW_COMBINE_FILE_INPUT_FORMAT = true;
+	
+	/**
+	 * Enables lazy freeing of rmvar-ed GPU pointers.
+	 * If the subsequent instructions potential have matrices of same sizes, this optimization
+	 * allows reuse of previously allocated GPU pointer. Thus, saving the cost of unnecessary CUDA alloc and free.   
+	 */
+	public static final boolean ALLOW_GPU_LAZY_CUDA_FREE = true;
 
 	//////////////////////
 	// Optimizer levels //

--- a/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
@@ -204,13 +204,6 @@ public class OptimizerUtils
 	 * 
 	 */
 	public static final boolean ALLOW_COMBINE_FILE_INPUT_FORMAT = true;
-	
-	/**
-	 * Enables lazy freeing of rmvar-ed GPU pointers.
-	 * If the subsequent instructions potential have matrices of same sizes, this optimization
-	 * allows reuse of previously allocated GPU pointer. Thus, saving the cost of unnecessary CUDA alloc and free.   
-	 */
-	public static final boolean ALLOW_GPU_LAZY_CUDA_FREE = true;
 
 	//////////////////////
 	// Optimizer levels //

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
@@ -374,7 +374,7 @@ public class ExecutionContext {
 		}
 		// The lock is added here for an output block
 		// so that any block currently in use is not deallocated by eviction on the GPU
-		mo.getGPUObject(getGPUContext(0)).addLock();
+		mo.getGPUObject(getGPUContext(0)).addWriteLock();
 		return mo;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysml.runtime.instructions.gpu;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.lops.runtime.RunMRJobs;
 import org.apache.sysml.runtime.DMLRuntimeException;
@@ -26,6 +28,7 @@ import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.GPUInstructionParser;
 import org.apache.sysml.runtime.instructions.Instruction;
+import org.apache.sysml.runtime.instructions.gpu.context.GPUContext;
 import org.apache.sysml.runtime.matrix.data.Pair;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.utils.GPUStatistics;
@@ -46,6 +49,8 @@ public abstract class GPUInstruction extends Instruction {
 		Builtin,
 		MatrixIndexing
 	};
+	
+	private static final Log LOG = LogFactory.getLog(GPUInstruction.class.getName());
 
 	// Memory/conversions
 	public final static String MISC_TIMER_HOST_TO_DEVICE =          "H2D";	// time spent in bringing data to gpu (from host)
@@ -191,6 +196,14 @@ public abstract class GPUInstruction extends Instruction {
 		if(DMLScript.SYNCHRONIZE_GPU) {
 			jcuda.runtime.JCuda.cudaDeviceSynchronize();
 		}
+		// if(LOG.isDebugEnabled()) {
+		 	ec.getGPUContext(0).printMemoryInfo(getOpcode());
+//			for(GPUContext gpuCtx : ec.getGPUContexts()) {
+//				if(gpuCtx != null)
+//					gpuCtx.printMemoryInfo();
+//			}
+		// }
+			
 	}
 
 	/**

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/GPUInstruction.java
@@ -196,13 +196,12 @@ public abstract class GPUInstruction extends Instruction {
 		if(DMLScript.SYNCHRONIZE_GPU) {
 			jcuda.runtime.JCuda.cudaDeviceSynchronize();
 		}
-		// if(LOG.isDebugEnabled()) {
-		 	ec.getGPUContext(0).printMemoryInfo(getOpcode());
-//			for(GPUContext gpuCtx : ec.getGPUContexts()) {
-//				if(gpuCtx != null)
-//					gpuCtx.printMemoryInfo();
-//			}
-		// }
+		if(LOG.isDebugEnabled()) {
+			for(GPUContext gpuCtx : ec.getGPUContexts()) {
+				if(gpuCtx != null)
+					gpuCtx.printMemoryInfo(getOpcode());
+			}
+		}
 			
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUContext.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUContext.java
@@ -390,10 +390,6 @@ public class GPUContext {
 	 * @param eager           true if to be done eagerly
 	 */
 	public void cudaFreeHelper(String instructionName, final Pointer toFree, boolean eager) {
-		// Always perform eager cudaFree if the ALLOW_GPU_LAZY_CUDA_FREE optimization is disabled. 
-		if(!OptimizerUtils.ALLOW_GPU_LAZY_CUDA_FREE)
-			eager = true;
-		
 		Pointer dummy = new Pointer();
 		if (toFree == dummy) // trying to free a null pointer
 			return;


### PR DESCRIPTION
- Guard the cudaFree with an optimization flag to be consistent with other SystemML features.
- Refactored the locks to seperate out read and write lock. This gives clear description of the error for different cases. 
- Also, I have added mem info (a  developer debugging utility).

@nakul02 can you please review this PR ?
