### PR TITLE
[MINOR] Bug in foreign parent check in RewriteElementwiseMultChainOptimization

### DIFF
--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteElementwiseMultChainOptimization.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteElementwiseMultChainOptimization.java
@@ -310,7 +310,7 @@ public class RewriteElementwiseMultChainOptimization extends HopRewriteRule {
 		final ArrayList<Hop> parents = child.getParent();
 		if (parents.size() > 1)
 			for (final Hop parent : parents)
-				if (parent instanceof BinaryOp && !emults.contains(parent))
+				if (!(parent instanceof BinaryOp) || !emults.contains(parent))
 					return false;
 		// child does not have foreign parents
 


### PR DESCRIPTION
The check for foreign parents in the interior of an element-wise multiply chain is incorrect.
Interior element-wise multiply nodes that have a foreign parent which is not a BinaryOp (for example, a write DataOp) are missed.
This leads to incorrect rewrites in unlucky DAGs.