### PR TITLE
[SYSTEMML-1875] Changed pom.xml to use the latest protoc-jar-maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
 			<plugin>
 			    <groupId>com.github.os72</groupId>
 			    <artifactId>protoc-jar-maven-plugin</artifactId>
-			    <version>3.0.0-b2.1</version>
+			    <version>3.4.0.1</version>
 			    <executions>
 			        <execution>
 			        	<id>caffe-sources</id>
@@ -354,7 +354,7 @@
 			                <goal>run</goal>
 			            </goals>
 			            <configuration>
-			                <protocVersion>2.5.0</protocVersion> <!-- 2.4.1, 2.5.0, 2.6.1, 3.0.0 -->
+			                <protocVersion>2.6.1</protocVersion> <!-- 2.4.1, 2.5.0, 2.6.1, 3.4.0 -->
 			                <inputDirectories>
 			                    <include>src/main/proto/caffe</include>
 			                </inputDirectories>


### PR DESCRIPTION
- This uses the latest protoc-jar-maven-plugin to get the protoc
compiler for ppc

Tested on mac, linux x86_64, linux ppc64le