### PR TITLE
[SYSTEMML-540] [WIP] Support softmax function on GPU via CuDNN

### DIFF
--- a/scripts/nn/test/compare_backends/gen_softmax.dml
+++ b/scripts/nn/test/compare_backends/gen_softmax.dml
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 #-------------------------------------------------------------
 #
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -8,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,10 +19,5 @@
 #
 #-------------------------------------------------------------
 
-# Additional tests to compare the accuracy of different convolution related operators with CuDNN
-./test_conv2d_bwd_filter.sh
-./test_conv2d_bwd_data.sh
-./test_conv2d.sh
-./test_maxpool.sh
-./test_maxpool_bwd.sh
-./test_softmax.sh
+X = rand(rows=$rows, cols=$cols, sparsity=$sp, min=-0.5, max=1)
+write(X, "input.mtx", format="binary")

--- a/scripts/nn/test/compare_backends/test_softmax.dml
+++ b/scripts/nn/test/compare_backends/test_softmax.dml
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 #-------------------------------------------------------------
 #
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -8,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,11 +18,8 @@
 # under the License.
 #
 #-------------------------------------------------------------
-
-# Additional tests to compare the accuracy of different convolution related operators with CuDNN
-./test_conv2d_bwd_filter.sh
-./test_conv2d_bwd_data.sh
-./test_conv2d.sh
-./test_maxpool.sh
-./test_maxpool_bwd.sh
-./test_softmax.sh
+source("nn/layers/softmax.dml") as softmax
+fmt = ifdef($fmt, 'csv')
+X = read("input.mtx")
+out = softmax::forward(X)
+write(out, $out, format=fmt)

--- a/scripts/nn/test/compare_backends/test_softmax.sh
+++ b/scripts/nn/test/compare_backends/test_softmax.sh
@@ -20,10 +20,24 @@
 #
 #-------------------------------------------------------------
 
-# Additional tests to compare the accuracy of different convolution related operators with CuDNN
-./test_conv2d_bwd_filter.sh
-./test_conv2d_bwd_data.sh
-./test_conv2d.sh
-./test_maxpool.sh
-./test_maxpool_bwd.sh
-./test_softmax.sh
+jars='systemml-*-extra.jar'
+
+for rows in 1 300
+do
+	for cols in 1 300
+	do
+		for sparsity in 0.1 0.2 0.6 0.9
+		do
+			# Generating the data
+			$SPARK_HOME/bin/spark-submit SystemML.jar -f gen_softmax.dml -nvargs sp=$sparsity rows=$rows cols=$cols
+			# Running a test in CPU mode
+			$SPARK_HOME/bin/spark-submit SystemML.jar -f test_softmax.dml -nvargs out=out_cp.csv
+			# Running a test in GPU mode
+			$SPARK_HOME/bin/spark-submit --jars $jars SystemML.jar -f test_softmax.dml -stats -gpu force -nvargs out=out_gpu.csv
+			# Comparing the CPU vs GPU results to make sure they are the same
+			$SPARK_HOME/bin/spark-submit SystemML.jar -f compare.dml -args out_cp.csv out_gpu.csv "softmax:rows="$rows",cols="$cols",sparsity="$sparsity
+			rm -rf out_cp.csv out_gpu.csv out_cp.csv.mtd out_gpu.csv.mtd
+			rm -rf input.mtx input.mtx.mtd
+		done
+	done
+done

--- a/src/main/java/org/apache/sysml/lops/UnaryCP.java
+++ b/src/main/java/org/apache/sysml/lops/UnaryCP.java
@@ -36,7 +36,7 @@ public class UnaryCP extends Lop
 	public enum OperationTypes {
 		NOT, ABS, SIN, COS, TAN, ASIN, ACOS, ATAN, SQRT, LOG, EXP, SINH, COSH, TANH,
 		CAST_AS_SCALAR, CAST_AS_MATRIX, CAST_AS_FRAME, CAST_AS_DOUBLE, CAST_AS_INT, CAST_AS_BOOLEAN, 
-		PRINT, NROW, NCOL, LENGTH, ROUND, STOP, CEIL, FLOOR, CUMSUM
+		PRINT, NROW, NCOL, LENGTH, ROUND, STOP, CEIL, FLOOR, CUMSUM, SOFTMAX
 	}
 	
 	public static final String CAST_AS_SCALAR_OPCODE = "castdts";
@@ -57,8 +57,9 @@ public class UnaryCP extends Lop
 	 * @param op operation type
 	 * @param dt data type
 	 * @param vt value type
+	 * @param et exec type
 	 */
-	public UnaryCP(Lop input, OperationTypes op, DataType dt, ValueType vt) {
+	public UnaryCP(Lop input, OperationTypes op, DataType dt, ValueType vt, ExecType et) {
 		super(Lop.Type.UnaryCP, dt, vt);
 		operation = op;
 		this.addInput(input);
@@ -70,7 +71,11 @@ public class UnaryCP extends Lop
 		boolean aligner = false;
 		boolean definesMRJob = false;
 		lps.addCompatibility(JobType.INVALID);
-		this.lps.setProperties(inputs, ExecType.CP, ExecLocation.ControlProgram, breaksAlignment, aligner, definesMRJob);
+		this.lps.setProperties(inputs, et, ExecLocation.ControlProgram, breaksAlignment, aligner, definesMRJob);
+	}
+	
+	public UnaryCP(Lop input, OperationTypes op, DataType dt, ValueType vt) {
+		this(input, op, dt, vt, ExecType.CP);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysml/lops/UnaryCP.java
+++ b/src/main/java/org/apache/sysml/lops/UnaryCP.java
@@ -176,6 +176,9 @@ public class UnaryCP extends Lop
 		case LENGTH:
 			return "length";
 
+		case SOFTMAX:
+			return "softmax";
+			
 		default:
 			throw new LopsException(this.printErrorLocation() + "Unknown operation: " + operation);
 		}

--- a/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
@@ -100,6 +100,7 @@ public class GPUInstructionParser  extends InstructionParser
 		String2GPUInstructionType.put( "atan",  GPUINSTRUCTION_TYPE.BuiltinUnary);
 		String2GPUInstructionType.put( "sign",  GPUINSTRUCTION_TYPE.BuiltinUnary);
 		String2GPUInstructionType.put( "sigmoid", GPUINSTRUCTION_TYPE.BuiltinUnary);
+		String2GPUInstructionType.put( "softmax", GPUINSTRUCTION_TYPE.BuiltinUnary);
 
 		// Binary Builtin functions
 		String2GPUInstructionType.put( "solve", GPUINSTRUCTION_TYPE.BuiltinBinary);

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinUnaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/BuiltinUnaryGPUInstruction.java
@@ -78,13 +78,14 @@ public abstract class BuiltinUnaryGPUInstruction extends GPUInstruction {
 			opcode = parts[0];
 			in.split(parts[1]);
 			out.split(parts[2]);
-			func = Builtin.getBuiltinFnObject(opcode);
+			// func = Builtin.getBuiltinFnObject(opcode);
+			// new UnaryOperator(func)
 			
 			if(in.getDataType() == DataType.SCALAR)
 				throw new DMLRuntimeException("The instruction is not supported on GPU:" + str);
 //				return new ScalarBuiltinCPInstruction(new SimpleOperator(func), in, out, opcode, str);
 			else if(in.getDataType() == DataType.MATRIX)
-				return new MatrixBuiltinGPUInstruction(new UnaryOperator(func), in, out, opcode, str);
+				return new MatrixBuiltinGPUInstruction(null, in, out, opcode, str);
 		}
 		
 		return null;

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixBuiltinGPUInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/MatrixBuiltinGPUInstruction.java
@@ -82,6 +82,8 @@ public class MatrixBuiltinGPUInstruction extends BuiltinUnaryGPUInstruction {
 				LibMatrixCUDA.sign(ec, ec.getGPUContext(0), getExtendedOpcode(), mat, _output.getName()); break;
 			case "sigmoid":
 				LibMatrixCUDA.sigmoid(ec, ec.getGPUContext(0), getExtendedOpcode(), mat, _output.getName()); break;
+			case "softmax":
+				LibMatrixCuDNN.softmax(ec, ec.getGPUContext(0), getExtendedOpcode(), mat, _output.getName()); break;
 			default:
 				throw new DMLRuntimeException("Unsupported GPU operator:" + opcode);
 		}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNN.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNN.java
@@ -35,6 +35,7 @@ import static jcuda.jcudnn.cudnnTensorFormat.CUDNN_TENSOR_NCHW;
 import static jcuda.runtime.JCuda.cudaMemset;
 import jcuda.CudaException;
 import jcuda.Pointer;
+import jcuda.jcudnn.JCudnn;
 import jcuda.jcudnn.cudnnActivationDescriptor;
 import jcuda.jcudnn.cudnnConvolutionFwdPreference;
 import jcuda.jcudnn.cudnnHandle;
@@ -53,6 +54,9 @@ import org.apache.sysml.runtime.instructions.gpu.context.ExecutionConfig;
 import org.apache.sysml.runtime.instructions.gpu.context.GPUContext;
 import org.apache.sysml.utils.GPUStatistics;
 import org.apache.sysml.utils.Statistics;
+
+import static jcuda.jcudnn.cudnnSoftmaxAlgorithm.CUDNN_SOFTMAX_ACCURATE;
+import static jcuda.jcudnn.cudnnSoftmaxMode.CUDNN_SOFTMAX_MODE_CHANNEL;
 
 /**
  * This class contains method that invoke CuDNN operations.
@@ -163,6 +167,46 @@ public class LibMatrixCuDNN extends LibMatrixCUDA {
 		else {
 			throwCuDNNDimensionError(N, CHW, K, CRS, N, KPQ);
 		}
+	}
+	
+	/**
+	 * Performs an "softmax" operation on a matrix on the GPU
+	 * @param ec	execution context
+	 * @param gCtx a valid {@link GPUContext}
+	 * @param instName the invoking instruction's name for record {@link Statistics}.
+	 * @param in1	input matrix
+	 * @param outputName	output matrix name
+	 * @throws DMLRuntimeException	if DMLRuntimeException occurs
+	 */
+	public static void softmax(ExecutionContext ec, GPUContext gCtx, String instName, MatrixObject in1, String outputName) throws DMLRuntimeException {
+		if(LOG.isTraceEnabled()) {
+			LOG.trace("GPU : softmax" + ", GPUContext=" + gCtx);
+		}
+		cudnnTensorDescriptor tensorDesc = allocateTensorDescriptor(toInt(in1.getNumRows()), toInt(in1.getNumColumns()), 1, 1);
+		Pointer srcPointer = getDensePointerForCuDNN(gCtx, in1, instName);
+		MatrixObject out = ec.getMatrixObject(outputName);
+		ec.allocateGPUMatrixObject(outputName, in1.getNumRows(), in1.getNumColumns());
+		Pointer dstPointer = getDensePointerForCuDNN(gCtx, out, instName);
+		JCudnn.cudnnSoftmaxForward(gCtx.getCudnnHandle(), CUDNN_SOFTMAX_ACCURATE, CUDNN_SOFTMAX_MODE_CHANNEL, 
+                one(), tensorDesc, srcPointer,
+                zero(), tensorDesc, dstPointer);
+		cudnnDestroyTensorDescriptor(tensorDesc);
+	}
+	
+	/**
+	 * Convenience method to get tensor descriptor
+	 * @param N number of images
+	 * @param C number of channels
+	 * @param H height
+	 * @param W width
+	 * @return cudnn tensor descriptor
+	 * @throws DMLRuntimeException if the input descriptor and matrix dimensions don't match
+	 */
+	private static cudnnTensorDescriptor allocateTensorDescriptor(int N, int C, int H, int W) throws DMLRuntimeException {
+		cudnnTensorDescriptor tensorDescriptor = new cudnnTensorDescriptor();
+		cudnnCreateTensorDescriptor(tensorDescriptor);
+		cudnnSetTensor4dDescriptor(tensorDescriptor, CUDNN_TENSOR_NCHW, LibMatrixCUDA.CUDNN_DATA_TYPE, N, C, H, W);
+		return tensorDescriptor;
 	}
 
 

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNN.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixCuDNN.java
@@ -186,6 +186,7 @@ public class LibMatrixCuDNN extends LibMatrixCUDA {
 		Pointer srcPointer = getDensePointerForCuDNN(gCtx, in1, instName);
 		MatrixObject out = ec.getMatrixObject(outputName);
 		ec.allocateGPUMatrixObject(outputName, in1.getNumRows(), in1.getNumColumns());
+		out.getGPUObject(gCtx).allocateAndFillDense(0);
 		Pointer dstPointer = getDensePointerForCuDNN(gCtx, out, instName);
 		JCudnn.cudnnSoftmaxForward(gCtx.getCudnnHandle(), CUDNN_SOFTMAX_ACCURATE, CUDNN_SOFTMAX_MODE_CHANNEL, 
                 one(), tensorDesc, srcPointer,


### PR DESCRIPTION
- This API only supports dense softmax function using CuDNN's cudnnSoftmaxForward kernel.
- Since we donot see much improvement in CuDNN v5, I recommend keeping this PR open until jcuda releases newer CuDNN. We can revisit this PR then.

Script:
```
X = rand(rows=64,cols=256*256)
source("nn/layers/softmax.dml") as softmax
for(i in 1:10000) {
        if(1==1){}
        out = softmax::forward(X)
}
print(toString(out))
```

Current master:
```
SystemML Statistics:
Total elapsed time:             35.922 sec.
Total compilation time:         0.807 sec.
Total execution time:           35.115 sec.
Number of compiled Spark inst:  0.
Number of executed Spark inst:  0.
CUDA/CuLibraries init time:     7.067/0.747 sec.
Number of executed GPU inst:    50000.
GPU mem tx time  (alloc/dealloc/set0/toDev/fromDev):    0.004/0.001/0.566/0.006/0.041 sec.
GPU mem tx count (alloc/dealloc/set0/toDev/fromDev/evict):      5/4/50001/0/1/1/0.
GPU conversion time  (sparseConv/sp2dense/dense2sp):    0.000/0.000/0.000 sec.
GPU conversion count (sparseConv/sp2dense/dense2sp):    0/0/0.
Cache hits (Mem, WB, FS, HDFS): 2/0/0/0.
Cache writes (WB, FS, HDFS):    2/0/0.
Cache times (ACQr/m, RLS, EXP): 0.042/0.001/0.001/0.000 sec.
HOP DAGs recompiled (PRED, SB): 0/0.
HOP DAGs recompile time:        0.009 sec.
Spark ctx create time (lazy):   0.000 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         2.28 sec.
Total JVM GC count:             3.
Total JVM GC time:              0.058 sec.
Heavy hitter instructions:
  #  Instruction  Time(s)  Count
  1  gpu_/          7.324  10000
  2  gpu_-          6.985  10000
  3  gpu_exp        6.665  10000
  4  gpu_uarmax     3.221  10000
  5  gpu_uark+      3.200  10000
  6  rand           0.286      1
  7  rmvar          0.095  40002
  8  toString       0.077      1
  9  createvar      0.069  50001
 10  cpvar          0.017  10001
```

This PR:
```
SystemML Statistics:
Total elapsed time:             34.044 sec.
Total compilation time:         0.768 sec.
Total execution time:           33.276 sec.
Number of compiled Spark inst:  0.
Number of executed Spark inst:  0.
CUDA/CuLibraries init time:     7.040/0.746 sec.
Number of executed GPU inst:    30000.
GPU mem tx time  (alloc/dealloc/set0/toDev/fromDev):    0.004/0.001/0.604/0.008/0.036 sec.
GPU mem tx count (alloc/dealloc/set0/toDev/fromDev/evict):      5/4/30001/0/1/1/0.
GPU conversion time  (sparseConv/sp2dense/dense2sp):    0.000/0.000/0.000 sec.
GPU conversion count (sparseConv/sp2dense/dense2sp):    0/0/0.
Cache hits (Mem, WB, FS, HDFS): 2/0/0/0.
Cache writes (WB, FS, HDFS):    2/0/0.
Cache times (ACQr/m, RLS, EXP): 0.036/0.001/0.002/0.000 sec.
HOP DAGs recompiled (PRED, SB): 0/0.
HOP DAGs recompile time:        0.014 sec.
Spark ctx create time (lazy):   0.000 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         2.211 sec.
Total JVM GC count:             2.
Total JVM GC time:              0.04 sec.
Heavy hitter instructions:
  #  Instruction  Time(s)  Count
  1  gpu_softmax   13.999  10000
  2  gpu_-          7.432  10000
  3  gpu_uarmax     4.090  10000
  4  rand           0.289      1
  5  rmvar          0.101  30002
  6  toString       0.078      1
  7  createvar      0.072  30001
  8  cpvar          0.029  10001
  9  print          0.003      1
 10  *              0.001      1
```