### PR TITLE
[SYSTEMML-446] Allow SystemML to run in -exec singlenode with gpu

### DIFF
--- a/src/main/java/org/apache/sysml/hops/Hop.java
+++ b/src/main/java/org/apache/sysml/hops/Hop.java
@@ -195,13 +195,23 @@ public abstract class Hop implements ParseInfo
 	public void checkAndSetForcedPlatform()
 	{
 		if(DMLScript.USE_ACCELERATOR && DMLScript.FORCE_ACCELERATOR && isGPUEnabled())
-			_etypeForced = ExecType.GPU;
-		else if ( DMLScript.rtplatform == RUNTIME_PLATFORM.SINGLE_NODE )
-			_etypeForced = ExecType.CP;
+			_etypeForced = ExecType.GPU; // enabled with -gpu force option
+		else if ( DMLScript.rtplatform == RUNTIME_PLATFORM.SINGLE_NODE ) {
+			if(OptimizerUtils.isMemoryBasedOptLevel() && DMLScript.USE_ACCELERATOR && isGPUEnabled()) {
+				// enabled with -exec singlenode -gpu option
+				_etypeForced = findExecTypeByMemEstimate();
+				if(_etypeForced != ExecType.CP && _etypeForced != ExecType.GPU)
+					_etypeForced = ExecType.CP;
+			}
+			else {
+				// enabled with -exec singlenode option
+				_etypeForced = ExecType.CP;  
+			}
+		}
 		else if ( DMLScript.rtplatform == RUNTIME_PLATFORM.HADOOP )
-			_etypeForced = ExecType.MR;
+			_etypeForced = ExecType.MR; // enabled with -exec hadoop option
 		else if ( DMLScript.rtplatform == RUNTIME_PLATFORM.SPARK )
-			_etypeForced = ExecType.SPARK;
+			_etypeForced = ExecType.SPARK; // enabled with -exec spark option
 	}
 	
 	public void checkAndSetInvalidCPDimsAndSize()


### PR DESCRIPTION
Currently, we can either force all instructions to:
- CP (via -exec singlenode) OR 
- GPU (via -gpu force)

However, a typical user may want to run in singlenode with GPU acceleration by using the option '-exec singlenode -gpu'. This PR enables such an option.

@bertholdreinwald @nakul02 @mboehm7 can you please review this PR ?