### PR TITLE
[SYSTEMML-1969] Perform float-to-double conversion during eviction on host

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUContext.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUContext.java
@@ -566,7 +566,7 @@ public class GPUContext {
 								+ "). Allocated GPU objects:" + allocatedGPUObjects.toString());
 			}
 			if (toBeRemoved.dirty) {
-				toBeRemoved.copyFromDeviceToHost(instructionName);
+				toBeRemoved.copyFromDeviceToHost(instructionName, true);
 			}
 			toBeRemoved.clearData(true);
 		}

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
@@ -592,7 +592,7 @@ public class GPUObject {
 					LOG.trace("GPU : data is dirty on device, copying to host, on " + this + ", GPUContext="
 						+ getGPUContext());
 				}
-				copyFromDeviceToHost(instName);
+				copyFromDeviceToHost(instName, false);
 				copied = true;
 			}
 		} catch (DMLRuntimeException e) {
@@ -872,7 +872,7 @@ public class GPUObject {
 		return (int) l;
 	}
 
-	protected void copyFromDeviceToHost(String instName) throws DMLRuntimeException {
+	protected void copyFromDeviceToHost(String instName, boolean isEviction) throws DMLRuntimeException {
 		if(LOG.isTraceEnabled()) {
 			LOG.trace("GPU : copyFromDeviceToHost, on " + this + ", GPUContext=" + getGPUContext());
 		}
@@ -886,7 +886,7 @@ public class GPUObject {
 				start = System.nanoTime();
 			MatrixBlock tmp = new MatrixBlock(toIntExact(mat.getNumRows()), toIntExact(mat.getNumColumns()), false);
 			tmp.allocateDenseBlock();
-			LibMatrixCUDA.cudaSupportFunctions.deviceToHost(getGPUContext(), getJcudaDenseMatrixPtr(), tmp.getDenseBlock(), instName);
+			LibMatrixCUDA.cudaSupportFunctions.deviceToHost(getGPUContext(), getJcudaDenseMatrixPtr(), tmp.getDenseBlock(), instName, isEviction);
 			tmp.recomputeNonZeros();
 			mat.acquireModify(tmp);
 			mat.release();
@@ -913,7 +913,7 @@ public class GPUObject {
 				int cols = toIntExact(mat.getNumColumns());
 				int nnz = toIntExact(getJcudaSparseMatrixPtr().nnz);
 				double[] values = new double[nnz];
-				LibMatrixCUDA.cudaSupportFunctions.deviceToHost(getGPUContext(), getJcudaSparseMatrixPtr().val, values, instName);
+				LibMatrixCUDA.cudaSupportFunctions.deviceToHost(getGPUContext(), getJcudaSparseMatrixPtr().val, values, instName, isEviction);
 				int[] rowPtr = new int[rows + 1];
 				int[] colInd = new int[nnz];
 				long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/CudaSupportFunctions.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/CudaSupportFunctions.java
@@ -81,7 +81,7 @@ public interface CudaSupportFunctions {
 	public int cusparsecsr2dense(cusparseHandle handle, int m, int n, cusparseMatDescr descrA, jcuda.Pointer csrValA, jcuda.Pointer csrRowPtrA, jcuda.Pointer csrColIndA, jcuda.Pointer A, int lda) ;
 	public int cusparsedense2csr(cusparseHandle handle, int m, int n, cusparseMatDescr descrA, jcuda.Pointer A, int lda, jcuda.Pointer nnzPerRow, jcuda.Pointer csrValA, jcuda.Pointer csrRowPtrA, jcuda.Pointer csrColIndA);
 	public int cusparsennz(cusparseHandle handle, int dirA, int m, int n, cusparseMatDescr descrA, jcuda.Pointer A, int lda, jcuda.Pointer nnzPerRowCol, jcuda.Pointer nnzTotalDevHostPtr);
-	public void deviceToHost(GPUContext gCtx, Pointer src, double [] dest, String instName) throws DMLRuntimeException;
+	public void deviceToHost(GPUContext gCtx, Pointer src, double [] dest, String instName, boolean isEviction) throws DMLRuntimeException;
 	public void hostToDevice(GPUContext gCtx, double [] src,  Pointer dest, String instName) throws DMLRuntimeException;
 	
 }

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/DoublePrecisionCudaSupportFunctions.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/DoublePrecisionCudaSupportFunctions.java
@@ -158,7 +158,7 @@ public class DoublePrecisionCudaSupportFunctions implements CudaSupportFunctions
 	}
 
 	@Override
-	public void deviceToHost(GPUContext gCtx, Pointer src, double[] dest, String instName) throws DMLRuntimeException {
+	public void deviceToHost(GPUContext gCtx, Pointer src, double[] dest, String instName, boolean isEviction) throws DMLRuntimeException {
 		long t1 = GPUStatistics.DISPLAY_STATISTICS  && instName != null? System.nanoTime() : 0;
 		cudaMemcpy(Pointer.to(dest), src, ((long)dest.length)*Sizeof.DOUBLE, cudaMemcpyDeviceToHost);
 		if(GPUStatistics.DISPLAY_STATISTICS && instName != null) 

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCUDA.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCUDA.java
@@ -946,7 +946,7 @@ public class LibMatrixCUDA {
 			s = (s + (threads*2-1)) / (threads*2);
 		}
 		double[] result = {-1f};
-		cudaSupportFunctions.deviceToHost(gCtx, tempOut, result, instName);
+		cudaSupportFunctions.deviceToHost(gCtx, tempOut, result, instName, false);
 		gCtx.cudaFreeHelper(instName, tempOut);
 		return result[0];
 	}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SinglePrecisionCudaSupportFunctions.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SinglePrecisionCudaSupportFunctions.java
@@ -162,10 +162,11 @@ public class SinglePrecisionCudaSupportFunctions implements CudaSupportFunctions
 	}
 	
 	@Override
-	public void deviceToHost(GPUContext gCtx, Pointer src, double[] dest, String instName) throws DMLRuntimeException {
+	public void deviceToHost(GPUContext gCtx, Pointer src, double[] dest, String instName, boolean isEviction) throws DMLRuntimeException {
 		long t1 = GPUStatistics.DISPLAY_STATISTICS  && instName != null? System.nanoTime() : 0;
 		LOG.debug("Potential OOM: Allocated additional space in deviceToHost");
-		if(PERFORM_CONVERSION_ON_DEVICE) {
+		// Only perform conversion on host if eviction to avoid recursive calls.
+		if(PERFORM_CONVERSION_ON_DEVICE && !isEviction) {
 			Pointer deviceDoubleData = gCtx.allocate(((long)dest.length)*Sizeof.DOUBLE);
 			LibMatrixCUDA.float2double(gCtx, src, deviceDoubleData, dest.length);
 			cudaMemcpy(Pointer.to(dest), deviceDoubleData, ((long)dest.length)*Sizeof.DOUBLE, cudaMemcpyDeviceToHost);


### PR DESCRIPTION
We invoke transfer matrix from device to host in two cases:
1. During eviction of unlocked matrices
2. During acquireHostRead

If the single-precision support is enabled, then float-to-double conversion is required as CP expects the data to be in double format. This conversion can be done on host or on device. We typically prefer to do this conversion on device due to GPU's high-memory bandwidth. However, the conversion requires an additional space to be allocated for the conversion, which can lead to infinite recursion during eviction: `evict -> devictToHost -> float2double -> allocate -> ensureFreeSpace -> evict`. To avoid this recursion, it is necessary to perform this conversion in host.

@nakul02 can you please review this PR ?