### PR TITLE
[SYSTEMML-540] Reduce the number of unknowns in ConvolutionOp

### DIFF
--- a/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
+++ b/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
@@ -511,6 +511,13 @@ public class ConvolutionOp extends Hop  implements MultiThreadedHop
 			getCHWPQFromParentOp();
 		}
 		
+		if(_cachedParams.P < 0 && _cachedParams.H >= 0 && _cachedParams.R >= 0 && _cachedParams.stride_h >= 0 && _cachedParams.pad_h >= 0) {
+			_cachedParams.P = (int) org.apache.sysml.runtime.util.ConvolutionUtils.getP(_cachedParams.H, _cachedParams.R, _cachedParams.stride_h, _cachedParams.pad_h);
+		}
+		if(_cachedParams.Q < 0 && _cachedParams.W >= 0 && _cachedParams.S >= 0 && _cachedParams.stride_w >= 0 && _cachedParams.pad_w >= 0) {
+			_cachedParams.Q = (int) org.apache.sysml.runtime.util.ConvolutionUtils.getQ(_cachedParams.W, _cachedParams.S, _cachedParams.stride_w, _cachedParams.pad_w);
+		}
+		
 		return _cachedParams;
 	}
 	
@@ -550,14 +557,6 @@ public class ConvolutionOp extends Hop  implements MultiThreadedHop
 			_cachedParams.C = (_cachedParams.C < 0) ? parentParam.K : _cachedParams.C;
 			_cachedParams.H = (_cachedParams.H < 0) ? parentParam.P : _cachedParams.H;
 			_cachedParams.W = (_cachedParams.W < 0) ? parentParam.Q : _cachedParams.W;
-		}
-		
-		// Now that we know 
-		if(_cachedParams.P < 0 && _cachedParams.H >= 0 && _cachedParams.R >= 0 && _cachedParams.stride_h >= 0 && _cachedParams.pad_h >= 0) {
-			_cachedParams.P = (int) org.apache.sysml.runtime.util.ConvolutionUtils.getP(_cachedParams.H, _cachedParams.R, _cachedParams.stride_h, _cachedParams.pad_h);
-		}
-		if(_cachedParams.Q < 0 && _cachedParams.W >= 0 && _cachedParams.S >= 0 && _cachedParams.stride_w >= 0 && _cachedParams.pad_w >= 0) {
-			_cachedParams.Q = (int) org.apache.sysml.runtime.util.ConvolutionUtils.getQ(_cachedParams.W, _cachedParams.S, _cachedParams.stride_w, _cachedParams.pad_w);
 		}
 	}
 	

--- a/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
+++ b/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
@@ -520,7 +520,7 @@ public class ConvolutionOp extends Hop  implements MultiThreadedHop
 		if(INFER_TENSOR_SHAPE_FROM_PARENT_CONV_OP) {
 			boolean isMaxPool = getOp() == ConvOp.MAX_POOLING;
 			boolean isConv = getOp() == ConvOp.DIRECT_CONV2D;
-			boolean unknownCHWPQ = _cachedParams.C < 0 && _cachedParams.H < 0 && _cachedParams.W < 0 && _cachedParams.P < 0 && _cachedParams.Q < 0;
+			boolean unknownCHWPQ = _cachedParams.C < 0 || _cachedParams.H < 0 || _cachedParams.W < 0 || _cachedParams.P < 0 || _cachedParams.Q < 0;
 			if((isMaxPool || isConv) && unknownCHWPQ) {
 				// Only infer input shape for convolution and maxpool
 				inferCHWPQFromParentOp();

--- a/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
+++ b/src/main/java/org/apache/sysml/hops/ConvolutionOp.java
@@ -810,7 +810,7 @@ public class ConvolutionOp extends Hop  implements MultiThreadedHop
 		if(LOG.isDebugEnabled() && ret < 0) {
 			LOG.debug("Unknown dimension " + dimString + " for ConvolutionOp:" + op.name() + 
 					" img_dim=[" + _cachedParams.N + " " + _cachedParams.C + " " + _cachedParams.H + " " + _cachedParams.W + "]" +
-					" filter_dim=[" + _cachedParams.K + " " + _cachedParams.C + " " + _cachedParams.H + " " + _cachedParams.W + "]" + 
+					" filter_dim=[" + _cachedParams.K + " " + _cachedParams.C + " " + _cachedParams.R + " " + _cachedParams.S + "]" + 
 					" output_feature_map=[" + _cachedParams.P + " " + _cachedParams.Q + "] stride=[" + _cachedParams.stride_h + " " + _cachedParams.stride_w + "]" +
 					" pad=[" + _cachedParams.pad_h + " " + _cachedParams.pad_w + "]");
 		}


### PR DESCRIPTION
- This PR reduces the unknowns during dynamic recompilation by inferring the input's height/width of ConvolutionOp based on its parent's output's height/width.
- Additionally, for developer debugging, I have guarded the functionality with the flag `INFER_TENSOR_SHAPE_FROM_PARENT_CONV_OP` and have added sufficient documentation to explain how these dimensions are inferred :)

@bertholdreinwald @mboehm7 @dusenberrymw can you please review this PR ?