### PR TITLE
[MINOR][PERF] String new line error

### DIFF
--- a/scripts/perftest/python/utils_exec.py
+++ b/scripts/perftest/python/utils_exec.py
@@ -101,7 +101,7 @@ def parse_hdfs_base(std_outs):
     hdfs_uri = None
     for line in std_outs:
         if line.startswith('hdfs://'):
-            hdfs_uri = line
+            hdfs_uri = line.strip()
     if hdfs_uri is None:
         sys.exit('HDFS URI not found')
     return hdfs_uri
@@ -160,7 +160,7 @@ def parse_hdfs_paths(std_outs):
         if 'No such file or directory' in i:
             break
         elif 'hdfs' in i:
-            current_dir = i.split(' ')[-1]
+            current_dir = i.split(' ')[-1].strip()
             hdfs_dir.append(current_dir)
 
     return hdfs_dir


### PR DESCRIPTION
While running performance tests on `AWS`, I noticed that a new line was being added to the end of the string. 
This caused weird file names (`m-svm.multinomial.dense.10k_100?.0.json`) and errors during the perf test execution.

By stripping the string this problem was resolved and could run my performance test workloads.


