### PR TITLE
[SYSTEMML-540] Avoid redundant computation of cudnnPoolingForward in max_pool_backward

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
@@ -356,7 +356,7 @@ public class ConvolutionGPUInstruction extends GPUInstruction {
 		else if (instOpcode.equalsIgnoreCase("maxpooling_backward")) {
 			MatrixObject image = getMatrixInputForGPUInstruction(ec, _input1.getName());
 			MatrixObject dout = getMatrixInputForGPUInstruction(ec, _input2.getName());
-			MatrixObject maxPoolOutput = _input2 != null ? getMatrixInputForGPUInstruction(ec, _input2.getName()) : null;
+			MatrixObject maxPoolOutput = _input3 != null ? getMatrixInputForGPUInstruction(ec, _input3.getName()) : null;
 			if(dout.getNumRows() != N || dout.getNumColumns() != C*P*Q) 
 				throw new DMLRuntimeException("Incorrect dimensions for dout in maxpooling_backward");
 			if(image.getNumRows() != N || image.getNumColumns() != C*H*W) 
@@ -378,7 +378,8 @@ public class ConvolutionGPUInstruction extends GPUInstruction {
 		if ( !instOpcode.equalsIgnoreCase("maxpooling") )
 			ec.releaseMatrixInputForGPUInstruction(_input2.getName());
 
-		if (instOpcode.equalsIgnoreCase("conv2d_bias_add"))
+		if (instOpcode.equalsIgnoreCase("conv2d_bias_add") || 
+			(instOpcode.equalsIgnoreCase("maxpooling_backward") && _input3 != null))
 			ec.releaseMatrixInputForGPUInstruction(_input3.getName());
 
 		ec.releaseMatrixOutputForGPUInstruction(_output.getName());

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
@@ -120,7 +120,7 @@ public class ConvolutionGPUInstruction extends GPUInstruction {
 		}
 		else if( opcode.equalsIgnoreCase("maxpooling_backward") ) {
 			boolean withMaxPoolOut = false;
-			if(parts.length == 16) {
+			if(parts.length == 18) {
 				withMaxPoolOut = true;
 			}
 			else

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
@@ -129,6 +129,7 @@ public class ConvolutionGPUInstruction extends GPUInstruction {
 			CPOperand in2 = new CPOperand(parts[2]);
 			CPOperand in3 = withMaxPoolOut ? new CPOperand(parts[15]) : null;
 			CPOperand out = withMaxPoolOut ? new CPOperand(parts[16]) : new CPOperand(parts[15]);
+			double memBudget = withMaxPoolOut ? Double.parseDouble(parts[17]) : Double.parseDouble(parts[16]);
 		
 			ArrayList<CPOperand> stride = new ArrayList<>();
 			ArrayList<CPOperand> padding = new ArrayList<>();
@@ -148,7 +149,7 @@ public class ConvolutionGPUInstruction extends GPUInstruction {
 			filter_shape.add(new CPOperand(parts[14]));
 
 			return new ConvolutionGPUInstruction(in1, in2, in3, out, opcode, str, stride,
-					padding, input_shape, filter_shape, Double.parseDouble(parts[16]));
+					padding, input_shape, filter_shape, memBudget);
 		}
 		else if (opcode.equalsIgnoreCase("conv2d_bias_add")) {
 			InstructionUtils.checkNumFields(parts, 17);

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/ConvolutionGPUInstruction.java
@@ -92,8 +92,7 @@ public class ConvolutionGPUInstruction extends GPUInstruction {
 		
 		if( ( opcode.equalsIgnoreCase("conv2d")
 			 || opcode.equalsIgnoreCase("conv2d_backward_filter")
-			 || opcode.equalsIgnoreCase("conv2d_backward_data")
-			 || opcode.equalsIgnoreCase("maxpooling_backward")) ) {
+			 || opcode.equalsIgnoreCase("conv2d_backward_data")) ) {
 			InstructionUtils.checkNumFields(parts, 16);
 			CPOperand in1 = new CPOperand(parts[1]);
 			CPOperand in2 = new CPOperand(parts[2]);
@@ -117,6 +116,38 @@ public class ConvolutionGPUInstruction extends GPUInstruction {
 			filter_shape.add(new CPOperand(parts[14]));
 
 			return new ConvolutionGPUInstruction(in1, in2, out, opcode, str, stride,
+					padding, input_shape, filter_shape, Double.parseDouble(parts[16]));
+		}
+		else if( opcode.equalsIgnoreCase("maxpooling_backward") ) {
+			boolean withMaxPoolOut = false;
+			if(parts.length == 16) {
+				withMaxPoolOut = true;
+			}
+			else
+				InstructionUtils.checkNumFields(parts, 16);
+			CPOperand in1 = new CPOperand(parts[1]);
+			CPOperand in2 = new CPOperand(parts[2]);
+			CPOperand in3 = withMaxPoolOut ? new CPOperand(parts[15]) : null;
+			CPOperand out = withMaxPoolOut ? new CPOperand(parts[16]) : new CPOperand(parts[15]);
+		
+			ArrayList<CPOperand> stride = new ArrayList<>();
+			ArrayList<CPOperand> padding = new ArrayList<>();
+			ArrayList<CPOperand> input_shape = new ArrayList<>();
+			ArrayList<CPOperand> filter_shape = new ArrayList<>();
+			stride.add(new CPOperand(parts[3]));
+			stride.add(new CPOperand(parts[4]));
+			padding.add(new CPOperand(parts[5]));
+			padding.add(new CPOperand(parts[6]));
+			input_shape.add(new CPOperand(parts[7]));
+			input_shape.add(new CPOperand(parts[8]));
+			input_shape.add(new CPOperand(parts[9]));
+			input_shape.add(new CPOperand(parts[10]));
+			filter_shape.add(new CPOperand(parts[11]));
+			filter_shape.add(new CPOperand(parts[12]));
+			filter_shape.add(new CPOperand(parts[13]));
+			filter_shape.add(new CPOperand(parts[14]));
+
+			return new ConvolutionGPUInstruction(in1, in2, in3, out, opcode, str, stride,
 					padding, input_shape, filter_shape, Double.parseDouble(parts[16]));
 		}
 		else if (opcode.equalsIgnoreCase("conv2d_bias_add")) {
@@ -324,7 +355,7 @@ public class ConvolutionGPUInstruction extends GPUInstruction {
 		else if (instOpcode.equalsIgnoreCase("maxpooling_backward")) {
 			MatrixObject image = getMatrixInputForGPUInstruction(ec, _input1.getName());
 			MatrixObject dout = getMatrixInputForGPUInstruction(ec, _input2.getName());
-			
+			MatrixObject maxPoolOutput = _input2 != null ? getMatrixInputForGPUInstruction(ec, _input2.getName()) : null;
 			if(dout.getNumRows() != N || dout.getNumColumns() != C*P*Q) 
 				throw new DMLRuntimeException("Incorrect dimensions for dout in maxpooling_backward");
 			if(image.getNumRows() != N || image.getNumColumns() != C*H*W) 
@@ -333,7 +364,7 @@ public class ConvolutionGPUInstruction extends GPUInstruction {
 			
 			MatrixObject out = getDenseMatrixOutputForGPUInstruction(ec, _output.getName(), N, C * H * W);
 			
-			LibMatrixCuDNN.maxpoolingBackward(ec.getGPUContext(0), getExtendedOpcode(), image, dout, out, N, C, H, W,
+			LibMatrixCuDNN.maxpoolingBackward(ec.getGPUContext(0), getExtendedOpcode(), image, dout, maxPoolOutput, out, N, C, H, W,
 					K, R, S, pad_h, pad_w, stride_h, stride_w, P, Q, _intermediateMemoryBudget);
 		}
 		else {


### PR DESCRIPTION
If the `max_pool` is invoked in the forward pass, then its output can be reused by the `max_pool_backward` rather than calling `cudnnPoolingForward` again. For sentence CNN with 2 epochs, this reduces the time for `max_pool_backward` from  6.361 to  2.966 seconds. Here are the stats:

```
With this PR (temporarily addressed issue 1 described below by rewriting DML for getting the statistics):
 5  gpu_maxpooling_backward [100:2-101:70] 2.966    936 sync[2.906s,936], nnc[0.000s,936], ad[0.017s,936], nnmb[0.027s,936]

Current Master:
  5  gpu_maxpooling_backward [100:2-101:70] 6.361    936 nnc[0.001s,936], nni[0.006s,936], nnmf[0.015s,936], nnmb[0.015s,936], ad[0.018s,936], sync[6.287s,936]
```

However, this optimization is disabled anytime there is a persistent read/write. So there are two (potentially overlapping) options here:
1. Fix following two persistent read/write issues:
a. `if loop` in  `nn/layers/dropout.dml`. 
b. A separate `cnn-forward()` method in the script.

2. Add optional argument `max_pool_forward` that accepts output of `max_pool`. This will work even if there are any lingering persistent read/write issues. However, it requires extending the `nn/layers/max_pool2d_builtin.dml` to accept the output of the forward function.


@bertholdreinwald @mboehm7 @prithvirajsen  @nakul02  @dusenberrymw 