### PR TITLE
[SYSTEMML-1980] HopDagValidator: Accept Integer Matrices

### DIFF
--- a/src/main/java/org/apache/sysml/hops/rewrite/HopDagValidator.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/HopDagValidator.java
@@ -126,7 +126,7 @@ public class HopDagValidator {
 
 		// check Matrix data type Hops must have Double Value type
 		if (dt == Expression.DataType.MATRIX )
-			check(vt == Expression.ValueType.DOUBLE, hop,
+			check(vt == Expression.ValueType.DOUBLE || vt == Expression.ValueType.INT, hop,
 				"has Matrix type but Value Type %s is not DOUBLE", vt);
 
 		//recursively process children


### PR DESCRIPTION
Under rare conditions a matrix can have INT ValueType and execute correctly.  For example the program

```
X= Rand( rows=2, cols=2, min=1, max=2)
R = cbind(as.matrix(nrow(X)) * 2, as.matrix(ncol(X)))
```

would throw an exception by the HopValidator because the Hops produced look like
(here, "MI" means matrix data type and integer value type):

```
----GENERIC (lines 28-0) [recompile=false]
------(33) u(cast_as_matrix) ([2]) [1,1,1000,1000,-1]MI [0,0,0 -> -MB]
------(35) b(*) (33,[2]) [1,1,1000,1000,-1]MI [0,0,0 -> -MB], CP
------(37) u(cast_as_matrix) ([2]) [1,1,1000,1000,-1]MI [0,0,0 -> -MB]
------(38) b(cbind) (35,37) [1,2,1000,1000,-1]MI [0,0,0 -> -MB], CP
------(44) PWrite R (38,[target/tes...],[false],[TEXT],[false],[,]) [1,2,-1,-1,-1]MI [0,0,0 -> -MB], CP
```

This patch relaxes the HopValidator to allow Integer matrices.