### PR TITLE
[SYSTEMML-445] Change the default CuDNN algorithm selector for conv2d_backward_data

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNNConvolutionAlgorithm.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNNConvolutionAlgorithm.java
@@ -25,6 +25,7 @@ import org.apache.sysml.runtime.instructions.gpu.context.GPUContext;
 import org.apache.sysml.utils.GPUStatistics;
 
 import jcuda.Pointer;
+import jcuda.jcudnn.cudnnConvolutionBwdDataPreference;
 import jcuda.jcudnn.cudnnConvolutionBwdFilterPreference;
 import jcuda.jcudnn.cudnnConvolutionDescriptor;
 import jcuda.jcudnn.cudnnConvolutionFwdPreference;
@@ -129,24 +130,17 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 		long t1 = GPUStatistics.DISPLAY_STATISTICS ? System.nanoTime() : 0;
 		LibMatrixCuDNNConvolutionAlgorithm ret = new LibMatrixCuDNNConvolutionAlgorithm(gCtx, instName, N, C, H, W, K, R, S, 
 				pad_h, pad_w, stride_h, stride_w, P, Q);
-		if(workspaceLimit <= 0) {
-			// If overhead is greater than intermediate allocated memory, prefer the cudnn operator with no memory requirement, 
-			// i.e. CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM
-			ret.algo = jcuda.jcudnn.cudnnConvolutionFwdAlgo.CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
-		}
-		else {
-			int[] algos = {-1};
-			long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
-			jcuda.jcudnn.JCudnn.cudnnGetConvolutionForwardAlgorithm(LibMatrixCuDNN.getCudnnHandle(gCtx), 
-					ret.nchwTensorDesc, ret.filterDesc, ret.convDesc, ret.nkpqTensorDesc,
-					cudnnConvolutionFwdPreference.CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
-			jcuda.jcudnn.JCudnn.cudnnGetConvolutionForwardWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
-					ret.nchwTensorDesc, ret.filterDesc, ret.convDesc, ret.nkpqTensorDesc, algos[0], sizeInBytesArray);
-			if (sizeInBytesArray[0] != 0)
-				ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
-			ret.sizeInBytes = sizeInBytesArray[0];
-			ret.algo = algos[0];
-		}
+		int[] algos = {-1};
+		long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
+		jcuda.jcudnn.JCudnn.cudnnGetConvolutionForwardAlgorithm(LibMatrixCuDNN.getCudnnHandle(gCtx), 
+				ret.nchwTensorDesc, ret.filterDesc, ret.convDesc, ret.nkpqTensorDesc,
+				cudnnConvolutionFwdPreference.CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
+		jcuda.jcudnn.JCudnn.cudnnGetConvolutionForwardWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
+				ret.nchwTensorDesc, ret.filterDesc, ret.convDesc, ret.nkpqTensorDesc, algos[0], sizeInBytesArray);
+		if (sizeInBytesArray[0] != 0)
+			ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
+		ret.sizeInBytes = sizeInBytesArray[0];
+		ret.algo = algos[0];
 		if (GPUStatistics.DISPLAY_STATISTICS)
 			GPUStatistics.maintainCPMiscTimes(instName, GPUInstruction.MISC_TIMER_CUDNN_INIT, System.nanoTime() - t1);
 		return ret;
@@ -181,25 +175,19 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 		LibMatrixCuDNNConvolutionAlgorithm ret = new LibMatrixCuDNNConvolutionAlgorithm(gCtx, instName, N, C, H, W, K, R, S, 
 				pad_h, pad_w, stride_h, stride_w, P, Q);
 		
-		if(workspaceLimit <= 0) {
-			// If overhead is greater than intermediate allocated memory, prefer the cudnn operator with no memory requirement
-			// i.e. CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0
-			ret.algo = jcuda.jcudnn.cudnnConvolutionBwdFilterAlgo.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
-		}
-		else {
-			int[] algos = {-1};
-			long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
-			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardFilterAlgorithm(
-					LibMatrixCuDNN.getCudnnHandle(gCtx), 
-					ret.nchwTensorDesc, ret.nkpqTensorDesc, ret.convDesc, ret.filterDesc, 
-					cudnnConvolutionBwdFilterPreference.CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
-			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardFilterWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
-					ret.nchwTensorDesc, ret.nkpqTensorDesc, ret.convDesc, ret.filterDesc, algos[0], sizeInBytesArray);
-			if (sizeInBytesArray[0] != 0)
-				ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
-			ret.sizeInBytes = sizeInBytesArray[0];
-			ret.algo = algos[0];
-		}
+		int[] algos = {-1};
+		long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
+		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardFilterAlgorithm(
+				LibMatrixCuDNN.getCudnnHandle(gCtx), 
+				ret.nchwTensorDesc, ret.nkpqTensorDesc, ret.convDesc, ret.filterDesc, 
+				cudnnConvolutionBwdFilterPreference.CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
+		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardFilterWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
+				ret.nchwTensorDesc, ret.nkpqTensorDesc, ret.convDesc, ret.filterDesc, algos[0], sizeInBytesArray);
+		if (sizeInBytesArray[0] != 0)
+			ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
+		ret.sizeInBytes = sizeInBytesArray[0];
+		ret.algo = algos[0];
+		
 		if (GPUStatistics.DISPLAY_STATISTICS)
 			GPUStatistics.maintainCPMiscTimes(instName, GPUInstruction.MISC_TIMER_CUDNN_INIT, System.nanoTime() - t1);
 		return ret;
@@ -238,25 +226,20 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 		// for sentence CNN (N=1, C=1, H=2060, W=300, F=500, Hf=5, Wf=300, sparsity=0.1).
 		// This causes more than 100x slowdown when compared with CUDNN_CONVOLUTION_BWD_DATA_ALGO_0.
 		// To keep things simple for now, we will always prefer to use memory-less operator: CUDNN_CONVOLUTION_BWD_DATA_ALGO_0
-//		if(workspaceLimit <= 0) {
-			// If overhead is greater than intermediate allocated memory, prefer the cudnn operator with no memory requirement
-			// i.e. CUDNN_CONVOLUTION_BWD_DATA_ALGO_0
-			ret.algo = jcuda.jcudnn.cudnnConvolutionBwdDataAlgo.CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
-//		}
-//		else {
-//			int[] algos = {-1};
-//			long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
-//			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataAlgorithm(
-//					LibMatrixCuDNN.getCudnnHandle(gCtx), 
-//					ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc,
-//					cudnnConvolutionBwdDataPreference.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
-//			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
-//					ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc, algos[0], sizeInBytesArray);
-//			if (sizeInBytesArray[0] != 0)
-//				ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
-//			ret.sizeInBytes = sizeInBytesArray[0];
-//			ret.algo = algos[0];
-//		}
+		workspaceLimit = 0;
+		
+		int[] algos = {-1};
+		long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
+		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataAlgorithm(
+				LibMatrixCuDNN.getCudnnHandle(gCtx), 
+				ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc,
+				cudnnConvolutionBwdDataPreference.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
+		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
+				ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc, algos[0], sizeInBytesArray);
+		if (sizeInBytesArray[0] != 0)
+			ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
+		ret.sizeInBytes = sizeInBytesArray[0];
+		ret.algo = algos[0];
 		if (GPUStatistics.DISPLAY_STATISTICS)
 			GPUStatistics.maintainCPMiscTimes(instName, GPUInstruction.MISC_TIMER_CUDNN_INIT, System.nanoTime() - t1);
 		return ret;

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNNConvolutionAlgorithm.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNNConvolutionAlgorithm.java
@@ -226,22 +226,21 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 		// for sentence CNN (N=1, C=1, H=2060, W=300, F=500, Hf=5, Wf=300, sparsity=0.1).
 		// This causes more than 100x slowdown when compared with CUDNN_CONVOLUTION_BWD_DATA_ALGO_0.
 		// To keep things simple for now, we will always prefer to use memory-less operator: CUDNN_CONVOLUTION_BWD_DATA_ALGO_0
-		workspaceLimit = 0;
-		
-		int[] algos = {-1};
-		long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
-		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataAlgorithm(
-				LibMatrixCuDNN.getCudnnHandle(gCtx), 
-				ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc,
-				cudnnConvolutionBwdDataPreference.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
-		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
-				ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc, algos[0], sizeInBytesArray);
-		if (sizeInBytesArray[0] != 0)
-			ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
-		ret.sizeInBytes = sizeInBytesArray[0];
-		ret.algo = algos[0];
-		if (GPUStatistics.DISPLAY_STATISTICS)
-			GPUStatistics.maintainCPMiscTimes(instName, GPUInstruction.MISC_TIMER_CUDNN_INIT, System.nanoTime() - t1);
+		ret.algo = jcuda.jcudnn.cudnnConvolutionBwdDataAlgo.CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
+//		int[] algos = {-1};
+//		long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
+//		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataAlgorithm(
+//				LibMatrixCuDNN.getCudnnHandle(gCtx), 
+//				ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc,
+//				cudnnConvolutionBwdDataPreference.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
+//		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
+//				ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc, algos[0], sizeInBytesArray);
+//		if (sizeInBytesArray[0] != 0)
+//			ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
+//		ret.sizeInBytes = sizeInBytesArray[0];
+//		ret.algo = algos[0];
+//		if (GPUStatistics.DISPLAY_STATISTICS)
+//			GPUStatistics.maintainCPMiscTimes(instName, GPUInstruction.MISC_TIMER_CUDNN_INIT, System.nanoTime() - t1);
 		return ret;
 	}
 	

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNNConvolutionAlgorithm.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNNConvolutionAlgorithm.java
@@ -25,7 +25,6 @@ import org.apache.sysml.runtime.instructions.gpu.context.GPUContext;
 import org.apache.sysml.utils.GPUStatistics;
 
 import jcuda.Pointer;
-import jcuda.jcudnn.cudnnConvolutionBwdDataPreference;
 import jcuda.jcudnn.cudnnConvolutionBwdFilterPreference;
 import jcuda.jcudnn.cudnnConvolutionDescriptor;
 import jcuda.jcudnn.cudnnConvolutionFwdPreference;
@@ -235,25 +234,29 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 		LibMatrixCuDNNConvolutionAlgorithm ret = new LibMatrixCuDNNConvolutionAlgorithm(gCtx, instName, N, C, H, W, K, R, S, 
 				pad_h, pad_w, stride_h, stride_w, P, Q);
 		
-		if(workspaceLimit <= 0) {
+		// CuDNN's cudnnGetConvolutionBackwardDataAlgorithm returns CUDNN_CONVOLUTION_BWD_DATA_ALGO_1 for atleast one scenario 
+		// for sentence CNN (N=1, C=1, H=2060, W=300, F=500, Hf=5, Wf=300, sparsity=0.1).
+		// This causes more than 100x slowdown when compared with CUDNN_CONVOLUTION_BWD_DATA_ALGO_0.
+		// To keep things simple for now, we will always prefer to use memory-less operator: CUDNN_CONVOLUTION_BWD_DATA_ALGO_0
+//		if(workspaceLimit <= 0) {
 			// If overhead is greater than intermediate allocated memory, prefer the cudnn operator with no memory requirement
 			// i.e. CUDNN_CONVOLUTION_BWD_DATA_ALGO_0
 			ret.algo = jcuda.jcudnn.cudnnConvolutionBwdDataAlgo.CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
-		}
-		else {
-			int[] algos = {-1};
-			long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
-			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataAlgorithm(
-					LibMatrixCuDNN.getCudnnHandle(gCtx), 
-					ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc,
-					cudnnConvolutionBwdDataPreference.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
-			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
-					ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc, algos[0], sizeInBytesArray);
-			if (sizeInBytesArray[0] != 0)
-				ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
-			ret.sizeInBytes = sizeInBytesArray[0];
-			ret.algo = algos[0];
-		}
+//		}
+//		else {
+//			int[] algos = {-1};
+//			long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
+//			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataAlgorithm(
+//					LibMatrixCuDNN.getCudnnHandle(gCtx), 
+//					ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc,
+//					cudnnConvolutionBwdDataPreference.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT, sizeInBytesArray[0], algos);
+//			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
+//					ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc, algos[0], sizeInBytesArray);
+//			if (sizeInBytesArray[0] != 0)
+//				ret.workSpace = gCtx.allocate(sizeInBytesArray[0]);
+//			ret.sizeInBytes = sizeInBytesArray[0];
+//			ret.algo = algos[0];
+//		}
 		if (GPUStatistics.DISPLAY_STATISTICS)
 			GPUStatistics.maintainCPMiscTimes(instName, GPUInstruction.MISC_TIMER_CUDNN_INIT, System.nanoTime() - t1);
 		return ret;


### PR DESCRIPTION
CuDNN's `cudnnGetConvolutionBackwardDataAlgorithm` returns `CUDNN_CONVOLUTION_BWD_DATA_ALGO_1` for atleast one scenario:
- sentence CNN (N=1, C=1, H=2060, W=300, F=500, Hf=5, Wf=300, sparsity=0.1) which is 200x slower than `CUDNN_CONVOLUTION_BWD_DATA_ALGO_0`. 

Since it is difficult to debug a closed-source method `cudnnGetConvolutionBackwardDataAlgorithm`, we will always prefer to use memory-less operator: `CUDNN_CONVOLUTION_BWD_DATA_ALGO_0`. We can revisit this for next CuDNN version. This is not an ideal solution, but the simplest one I could think of. I welcome discussion on any alternative solutions you may have.  And this goes without saying, we can revisit this for next CuDNN version.

@nakul02 @prithvirajsen @bertholdreinwald can you please review this PR ?

To reproduce the bug in CuDNN's `cudnnGetConvolutionBackwardDataAlgorithm`, please use the script https://github.com/apache/systemml/blob/master/scripts/nn/test/compare_backends/test_conv2d_bwd_data.sh and the above mentioned parameters. 

Setup:
- Nvidia K80
- CuDNN 5



1. Current master (selects `CUDNN_CONVOLUTION_BWD_DATA_ALGO_1`):
```
SystemML Statistics:
Total elapsed time:             50.828 sec.
Total compilation time:         8.908 sec.
Total execution time:           41.921 sec.
Number of compiled Spark inst:  0.
Number of executed Spark inst:  0.
CUDA/CuLibraries init time:     7.099/0.764 sec.
Number of executed GPU inst:    1.
GPU mem tx time  (alloc/dealloc/set0/toDev/fromDev):    0.007/0.007/0.000/0.155/0.013 sec.
GPU mem tx count (alloc/dealloc/set0/toDev/fromDev/evict):      11/9/11/2/8/1/0.
GPU conversion time  (sparseConv/sp2dense/dense2sp):    0.001/0.010/0.000 sec.
GPU conversion count (sparseConv/sp2dense/dense2sp):    2/2/0.
Cache hits (Mem, WB, FS, HDFS): 0/0/0/2.
Cache writes (WB, FS, HDFS):    1/0/1.
Cache times (ACQr/m, RLS, EXP): 0.145/0.003/0.001/0.091 sec.
HOP DAGs recompiled (PRED, SB): 0/0.
HOP DAGs recompile time:        0.000 sec.
Spark ctx create time (lazy):   1.016 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         2.068 sec.
Total JVM GC count:             4.
Total JVM GC time:              0.079 sec.
Heavy hitter instructions:
 #  Instruction                                                   Time(s)  Count  Misc Timers
 1  gpu_conv2d_backward_data [test_conv2d_bwd_data.dml 3:0-3:141   41.825      1 sync[41.649s,1], nnc[0.000s,1], nncbd[0.000s,1], H2D[0.001s,
    ]                                                                            2], nni[0.001s,1], ad[0.001s,1], s2d[0.010s,2], aqrs[0.145s,
                                                                                                                                           2]
 2  write [test_conv2d_bwd_data.dml 3:0-3:141]                      0.091      1
 3  createvar [test_conv2d_bwd_data.dml 1:0-1:21]                   0.002      1
 4  rmvar [-1:-1--1:-1]                                             0.000      1
 5  createvar [test_conv2d_bwd_data.dml 3:0-3:141]                  0.000      1
 6  createvar [test_conv2d_bwd_data.dml 2:0-2:22]                   0.000      1

nvprof results:
Time(%)      Time     Calls       Avg       Min       Max  Name
 99.99%  57.1715s         1  57.1715s  57.1715s  57.1715s  void cudnn::detail::dgrad_alg1_engine<int=512, int=6, int=5, int=3, int=3, int=3, bool=1, bool=0>(int, int, int, double const *, int, double const , int, double*, kernel_grad_params, int, int, double, int)
  0.01%  4.1786ms         2  2.0893ms  41.023us  4.1376ms  void cusparseZeroOutForCSR_kernel<double>(int, int, double*, int)
  0.00%  1.2009ms         1  1.2009ms  1.2009ms  1.2009ms  [CUDA memcpy DtoH]
```

2. This PR (selects `CUDNN_CONVOLUTION_BWD_DATA_ALGO_0`):
```
SystemML Statistics:
Total elapsed time:             9.027 sec.
Total compilation time:         8.734 sec.
Total execution time:           0.292 sec.
Number of compiled Spark inst:  0.
Number of executed Spark inst:  0.
CUDA/CuLibraries init time:     7.009/0.744 sec.
Number of executed GPU inst:    1.
GPU mem tx time  (alloc/dealloc/set0/toDev/fromDev):    0.007/0.007/0.000/0.176/0.011 sec.
GPU mem tx count (alloc/dealloc/set0/toDev/fromDev/evict):      11/9/11/2/8/1/0.
GPU conversion time  (sparseConv/sp2dense/dense2sp):    0.001/0.010/0.000 sec.
GPU conversion count (sparseConv/sp2dense/dense2sp):    2/2/0.
Cache hits (Mem, WB, FS, HDFS): 0/0/0/2.
Cache writes (WB, FS, HDFS):    1/0/1.
Cache times (ACQr/m, RLS, EXP): 0.166/0.001/0.001/0.084 sec.
HOP DAGs recompiled (PRED, SB): 0/0.
HOP DAGs recompile time:        0.000 sec.
Spark ctx create time (lazy):   0.941 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         2.087 sec.
Total JVM GC count:             4.
Total JVM GC time:              0.082 sec.
Heavy hitter instructions:
 #  Instruction                                                   Time(s)  Count  Misc Timers
 1  gpu_conv2d_backward_data [test_conv2d_bwd_data.dml 3:0-3:141    0.204      1 nnc[0.000s,1], nncbd[0.000s,1], nni[0.001s,1], H2D[0.001s,2]
    ]                                                                            , ad[0.001s,1], sync[0.006s,1], s2d[0.010s,2], aqrs[0.166s,2
                                                                                                                                            ]
 2  write [test_conv2d_bwd_data.dml 3:0-3:141]                      0.084      1
 3  createvar [test_conv2d_bwd_data.dml 1:0-1:21]                   0.002      1
 4  rmvar [-1:-1--1:-1]                                             0.000      1
 5  createvar [test_conv2d_bwd_data.dml 3:0-3:141]                  0.000      1
 6  createvar [test_conv2d_bwd_data.dml 2:0-2:22]                   0.000      1

nvprof results:
Time(%)      Time     Calls       Avg       Min       Max  Name
 45.45%  6.3042ms         1  6.3042ms  6.3042ms  6.3042ms  void cudnn::detail::dgrad_engine<int=128, int=6, int=7, int=3, int=3, int=5, bool=1>(int, int, int, double const *, int, double const , int, double*, kernel_grad_params, int, int, double, int)
 30.18%  4.1854ms         2  2.0927ms  41.727us  4.1437ms  void cusparseZeroOutForCSR_kernel<double>(int, int, double*, int)
  7.17%  994.67us         1  994.67us  994.67us  994.67us  [CUDA memcpy DtoH]
```
