### PR TITLE
[SYSTEMML-1940] Modify the default directory of performance test to avoid maven compilation issue

### DIFF
--- a/scripts/perftest/python/run_perftest.py
+++ b/scripts/perftest/python/run_perftest.py
@@ -283,7 +283,7 @@ if __name__ == '__main__':
     default_mat_shape = ['10k_100']
 
     # Default temp directory, contains everything generated in perftest
-    default_config_dir = join(systemml_home, 'scripts', 'perftest', 'temp')
+    default_config_dir = join(systemml_home, 'temp')
 
     # Initialize time
     start_time = time.time()

--- a/scripts/perftest/python/run_perftest.py
+++ b/scripts/perftest/python/run_perftest.py
@@ -283,7 +283,7 @@ if __name__ == '__main__':
     default_mat_shape = ['10k_100']
 
     # Default temp directory, contains everything generated in perftest
-    default_config_dir = join(systemml_home, 'temp')
+    default_config_dir = join(systemml_home, 'temp_perftest')
 
     # Initialize time
     start_time = time.time()


### PR DESCRIPTION
- Currently, the performance test generates it data in scripts folder. This causes maven to take too long for compilation as it tries to create jar with all the data.

@nakul02 @krishnakalyan3 can you  please review this PR ?