### PR TITLE
[SYSTEMML-1648, 1865] SVM tests with MLContext

### DIFF
--- a/scripts/algorithms/l2-svm-predict.dml
+++ b/scripts/algorithms/l2-svm-predict.dml
@@ -26,7 +26,7 @@
 # accuracy (%) for the predictions
 #
 # Example Usage:
-# hadoop jar SystemML.jar -f l2-svm-predict.dml -nvargs X=data Y=labels model=model scores=scores accuracy=accuracy confusion=confusion fmt="text"
+# hadoop jar SystemML.jar -f l2-svm-predict.dml -nvargs X=data Y=labels scoring_only=FALSE model=model scores=scores accuracy=accuracy confusion=confusion fmt="text"
 #
 # Note about inputs: 
 # labels (entries in Y) should either be set to +1/-1
@@ -37,6 +37,7 @@ cmdLine_Y = ifdef($Y, " ")
 cmdLine_confusion = ifdef($confusion, " ")
 cmdLine_accuracy = ifdef($accuracy, " ")
 cmdLine_scores = ifdef($scores, " ")
+cmdLine_scoring_only = ifdef($scoring_only, FALSE)
 cmdLine_fmt = ifdef($fmt, "text")
 
 X = read($X)
@@ -61,7 +62,7 @@ scores = b + (X %*% w[1:ncol(X),])
 if(cmdLine_scores != " ")
 	write(scores, cmdLine_scores, format=cmdLine_fmt)
 
-if(cmdLine_Y != " "){
+if(cmdLine_scoring_only == FALSE){
 	y = read(cmdLine_Y)
 
 	pred = (scores >= 0)
@@ -88,22 +89,12 @@ if(cmdLine_Y != " "){
 		check_min_y_plus = sum(pred_is_minus*y_is_plus)
 		check_max_y_minus = sum(pred_is_plus*y_is_minus)
 		check_max_y_plus = sum(pred_is_plus*y_is_plus)
-
-		#s = check_min_y_minus + "," + check_min_y_plus
-		#s = append(s, check_max_y_minus + "," + check_max_y_plus)
-		#s = append(s, "")
-		#write(s, cmdLine_confusion)
 		
-		confusion_mat = matrix(0, rows=3, cols=3)
-        confusion_mat[1,2] = negative_label
-        confusion_mat[1,3] = positive_label
-        confusion_mat[2,1] = negative_label
-        confusion_mat[3,1] = positive_label
-        confusion_mat[2,2] = check_min_y_minus
-        confusion_mat[2,3] = check_max_y_minus
-        confusion_mat[3,2] = check_min_y_plus
-        confusion_mat[3,3] = check_max_y_plus
-
-        write(confusion_mat, cmdLine_confusion, format="csv")
+		confusion_mat = matrix(0, rows=2, cols=2)
+		confusion_mat[1,1] = check_min_y_minus
+		confusion_mat[1,2] = check_min_y_plus
+		confusion_mat[2,1] = check_max_y_minus
+		confusion_mat[2,2] = check_max_y_plus
+		write(confusion_mat, cmdLine_confusion, format="csv")
 	}
 }

--- a/scripts/algorithms/l2-svm-predict.dml
+++ b/scripts/algorithms/l2-svm-predict.dml
@@ -83,22 +83,22 @@ if(!cmdLine_scoring_only){
     if(negative_label != -1 | positive_label != +1)
       Y = 2/(positive_label - negative_label)*Y - (negative_label + positive_label)/(positive_label - negative_label)
     		
-	pred_is_minus = (pred == -1)
-	pred_is_plus = 1 - pred_is_minus
-	y_is_minus = (Y == -1)
-	y_is_plus = 1 - y_is_minus
+    pred_is_minus = (pred == -1)
+    pred_is_plus = 1 - pred_is_minus
+    y_is_minus = (Y == -1)
+    y_is_plus = 1 - y_is_minus
 
-	check_min_y_minus = sum(pred_is_minus*y_is_minus)
-	check_min_y_plus = sum(pred_is_minus*y_is_plus)
-	check_max_y_minus = sum(pred_is_plus*y_is_minus)
-	check_max_y_plus = sum(pred_is_plus*y_is_plus)
+    check_min_y_minus = sum(pred_is_minus*y_is_minus)
+    check_min_y_plus = sum(pred_is_minus*y_is_plus)
+    check_max_y_minus = sum(pred_is_plus*y_is_minus)
+    check_max_y_plus = sum(pred_is_plus*y_is_plus)
 		
-	confusion_mat = matrix(0, rows=2, cols=2)
-	confusion_mat[1,1] = check_min_y_minus
-	confusion_mat[1,2] = check_min_y_plus
-	confusion_mat[2,1] = check_max_y_minus
-	confusion_mat[2,2] = check_max_y_plus
+    confusion_mat = matrix(0, rows=2, cols=2)
+    confusion_mat[1,1] = check_min_y_minus
+    confusion_mat[1,2] = check_min_y_plus
+    confusion_mat[2,1] = check_max_y_minus
+    confusion_mat[2,2] = check_max_y_plus
 	
-	write(confusion_mat, cmdLine_confusion, format="csv")
+    write(confusion_mat, cmdLine_confusion, format="csv")
   }
 }

--- a/scripts/algorithms/l2-svm-predict.dml
+++ b/scripts/algorithms/l2-svm-predict.dml
@@ -46,7 +46,7 @@ w = read($model)
 
 dimensions = as.scalar(w[nrow(w),1])
 if(dimensions != ncol(X))
-	stop("Stopping due to invalid input: Model dimensions do not seem to match input data dimensions")
+  stop("Stopping due to invalid input: Model dimensions do not seem to match input data dimensions")
 	
 intercept = as.scalar(w[nrow(w)-1,1])
 negative_label = as.scalar(w[nrow(w)-2,1])
@@ -55,46 +55,50 @@ w = w[1:(nrow(w)-4),]
 
 b = 0.0
 if(intercept == 1)
-	b = as.scalar(w[nrow(w),1])
+  b = as.scalar(w[nrow(w),1])
 
 scores = b + (X %*% w[1:ncol(X),])
 
 if(cmdLine_scores != " ")
-	write(scores, cmdLine_scores, format=cmdLine_fmt)
+  write(scores, cmdLine_scores, format=cmdLine_fmt)
 
 if(!cmdLine_scoring_only){
-	Y = read(cmdLine_Y)
+  Y = read(cmdLine_Y)
 
-	pred = (scores >= 0)
-	pred_labels = pred*positive_label + (1-pred)*negative_label
-	num_correct = sum(pred_labels == Y)
-	acc = 100*num_correct/nrow(X)
+  pred = (scores >= 0)
+  pred_labels = pred*positive_label + (1-pred)*negative_label
+  num_correct = sum(pred_labels == Y)
+  acc = 100*num_correct/nrow(X)
 
-	acc_str = "Accuracy (%): " + acc
-	print(acc_str)
-	if(cmdLine_accuracy != " ")
-		write(acc_str, cmdLine_accuracy)
+  acc_str = "Accuracy (%): " + acc
+  print(acc_str)
+  
+  if(cmdLine_accuracy != " ")
+    write(acc_str, cmdLine_accuracy)
 
-	if(cmdLine_confusion != " "){
-		pred = 2*pred - 1
-		if(negative_label != -1 | positive_label != +1)
-        	Y = 2/(positive_label - negative_label)*Y - (negative_label + positive_label)/(positive_label - negative_label)
+  if(cmdLine_confusion != " "){
+  
+    pred = 2*pred - 1
+    
+    if(negative_label != -1 | positive_label != +1)
+      Y = 2/(positive_label - negative_label)*Y - (negative_label + positive_label)/(positive_label - negative_label)
+    		
+	pred_is_minus = (pred == -1)
+	pred_is_plus = 1 - pred_is_minus
+	y_is_minus = (Y == -1)
+	y_is_plus = 1 - y_is_minus
+
+	check_min_y_minus = sum(pred_is_minus*y_is_minus)
+	check_min_y_plus = sum(pred_is_minus*y_is_plus)
+	check_max_y_minus = sum(pred_is_plus*y_is_minus)
+	check_max_y_plus = sum(pred_is_plus*y_is_plus)
 		
-		pred_is_minus = (pred == -1)
-		pred_is_plus = 1 - pred_is_minus
-		y_is_minus = (Y == -1)
-		y_is_plus = 1 - y_is_minus
-
-		check_min_y_minus = sum(pred_is_minus*y_is_minus)
-		check_min_y_plus = sum(pred_is_minus*y_is_plus)
-		check_max_y_minus = sum(pred_is_plus*y_is_minus)
-		check_max_y_plus = sum(pred_is_plus*y_is_plus)
-		
-		confusion_mat = matrix(0, rows=2, cols=2)
-		confusion_mat[1,1] = check_min_y_minus
-		confusion_mat[1,2] = check_min_y_plus
-		confusion_mat[2,1] = check_max_y_minus
-		confusion_mat[2,2] = check_max_y_plus
-		write(confusion_mat, cmdLine_confusion, format="csv")
-	}
+	confusion_mat = matrix(0, rows=2, cols=2)
+	confusion_mat[1,1] = check_min_y_minus
+	confusion_mat[1,2] = check_min_y_plus
+	confusion_mat[2,1] = check_max_y_minus
+	confusion_mat[2,2] = check_max_y_plus
+	
+	write(confusion_mat, cmdLine_confusion, format="csv")
+  }
 }

--- a/scripts/algorithms/l2-svm-predict.dml
+++ b/scripts/algorithms/l2-svm-predict.dml
@@ -62,12 +62,12 @@ scores = b + (X %*% w[1:ncol(X),])
 if(cmdLine_scores != " ")
 	write(scores, cmdLine_scores, format=cmdLine_fmt)
 
-if(cmdLine_scoring_only == FALSE){
-	y = read(cmdLine_Y)
+if(!cmdLine_scoring_only){
+	Y = read(cmdLine_Y)
 
 	pred = (scores >= 0)
 	pred_labels = pred*positive_label + (1-pred)*negative_label
-	num_correct = sum(pred_labels == y)
+	num_correct = sum(pred_labels == Y)
 	acc = 100*num_correct/nrow(X)
 
 	acc_str = "Accuracy (%): " + acc
@@ -78,11 +78,11 @@ if(cmdLine_scoring_only == FALSE){
 	if(cmdLine_confusion != " "){
 		pred = 2*pred - 1
 		if(negative_label != -1 | positive_label != +1)
-        	y = 2/(positive_label - negative_label)*y - (negative_label + positive_label)/(positive_label - negative_label)
+        	Y = 2/(positive_label - negative_label)*Y - (negative_label + positive_label)/(positive_label - negative_label)
 		
 		pred_is_minus = (pred == -1)
 		pred_is_plus = 1 - pred_is_minus
-		y_is_minus = (y == -1)
+		y_is_minus = (Y == -1)
 		y_is_plus = 1 - y_is_minus
 
 		check_min_y_minus = sum(pred_is_minus*y_is_minus)

--- a/scripts/algorithms/l2-svm.dml
+++ b/scripts/algorithms/l2-svm.dml
@@ -102,23 +102,24 @@ Xw = matrix(0, rows=nrow(X), cols=1)
 debug_str = "# Iter, Obj"
 iter = 0
 while(continue == 1 & iter < maxiterations)  {
-	# minimizing primal obj along direction s
+    # minimizing primal obj along direction s
     step_sz = 0
     Xd = X %*% s
     wd = lambda * sum(w * s)
     dd = lambda * sum(s * s)
     continue1 = 1
     while(continue1 == 1){
-		tmp_Xw = Xw + step_sz*Xd
+	tmp_Xw = Xw + step_sz*Xd
       	out = 1 - Y * (tmp_Xw)
       	sv = (out > 0)
       	out = out * sv
       	g = wd + step_sz*dd - sum(out * Y * Xd)
       	h = dd + sum(Xd * sv * Xd)
       	step_sz = step_sz - g/h
-      	if (g*g/h < 0.0000000001){
-        	continue1 = 0
-      	}
+#	if (g*g/h < 0.0000000001){
+#       	continue1 = 0
+#      	}
+	continue1 = (gg/h >= 0.0000000001);
     }
 
     #update weights
@@ -135,17 +136,18 @@ while(continue == 1 & iter < maxiterations)  {
 	  debug_str = append(debug_str, iter + "," + obj)
 	
     tmp = sum(s * g_old)
-    if(step_sz*tmp < epsilon*obj){
-    	continue = 0
-    }
+#    if(step_sz*tmp < epsilon*obj){
+#    	continue = 0
+#    }
+    continue = (step_sztmp >= epsilon*obj & sum(s^2) != 0);
 
     #non-linear CG step
     be = sum(g_new * g_new)/sum(g_old * g_old)
     s = be * s + g_new
     g_old = g_new
-		if(sum(s^2) == 0){
-			continue = 0
-		}
+    if(sum(s^2) == 0){
+	continue = 0
+    }
     iter = iter + 1
 }
 

--- a/scripts/algorithms/l2-svm.dml
+++ b/scripts/algorithms/l2-svm.dml
@@ -35,7 +35,7 @@
 #
 
 cmdLine_fmt = ifdef($fmt, "text")
-cmdLine_icpt = ifdef($icpt, 0)
+cmdLine_icpt = ifdef($icpt, 1)
 cmdLine_tol = ifdef($tol, 0.001)
 cmdLine_reg = ifdef($reg, 1.0)
 cmdLine_maxiter = ifdef($maxiter, 100)
@@ -156,8 +156,8 @@ extra_model_params[4,1] = dimensions
 weights = w
 w = t(cbind(t(w), t(extra_model_params)))
 write(w, $model, format=cmdLine_fmt)
-write(extra_model_params, "", format=cmdLine_fmt)
-write(weights, "", format=cmdLine_fmt)
+write(extra_model_params, " ", format=cmdLine_fmt)
+write(weights, " ", format=cmdLine_fmt)
 
 logFile = $Log
 if(logFile != " ") {

--- a/scripts/algorithms/l2-svm.dml
+++ b/scripts/algorithms/l2-svm.dml
@@ -116,9 +116,6 @@ while(continue == 1 & iter < maxiterations)  {
       	g = wd + step_sz*dd - sum(out * Y * Xd)
       	h = dd + sum(Xd * sv * Xd)
       	step_sz = step_sz - g/h
-#	if (g*g/h < 0.0000000001){
-#       	continue1 = 0
-#      	}
 	continue1 = (gg/h >= 0.0000000001);
     }
 
@@ -136,9 +133,6 @@ while(continue == 1 & iter < maxiterations)  {
 	  debug_str = append(debug_str, iter + "," + obj)
 	
     tmp = sum(s * g_old)
-#    if(step_sz*tmp < epsilon*obj){
-#    	continue = 0
-#    }
     continue = (step_sztmp >= epsilon*obj & sum(s^2) != 0);
 
     #non-linear CG step

--- a/scripts/algorithms/l2-svm.dml
+++ b/scripts/algorithms/l2-svm.dml
@@ -44,7 +44,7 @@ X = read($X)
 Y = read($Y)
 
 if(nrow(X) < 2)
-	stop("Stopping due to invalid inputs: Not possible to learn a binary class classifier without at least 2 rows")
+  stop("Stopping due to invalid inputs: Not possible to learn a binary class classifier without at least 2 rows")
 
 check_min = min(Y)
 check_max = max(Y)
@@ -52,13 +52,13 @@ num_min = sum(Y == check_min)
 num_max = sum(Y == check_max)
 
 if(check_min == check_max)
-	stop("Stopping due to invalid inputs: Y seems to contain exactly one label")
+  stop("Stopping due to invalid inputs: Y seems to contain exactly one label")
 
 if(num_min + num_max != nrow(Y))
-	stop("Stopping due to invalid inputs: Y seems to contain more than 2 labels")
+  stop("Stopping due to invalid inputs: Y seems to contain more than 2 labels")
 	
 if(check_min != -1 | check_max != +1) 
-	Y = 2/(check_max - check_min)*Y - (check_min + check_max)/(check_max - check_min)
+  Y = 2/(check_max - check_min)*Y - (check_min + check_max)/(check_max - check_min)
 
 positive_label = check_max
 negative_label = check_min
@@ -67,31 +67,31 @@ continue = 1
 
 intercept = cmdLine_icpt
 if(intercept != 0 & intercept != 1)
-	stop("Stopping due to invalid argument: Currently supported intercept options are 0 and 1")
+  stop("Stopping due to invalid argument: Currently supported intercept options are 0 and 1")
 
 epsilon = cmdLine_tol
 if(epsilon < 0)
-	stop("Stopping due to invalid argument: Tolerance (tol) must be non-negative")
+  stop("Stopping due to invalid argument: Tolerance (tol) must be non-negative")
 	
 lambda = cmdLine_reg
 if(lambda < 0)
-	stop("Stopping due to invalid argument: Regularization constant (reg) must be non-negative")
+  stop("Stopping due to invalid argument: Regularization constant (reg) must be non-negative")
 	
 maxiterations = cmdLine_maxiter
 if(maxiterations < 1)
-	stop("Stopping due to invalid argument: Maximum iterations should be a positive integer")
+  stop("Stopping due to invalid argument: Maximum iterations should be a positive integer")
 
 num_samples = nrow(X)
 dimensions = ncol(X)
 
 if (intercept == 1) {
-	ones  = matrix(1, rows=num_samples, cols=1)
-	X = cbind(X, ones);
+  ones  = matrix(1, rows=num_samples, cols=1)
+  X = cbind(X, ones);
 }
 
 num_rows_in_w = dimensions
 if(intercept == 1){
-	num_rows_in_w = num_rows_in_w + 1
+  num_rows_in_w = num_rows_in_w + 1
 }
 w = matrix(0, rows=num_rows_in_w, cols=1)
 
@@ -102,47 +102,48 @@ Xw = matrix(0, rows=nrow(X), cols=1)
 debug_str = "# Iter, Obj"
 iter = 0
 while(continue == 1 & iter < maxiterations)  {
-    # minimizing primal obj along direction s
-    step_sz = 0
-    Xd = X %*% s
-    wd = lambda * sum(w * s)
-    dd = lambda * sum(s * s)
-    continue1 = 1
-    while(continue1 == 1){
-	tmp_Xw = Xw + step_sz*Xd
-      	out = 1 - Y * (tmp_Xw)
-      	sv = (out > 0)
-      	out = out * sv
-      	g = wd + step_sz*dd - sum(out * Y * Xd)
-      	h = dd + sum(Xd * sv * Xd)
-      	step_sz = step_sz - g/h
-	continue1 = (gg/h >= 0.0000000001);
-    }
-
-    #update weights
-    w = w + step_sz*s
-    Xw = Xw + step_sz*Xd
-	
-    out = 1 - Y * Xw
+  # minimizing primal obj along direction s
+  step_sz = 0
+  Xd = X %*% s
+  wd = lambda * sum(w * s)
+  dd = lambda * sum(s * s)
+  
+  continue1 = 1
+  while(continue1 == 1){
+    tmp_Xw = Xw + step_sz*Xd
+    out = 1 - Y * (tmp_Xw)
     sv = (out > 0)
-    out = sv * out
-    obj = 0.5 * sum(out * out) + lambda/2 * sum(w * w)
-    g_new = t(X) %*% (out * Y) - lambda * w
+    out = out * sv
+    g = wd + step_sz*dd - sum(out * Y * Xd)
+    h = dd + sum(Xd * sv * Xd)
+    step_sz = step_sz - g/h
+    continue1 = (gg/h >= 0.0000000001);
+  }
 
-    print("ITER " + iter + ": OBJ=" + obj)
-	  debug_str = append(debug_str, iter + "," + obj)
+  #update weights
+  w = w + step_sz*s
+  Xw = Xw + step_sz*Xd
 	
-    tmp = sum(s * g_old)
-    continue = (step_sztmp >= epsilon*obj & sum(s^2) != 0);
+  out = 1 - Y * Xw
+  sv = (out > 0)
+  out = sv * out
+  obj = 0.5 * sum(out * out) + lambda/2 * sum(w * w)
+  g_new = t(X) %*% (out * Y) - lambda * w
 
-    #non-linear CG step
-    be = sum(g_new * g_new)/sum(g_old * g_old)
-    s = be * s + g_new
-    g_old = g_new
-    if(sum(s^2) == 0){
-	continue = 0
-    }
-    iter = iter + 1
+  print("ITER " + iter + ": OBJ=" + obj)
+  debug_str = append(debug_str, iter + "," + obj)
+	
+  tmp = sum(s * g_old)
+  continue = (step_sztmp >= epsilon*obj & sum(s^2) != 0);
+
+  #non-linear CG step
+  be = sum(g_new * g_new)/sum(g_old * g_old)
+  s = be * s + g_new
+  g_old = g_new
+  
+  if(sum(s^2) == 0) continue = 0;
+    
+  iter = iter + 1
 }
 
 extra_model_params = matrix(0, rows=4, cols=1)
@@ -159,5 +160,5 @@ write(w, $model, format=cmdLine_fmt)
 
 logFile = $Log
 if(logFile != " ") {
-	write(debug_str, logFile)
+  write(debug_str, logFile)
 }

--- a/scripts/algorithms/l2-svm.dml
+++ b/scripts/algorithms/l2-svm.dml
@@ -144,10 +144,6 @@ while(continue == 1 & iter < maxiterations)  {
     s = be * s + g_new
     g_old = g_new
 
-	if(sum(s^2) == 0){
-	    continue = 0
-	}
-
     iter = iter + 1
 }
 
@@ -157,8 +153,11 @@ extra_model_params[2,1] = negative_label
 extra_model_params[3,1] = intercept
 extra_model_params[4,1] = dimensions
 
+weights = w
 w = t(cbind(t(w), t(extra_model_params)))
 write(w, $model, format=cmdLine_fmt)
+write(extra_model_params, "", format=cmdLine_fmt)
+write(weights, "", format=cmdLine_fmt)
 
 logFile = $Log
 if(logFile != " ") {

--- a/scripts/algorithms/l2-svm.dml
+++ b/scripts/algorithms/l2-svm.dml
@@ -63,8 +63,6 @@ if(check_min != -1 | check_max != +1)
 positive_label = check_max
 negative_label = check_min
 
-continue = 1
-
 intercept = cmdLine_icpt
 if(intercept != 0 & intercept != 1)
   stop("Stopping due to invalid argument: Currently supported intercept options are 0 and 1")
@@ -101,15 +99,16 @@ s = g_old
 Xw = matrix(0, rows=nrow(X), cols=1)
 debug_str = "# Iter, Obj"
 iter = 0
-while(continue == 1 & iter < maxiterations)  {
+continue = TRUE
+while(continue & iter < maxiterations)  {
   # minimizing primal obj along direction s
   step_sz = 0
   Xd = X %*% s
   wd = lambda * sum(w * s)
   dd = lambda * sum(s * s)
   
-  continue1 = 1
-  while(continue1 == 1){
+  continue1 = TRUE
+  while(continue1){
     tmp_Xw = Xw + step_sz*Xd
     out = 1 - Y * (tmp_Xw)
     sv = (out > 0)
@@ -117,6 +116,7 @@ while(continue == 1 & iter < maxiterations)  {
     g = wd + step_sz*dd - sum(out * Y * Xd)
     h = dd + sum(Xd * sv * Xd)
     step_sz = step_sz - g/h
+    
     continue1 = (gg/h >= 0.0000000001);
   }
 
@@ -141,7 +141,7 @@ while(continue == 1 & iter < maxiterations)  {
   s = be * s + g_new
   g_old = g_new
   
-  if(sum(s^2) == 0) continue = 0;
+  continue = (sum(s^2) != 0);
     
   iter = iter + 1
 }

--- a/scripts/algorithms/l2-svm.dml
+++ b/scripts/algorithms/l2-svm.dml
@@ -35,7 +35,7 @@
 #
 
 cmdLine_fmt = ifdef($fmt, "text")
-cmdLine_icpt = ifdef($icpt, 1)
+cmdLine_icpt = ifdef($icpt, 0)
 cmdLine_tol = ifdef($tol, 0.001)
 cmdLine_reg = ifdef($reg, 1.0)
 cmdLine_maxiter = ifdef($maxiter, 100)
@@ -123,7 +123,7 @@ while(continue == 1 & iter < maxiterations)  {
 
     #update weights
     w = w + step_sz*s
-	Xw = Xw + step_sz*Xd
+	  Xw = Xw + step_sz*Xd
 	
     out = 1 - Y * Xw
     sv = (out > 0)
@@ -132,7 +132,7 @@ while(continue == 1 & iter < maxiterations)  {
     g_new = t(X) %*% (out * Y) - lambda * w
 
     print("ITER " + iter + ": OBJ=" + obj)
-	debug_str = append(debug_str, iter + "," + obj)
+	  debug_str = append(debug_str, iter + "," + obj)
 	
     tmp = sum(s * g_old)
     if(step_sz*tmp < epsilon*obj){
@@ -143,7 +143,9 @@ while(continue == 1 & iter < maxiterations)  {
     be = sum(g_new * g_new)/sum(g_old * g_old)
     s = be * s + g_new
     g_old = g_new
-
+		if(sum(s^2) == 0){
+			continue = 0
+		}
     iter = iter + 1
 }
 

--- a/scripts/algorithms/l2-svm.dml
+++ b/scripts/algorithms/l2-svm.dml
@@ -121,7 +121,7 @@ while(continue == 1 & iter < maxiterations)  {
 
     #update weights
     w = w + step_sz*s
-	  Xw = Xw + step_sz*Xd
+    Xw = Xw + step_sz*Xd
 	
     out = 1 - Y * Xw
     sv = (out > 0)
@@ -154,8 +154,8 @@ extra_model_params[4,1] = dimensions
 weights = w
 w = t(cbind(t(w), t(extra_model_params)))
 write(w, $model, format=cmdLine_fmt)
-write(extra_model_params, " ", format=cmdLine_fmt)
-write(weights, " ", format=cmdLine_fmt)
+# write(extra_model_params, " ", format=cmdLine_fmt)
+# write(weights, " ", format=cmdLine_fmt)
 
 logFile = $Log
 if(logFile != " ") {

--- a/scripts/algorithms/m-svm-predict.dml
+++ b/scripts/algorithms/m-svm-predict.dml
@@ -41,7 +41,7 @@ W = read($model);
 
 dimensions = as.scalar(W[nrow(W),1])
 if(dimensions != ncol(X))
-	stop("Stopping due to invalid input: Model dimensions do not seem to match input data dimensions")
+  stop("Stopping due to invalid input: Model dimensions do not seem to match input data dimensions")
 
 intercept = as.scalar(W[nrow(W)-1,1])
 W = W[1:(nrow(W)-2),]
@@ -52,34 +52,34 @@ m=ncol(X);
 
 b = matrix(0, rows=1, cols=num_classes)
 if (intercept == 1)
-	b = W[m+1,]
+  b = W[m+1,]
 
 ones = matrix(1, rows=N, cols=1)
 scores = X %*% W[1:m,] + ones %*% b;
 	
 if(cmdLine_scores != " ")
-	write(scores, cmdLine_scores, format=cmdLine_fmt);
+  write(scores, cmdLine_scores, format=cmdLine_fmt);
 
 if(!cmdLine_scoring_only){
-	Y = read(cmdLine_Y);
+  Y = read(cmdLine_Y);
 	
-	if(min(Y) < 1)
-		stop("Stopping due to invalid argument: Label vector (Y) must be recoded")
+  if(min(Y) < 1)
+    stop("Stopping due to invalid argument: Label vector (Y) must be recoded")
 	
-	pred = rowIndexMax(scores);
-	correct_percentage = sum((pred - Y) == 0) / N * 100;
-	
-	acc_str = "Accuracy (%): " + correct_percentage
-	print(acc_str)
-	if(cmdLine_accuracy != " ")
-		write(acc_str, cmdLine_accuracy)
+  pred = rowIndexMax(scores);
+  correct_percentage = sum((pred - Y) == 0) / N * 100;
+  
+  acc_str = "Accuracy (%): " + correct_percentage
+  print(acc_str)
+  if(cmdLine_accuracy != " ")
+    write(acc_str, cmdLine_accuracy)
 
-	num_classes_ground_truth = max(Y)
-	if(num_classes < num_classes_ground_truth)
-		num_classes = num_classes_ground_truth
+  num_classes_ground_truth = max(Y)
+  if(num_classes < num_classes_ground_truth)
+    num_classes = num_classes_ground_truth
 
-	if(cmdLine_confusion != " "){
-		confusion_mat = table(Y, pred, num_classes, num_classes)
-		write(confusion_mat, cmdLine_confusion, format="csv")
-	}
+  if(cmdLine_confusion != " "){
+    confusion_mat = table(Y, pred, num_classes, num_classes)
+    write(confusion_mat, cmdLine_confusion, format="csv")
+  }
 }

--- a/scripts/algorithms/m-svm-predict.dml
+++ b/scripts/algorithms/m-svm-predict.dml
@@ -60,26 +60,26 @@ scores = X %*% W[1:m,] + ones %*% b;
 if(cmdLine_scores != " ")
 	write(scores, cmdLine_scores, format=cmdLine_fmt);
 
-if(cmdLine_scoring_only == FALSE){
-	y = read(cmdLine_Y);
+if(!cmdLine_scoring_only){
+	Y = read(cmdLine_Y);
 	
-	if(min(y) < 1)
+	if(min(Y) < 1)
 		stop("Stopping due to invalid argument: Label vector (Y) must be recoded")
 	
 	pred = rowIndexMax(scores);
-	correct_percentage = sum((pred - y) == 0) / N * 100;
+	correct_percentage = sum((pred - Y) == 0) / N * 100;
 	
 	acc_str = "Accuracy (%): " + correct_percentage
 	print(acc_str)
 	if(cmdLine_accuracy != " ")
 		write(acc_str, cmdLine_accuracy)
 
-	num_classes_ground_truth = max(y)
+	num_classes_ground_truth = max(Y)
 	if(num_classes < num_classes_ground_truth)
 		num_classes = num_classes_ground_truth
 
 	if(cmdLine_confusion != " "){
-		confusion_mat = table(y, pred, num_classes, num_classes)
+		confusion_mat = table(Y, pred, num_classes, num_classes)
 		write(confusion_mat, cmdLine_confusion, format="csv")
 	}
 }

--- a/scripts/algorithms/m-svm-predict.dml
+++ b/scripts/algorithms/m-svm-predict.dml
@@ -26,13 +26,14 @@
 # accuracy (%) for the predictions
 #
 # Example Usage:
-# hadoop jar SystemML.jar -f m-svm-predict.dml -nvargs X=data Y=labels model=model scores=scores accuracy=accuracy confusion=confusion fmt="text"
+# hadoop jar SystemML.jar -f m-svm-predict.dml -nvargs X=data Y=labels scoring_only=FALSE model=model scores=scores accuracy=accuracy confusion=confusion fmt="text"
 #													 
 
 cmdLine_Y = ifdef($Y, " ")
 cmdLine_confusion = ifdef($confusion, " ")
 cmdLine_accuracy = ifdef($accuracy, " ")
 cmdLine_scores = ifdef($scores, " ")
+cmdLine_scoring_only = ifdef($scoring_only, FALSE)
 cmdLine_fmt = ifdef($fmt, "text")
 
 X = read($X);
@@ -59,7 +60,7 @@ scores = X %*% W[1:m,] + ones %*% b;
 if(cmdLine_scores != " ")
 	write(scores, cmdLine_scores, format=cmdLine_fmt);
 
-if(cmdLine_Y != " "){
+if(cmdLine_scoring_only == FALSE){
 	y = read(cmdLine_Y);
 	
 	if(min(y) < 1)

--- a/scripts/algorithms/m-svm.dml
+++ b/scripts/algorithms/m-svm.dml
@@ -165,8 +165,8 @@ extra_model_params[2, 1] = dimensions
 weights = w
 w = t(cbind(t(w), t(extra_model_params)))
 write(w, $model, format=cmdLine_fmt)
-write(extra_model_params, " ", format=cmdLine_fmt)
-write(weights, " ", format=cmdLine_fmt)
+# write(extra_model_params, " ", format=cmdLine_fmt)
+# write(weights, " ", format=cmdLine_fmt)
 
 debug_str = "# Class, Iter, Obj"
 for(iter_class in 1:ncol(debug_mat)){

--- a/scripts/algorithms/m-svm.dml
+++ b/scripts/algorithms/m-svm.dml
@@ -41,123 +41,128 @@ print("icpt=" + cmdLine_icpt + " tol=" + cmdLine_tol + " reg=" + cmdLine_reg + "
 X = read($X)
 
 if(nrow(X) < 2)
-	stop("Stopping due to invalid inputs: Not possible to learn a classifier without at least 2 rows")
+  stop("Stopping due to invalid inputs: Not possible to learn a classifier without at least 2 rows")
 
 dimensions = ncol(X)
 
 Y = read($Y)
 
 if(nrow(X) != nrow(Y))
-	stop("Stopping due to invalid argument: Numbers of rows in X and Y must match")
+  stop("Stopping due to invalid argument: Numbers of rows in X and Y must match")
 
 intercept = cmdLine_icpt
 if(intercept != 0 & intercept != 1)
-	stop("Stopping due to invalid argument: Currently supported intercept options are 0 and 1")
+  stop("Stopping due to invalid argument: Currently supported intercept options are 0 and 1")
 
 min_y = min(Y)
 if(min_y < 1)
-	stop("Stopping due to invalid argument: Label vector (Y) must be recoded")
+  stop("Stopping due to invalid argument: Label vector (Y) must be recoded")
+  
 num_classes = max(Y)
 if(num_classes == 1)
-	stop("Stopping due to invalid argument: Maximum label value is 1, need more than one class to learn a multi-class classifier")	
+  stop("Stopping due to invalid argument: Maximum label value is 1, need more than one class to learn a multi-class classifier")
+  
 mod1 = Y %% 1
 mod1_should_be_nrow = sum(abs(mod1 == 0))
 if(mod1_should_be_nrow != nrow(Y))
-	stop("Stopping due to invalid argument: Please ensure that Y contains (positive) integral labels")
+  stop("Stopping due to invalid argument: Please ensure that Y contains (positive) integral labels")
 	
 epsilon = cmdLine_tol
 if(epsilon < 0)
-	stop("Stopping due to invalid argument: Tolerance (tol) must be non-negative")
+  stop("Stopping due to invalid argument: Tolerance (tol) must be non-negative")
 
 lambda = cmdLine_reg
 if(lambda < 0)
-	stop("Stopping due to invalid argument: Regularization constant (reg) must be non-negative")
+  stop("Stopping due to invalid argument: Regularization constant (reg) must be non-negative")
 
 max_iterations = cmdLine_maxiter
 if(max_iterations < 1)
-	stop("Stopping due to invalid argument: Maximum iterations should be a positive integer")
+  stop("Stopping due to invalid argument: Maximum iterations should be a positive integer")
 
 num_samples = nrow(X)
 num_features = ncol(X)
 
 if (intercept == 1) {
-	ones  = matrix(1, rows=num_samples, cols=1);
-	X = cbind(X, ones);
+  ones  = matrix(1, rows=num_samples, cols=1);
+  X = cbind(X, ones);
 }
 
 num_rows_in_w = num_features
 if(intercept == 1){
-	num_rows_in_w = num_rows_in_w + 1
+  num_rows_in_w = num_rows_in_w + 1
 }
 w = matrix(0, rows=num_rows_in_w, cols=num_classes)
 
 debug_mat = matrix(-1, rows=max_iterations, cols=num_classes)
+
 parfor(iter_class in 1:num_classes){		  
-	Y_local = 2 * (Y == iter_class) - 1
-	w_class = matrix(0, rows=num_features, cols=1)
-	if (intercept == 1) {
-		zero_matrix = matrix(0, rows=1, cols=1);
-		w_class = t(cbind(t(w_class), zero_matrix));
-	}
- 
-	g_old = t(X) %*% Y_local
-	s = g_old
-
-	Xw = matrix(0, rows=nrow(X), cols=1)
-	iter = 0
-	continue = 1
-	while(continue == 1)  {
-		# minimizing primal obj along direction s
- 		step_sz = 0
- 		Xd = X %*% s
- 		wd = lambda * sum(w_class * s)
-		dd = lambda * sum(s * s)
-		continue1 = 1
-		while(continue1 == 1){
- 			tmp_Xw = Xw + step_sz*Xd
- 			out = 1 - Y_local * (tmp_Xw)
- 			sv = (out > 0)
- 			out = out * sv
- 			g = wd + step_sz*dd - sum(out * Y_local * Xd)
- 			h = dd + sum(Xd * sv * Xd)
- 			step_sz = step_sz - g/h
- 			if (g*g/h < 0.0000000001){
-			continue1 = 0
-		}
-	}
- 
-		#update weights
-		w_class = w_class + step_sz*s
-		Xw = Xw + step_sz*Xd
- 
-		out = 1 - Y_local * Xw
-		sv = (out > 0)
-		out = sv * out
-		obj = 0.5 * sum(out * out) + lambda/2 * sum(w_class * w_class)
-  		g_new = t(X) %*% (out * Y_local) - lambda * w_class
-
-  		tmp = sum(s * g_old)
+  Y_local = 2 * (Y == iter_class) - 1
+  w_class = matrix(0, rows=num_features, cols=1)
   
-  		train_acc = sum(Y_local*(X%*%w_class) >= 0)/num_samples*100
-  		print("For class " + iter_class + " iteration " + iter + " training accuracy: " + train_acc)
-  		debug_mat[iter+1,iter_class] = obj	   
-   
-  		if((step_sz*tmp < epsilon*obj) | (iter >= max_iterations-1)){
-   			continue = 0
-  		}
- 
-  		#non-linear CG step
-  		be = sum(g_new * g_new)/sum(g_old * g_old)
-  		s = be * s + g_new
-  		g_old = g_new
-			if(sum(s^2) == 0){
-				continue = 0
-			}
-  		iter = iter + 1
- 	}
+  if (intercept == 1) {
+    zero_matrix = matrix(0, rows=1, cols=1);
+    w_class = t(cbind(t(w_class), zero_matrix));
+  }
+  
+  g_old = t(X) %*% Y_local
+  s = g_old
 
-	w[,iter_class] = w_class
-}
+  Xw = matrix(0, rows=nrow(X), cols=1)
+  iter = 0
+  continue = 1
+  while(continue == 1)  {
+    # minimizing primal obj along direction s
+    step_sz = 0
+    Xd = X %*% s
+    wd = lambda * sum(w_class * s)
+    dd = lambda * sum(s * s)
+    
+    continue1 = 1
+    while(continue1 == 1){
+      tmp_Xw = Xw + step_sz*Xd
+      out = 1 - Y_local * (tmp_Xw)
+      sv = (out > 0)
+      out = out * sv
+      g = wd + step_sz*dd - sum(out * Y_local * Xd)
+      h = dd + sum(Xd * sv * Xd)
+      step_sz = step_sz - g/h
+      
+      if (g*g/h < 0.0000000001)
+        continue1 = 0;
+      
+    }
+    
+    #update weights
+    w_class = w_class + step_sz*s
+    Xw = Xw + step_sz*Xd
+ 
+    out = 1 - Y_local * Xw
+    sv = (out > 0)
+    out = sv * out
+    obj = 0.5 * sum(out * out) + lambda/2 * sum(w_class * w_class)
+    g_new = t(X) %*% (out * Y_local) - lambda * w_class
+
+    tmp = sum(s * g_old)
+  
+    train_acc = sum(Y_local*(X%*%w_class) >= 0)/num_samples*100
+    print("For class " + iter_class + " iteration " + iter + " training accuracy: " + train_acc)
+    debug_mat[iter+1,iter_class] = obj	   
+   
+    if((step_sz*tmp < epsilon*obj) | (iter >= max_iterations-1))
+      continue = 0;  			
+  	 
+    #non-linear CG step
+    be = sum(g_new * g_new)/sum(g_old * g_old)
+    s = be * s + g_new
+    g_old = g_new
+	
+    if(sum(s^2) == 0) continue = 0;
+    
+    iter = iter + 1
+  }
+
+  w[,iter_class] = w_class
+} # parfor loop
 
 extra_model_params = matrix(0, rows=2, cols=ncol(w))
 extra_model_params[1, 1] = intercept
@@ -170,13 +175,14 @@ write(w, $model, format=cmdLine_fmt)
 
 debug_str = "# Class, Iter, Obj"
 for(iter_class in 1:ncol(debug_mat)){
-	for(iter in 1:nrow(debug_mat)){
-		obj = as.scalar(debug_mat[iter, iter_class])
-		if(obj != -1) 
-			debug_str = append(debug_str, iter_class + "," + iter + "," + obj)
-	}
+  for(iter in 1:nrow(debug_mat)){
+    obj = as.scalar(debug_mat[iter, iter_class])
+    if(obj != -1) 
+      debug_str = append(debug_str, iter_class + "," + iter + "," + obj)
+  }
 }
+
 logFile = $Log
-if(logFile != " ") {
-	write(debug_str, logFile)
-}
+if(logFile != " ")
+  write(debug_str, logFile)
+

--- a/scripts/algorithms/m-svm.dml
+++ b/scripts/algorithms/m-svm.dml
@@ -150,7 +150,9 @@ parfor(iter_class in 1:num_classes){
   		be = sum(g_new * g_new)/sum(g_old * g_old)
   		s = be * s + g_new
   		g_old = g_new
-
+			if(sum(s^2) == 0){
+				continue = 0
+			}
   		iter = iter + 1
  	}
 

--- a/scripts/algorithms/m-svm.dml
+++ b/scripts/algorithms/m-svm.dml
@@ -126,16 +126,16 @@ parfor(iter_class in 1:num_classes){
 
   Xw = matrix(0, rows=nrow(X), cols=1)
   iter = 0
-  continue = 1
-  while(continue == 1)  {
+  continue = TRUE
+  while(continue)  {
     # minimizing primal obj along direction s
     step_sz = 0
     Xd = X %*% s
     wd = lambda * sum(w_class * s)
     dd = lambda * sum(s * s)
     
-    continue1 = 1
-    while(continue1 == 1){
+    continue1 = TRUE
+    while(continue1){
       tmp_Xw = Xw + step_sz*Xd
       out = 1 - Y_local * (tmp_Xw)
       sv = (out > 0)
@@ -144,8 +144,7 @@ parfor(iter_class in 1:num_classes){
       h = dd + sum(Xd * sv * Xd)
       step_sz = step_sz - g/h
       
-      if (g*g/h < 0.0000000001)
-        continue1 = 0;
+      continue1 = (g*g/h >= 0.0000000001)
       
     }
     
@@ -173,7 +172,7 @@ parfor(iter_class in 1:num_classes){
     s = be * s + g_new
     g_old = g_new
 	
-    if(sum(s^2) == 0) continue = 0;
+    continue = (sum(s^2) != 0)
     
     iter = iter + 1
   }

--- a/scripts/algorithms/m-svm.dml
+++ b/scripts/algorithms/m-svm.dml
@@ -26,6 +26,23 @@
 # Assume SVM_HOME is set to the home of the dml script
 # Assume input and output directories are on hdfs as INPUT_DIR and OUTPUT_DIR
 # Assume epsilon = 0.001, lambda=1.0, max_iterations = 100
+#
+# INPUT PARAMETERS:
+# ---------------------------------------------------------------------------------------------
+# NAME      TYPE    DEFAULT     MEANING
+# ---------------------------------------------------------------------------------------------
+# X         String  ---         Location to read the matrix X of feature vectors
+# Y         String  ---         Location to read response matrix Y
+# icpt      Int     0           Intercept presence
+#                               0 = no intercept
+#                               1 = add intercept;
+# tol       Double  0.001       Tolerance (epsilon);
+# reg       Double  1.0         Regularization parameter
+# maxiter   Int     100         Maximum number of conjugate gradient iterations
+# model     String  ---         Location to write model
+# fmt       String  "text"      The output format of the output, such as "text" or "csv"
+# Log       String  ---         [OPTIONAL] Location to write the log file
+# ---------------------------------------------------------------------------------------------
 # 
 # hadoop jar SystemML.jar -f $SVM_HOME/m-svm.dml -nvargs X=$INPUT_DIR/X Y=$INPUT_DIR/y icpt=intercept tol=.001 reg=1.0 maxiter=100 model=$OUTPUT_DIR/w Log=$OUTPUT_DIR/Log fmt="text"
 #

--- a/scripts/algorithms/m-svm.dml
+++ b/scripts/algorithms/m-svm.dml
@@ -151,10 +151,6 @@ parfor(iter_class in 1:num_classes){
   		s = be * s + g_new
   		g_old = g_new
 
-		if(sum(s^2) == 0){
-	    	continue = 0
-		}
-
   		iter = iter + 1
  	}
 
@@ -164,8 +160,11 @@ parfor(iter_class in 1:num_classes){
 extra_model_params = matrix(0, rows=2, cols=ncol(w))
 extra_model_params[1, 1] = intercept
 extra_model_params[2, 1] = dimensions
+weights = w
 w = t(cbind(t(w), t(extra_model_params)))
 write(w, $model, format=cmdLine_fmt)
+write(extra_model_params, " ", format=cmdLine_fmt)
+write(weights, " ", format=cmdLine_fmt)
 
 debug_str = "# Class, Iter, Obj"
 for(iter_class in 1:ncol(debug_mat)){

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/algorithms/MLContextSVMTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/algorithms/MLContextSVMTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.test.integration.mlcontext.algorithms;
+
+import static org.apache.sysml.api.mlcontext.ScriptFactory.dmlFromFile;
+
+import org.apache.log4j.Logger;
+import org.apache.sysml.api.mlcontext.Script;
+import org.apache.sysml.hops.OptimizerUtils;
+import org.apache.sysml.test.integration.mlcontext.MLContextTestBase;
+import org.apache.sysml.test.utils.TestUtils;
+import org.junit.Test;
+
+public class MLContextSVMTest extends MLContextTestBase {
+        protected static Logger log = Logger.getLogger(MLContextSVMTest.class);
+
+        protected final static String TEST_SCRIPT_L2SVM = "scripts/algorithms/l2-svm.dml";
+        protected final static String TEST_SCRIPT_MSVM  = "scripts/algorithms/m-svm.dml";
+
+        private final static double sparsity1 = 0.7;//dense
+        private final static double sparsity2 = 0.1;//sparse
+
+        private final static int rows = 3468;
+        private final static int cols = 1007;
+
+        public enum SVMtype {
+                L2SVM,
+                MSVM
+        }
+
+        @Test
+        public void testL2SVMDenseRewrites() {
+                runSVMTestMLC(SVMtype.L2SVM, 1, true, false);
+        }
+
+        @Test
+        public void testL2SVMSparseRewrites() {
+                runSVMTestMLC(SVMtype.L2SVM, 1, true, true);
+        }
+
+        @Test
+        public void testL2SVMDense() {
+                runSVMTestMLC(SVMtype.L2SVM, 1, false, false);
+        }
+
+        @Test
+        public void testL2SVMSparse() {
+                runSVMTestMLC(SVMtype.L2SVM, 1, false, true);
+        }
+
+        @Test
+        public void testMSVMDenseBinaryRewrites() {
+                runSVMTestMLC(SVMtype.MSVM, 2, true, false);
+        }
+
+        @Test
+        public void testMSVMSparseBinaryRewrites() {
+                runSVMTestMLC(SVMtype.MSVM, 2, true, true);
+        }
+
+        @Test
+        public void testMSVMDenseMulRewrites() {
+                runSVMTestMLC(SVMtype.MSVM, 4, true, false);
+        }
+
+        @Test
+        public void testMSVMSparseMulRewrites() {
+                runSVMTestMLC(SVMtype.MSVM, 4, true, true);
+        }
+
+        @Test
+        public void testMSVMDenseBinary() {
+                runSVMTestMLC(SVMtype.MSVM, 2, false, false);
+        }
+
+        @Test
+        public void testMSVMSparseBinary() {
+                runSVMTestMLC(SVMtype.MSVM, 2, false, true);
+        }
+
+        @Test
+        public void testMSVMDenseMul() {
+                runSVMTestMLC(SVMtype.MSVM, 4, false, false);
+        }
+
+        @Test
+        public void testMSVMSparseMul() {
+                runSVMTestMLC(SVMtype.MSVM, 4, false, true);
+        }
+        
+        /* This test is only for the I/O check, TODO: validate output */
+        private void runSVMTestMLC(SVMtype type, int numClasses,boolean rewrites, boolean sparse) {
+
+                 OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = rewrites;
+
+                 double[][] X = getRandomMatrix(rows, cols, 0, 1, sparse ? sparsity2: sparsity1, 714);
+                 double[][] Y = TestUtils.round(getRandomMatrix(rows, 1, 1, numClasses, 1.0, 136));
+
+                 switch(type) {
+                 case L2SVM:
+                            Script l2svm = dmlFromFile(TEST_SCRIPT_L2SVM);
+                            l2svm.in("X", X).in("Y", Y).in("$icpt", 0).in("$tol", 0.001)
+                                  .in("$reg", 1.0).in("$maxiter", 100).out("w");
+                            ml.execute(l2svm);
+
+                            break;
+
+                 case MSVM:
+                           Script msvm = dmlFromFile(TEST_SCRIPT_MSVM);
+                           msvm.in("X", X).in("Y", Y).in("$icpt", 0).in("$tol", 0.001)
+                                .in("$reg", 1.0).in("$maxiter", 100).out("w");
+                           ml.execute(msvm);
+
+                           break;
+                 }
+        }
+}

--- a/src/test/java/org/apache/sysml/test/integration/mlcontext/algorithms/MLContextSVMTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/mlcontext/algorithms/MLContextSVMTest.java
@@ -116,16 +116,16 @@ public class MLContextSVMTest extends MLContextTestBase {
                  switch(type) {
                  case L2SVM:
                             Script l2svm = dmlFromFile(TEST_SCRIPT_L2SVM);
-                            l2svm.in("X", X).in("Y", Y).in("$icpt", 0).in("$tol", 0.001)
-                                  .in("$reg", 1.0).in("$maxiter", 100).out("w");
+                            l2svm.in("X", X).in("Y", Y).in("$icpt", "0").in("$tol", "0.001")
+                                  .in("$reg", "1.0").in("$maxiter", "100").out("w");
                             ml.execute(l2svm);
 
                             break;
 
                  case MSVM:
                            Script msvm = dmlFromFile(TEST_SCRIPT_MSVM);
-                           msvm.in("X", X).in("Y", Y).in("$icpt", 0).in("$tol", 0.001)
-                                .in("$reg", 1.0).in("$maxiter", 100).out("w");
+                           msvm.in("X", X).in("Y", Y).in("$icpt", "0").in("$tol", "0.001")
+                                .in("$reg", "1.0").in("$maxiter", "100").out("w");
                            ml.execute(msvm);
 
                            break;

--- a/src/test_suites/java/org/apache/sysml/test/integration/mlcontext/algorithms/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/mlcontext/algorithms/ZPackageSuite.java
@@ -27,6 +27,8 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+        MLContextUnivariateStatisticsTest.class,
+        MLContextLinregTest.class,      
         MLContextSVMTest.class
 })
 

--- a/src/test_suites/java/org/apache/sysml/test/integration/mlcontext/algorithms/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/mlcontext/algorithms/ZPackageSuite.java
@@ -26,11 +26,11 @@ import org.junit.runners.Suite;
  * Group together the tests in this package.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({
-        MLContextUnivariateStatisticsTest.class,
-        MLContextLinregTest.class,      
-        MLContextSVMTest.class
-})
+@Suite.SuiteClasses({ 
+  MLContextUnivariateStatisticsTest.class,
+  MLContextLinregTest.class,
+  MLContextSVMTest.class,
+    })
 
 /** This class is just a holder for the above JUnit annotations. */
 public class ZPackageSuite {

--- a/src/test_suites/java/org/apache/sysml/test/integration/mlcontext/algorithms/ZPackageSuite.java
+++ b/src/test_suites/java/org/apache/sysml/test/integration/mlcontext/algorithms/ZPackageSuite.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.test.integration.mlcontext.algorithms;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Group together the tests in this package.
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        MLContextSVMTest.class
+})
+
+/** This class is just a holder for the above JUnit annotations. */
+public class ZPackageSuite {
+
+}


### PR DESCRIPTION
- Reformat the dml scripts with 2 spaces
- Adds a test class for `l2-svm.dml` and `m-svm.dml`
- minor doc improvements