### PR TITLE
[WIP] Add support for RNN and LSTM

### DIFF
--- a/docs/reference-guide-caffe2dml.md
+++ b/docs/reference-guide-caffe2dml.md
@@ -168,6 +168,61 @@ layer {
 }
 ```
 
+## Recurrent Layers
+
+### RNN Layer
+
+In a simple RNN, the output of the previous timestep is fed back in as an additional input at the current timestep.
+
+Invokes [nn/layers/rnn.dml](https://github.com/apache/systemml/blob/master/scripts/nn/layers/rnn.dml) layer.
+
+**Required Parameters:**
+
+- num_output: number of output
+- return_sequences: Whether to return output at all timesteps, or just for the final timestep.
+
+**Sample Usage:**
+```
+layer {
+        top: "rnn_1"
+        recurrent_param {
+                return_sequences: false
+                num_output: 32
+        }
+        type: "RNN"
+        name: "rnn_1"
+        bottom: "rnn_1_input"
+}
+```
+
+### LSTM Layer
+
+In an LSTM, an internal cell state is maintained, additive
+interactions operate over the cell state at each timestep, and
+some amount of this cell state is exposed as output at each
+timestep.  Additionally, the output of the previous timestep is fed
+back in as an additional input at the current timestep.
+   
+Invokes [nn/layers/lstm.dml](https://github.com/apache/systemml/blob/master/scripts/nn/layers/lstm.dml) layer.
+
+**Required Parameters:**
+
+- num_output: number of output
+- return_sequences: Whether to return output at all timesteps, or just for the final timestep.
+
+**Sample Usage:**
+```
+layer {
+        top: "lstm_1"
+        recurrent_param {
+                return_sequences: false
+                num_output: 32
+        }
+        type: "LSTM"
+        name: "lstm_1"
+        bottom: "lstm_1_input"
+}
+```
 
 ## Common Layers
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -382,6 +382,17 @@ file and remove all the `@Ignore` annotations from all the tests. Then run the N
 	mvn -Dit.test=org.apache.sysml.test.gpu.NeuralNetworkOpTests verify -PgpuTests
 
 
+# Run other GPU Unit Tests 
+
+	rm result.txt
+	for t in AggregateUnaryOpTests  BinaryOpTests  MatrixMatrixElementWiseOpTests  RightIndexingTests AppendTest  MatrixMultiplicationOpTest ReorgOpTests ScalarMatrixElementwiseOpTests UnaryOpTests
+	do
+		mvn -Dit.test="org.apache.sysml.test.gpu."$t verify -PgpuTests &> tmp.txt
+		SUCCESS=`grep "BUILD SUCCESS" tmp.txt`
+		echo $t" => "$SUCCESS >> result.txt
+		rm tmp.txt
+	done
+
 # Voting
 
 Following a successful release candidate vote by SystemML PMC members on the SystemML mailing list, the release candidate

--- a/scripts/nn/layers/lstm.dml
+++ b/scripts/nn/layers/lstm.dml
@@ -70,6 +70,12 @@ forward = function(matrix[double] X, matrix[double] W, matrix[double] b, int T, 
    */
   N = nrow(X)
   M = as.integer(ncol(W)/4)
+  N1 = nrow(out0)
+  if(N < N1) {
+    # Allow for smaller out0 for last batch
+    out0 = out0[1:N,]
+    c0 = c0[1:N,]
+  }
   out_prev = out0
   c_prev = c0
   c = c_prev
@@ -161,6 +167,12 @@ backward = function(matrix[double] dout, matrix[double] dc,
    */
   N = nrow(X)
   M = as.integer(ncol(W)/4)
+  N1 = nrow(out0)
+  if(N < N1) {
+    # Allow for smaller out0 for last batch
+    out0 = out0[1:N,]
+    c0 = c0[1:N,]
+  }
   dX = matrix(0, rows=N, cols=T*D)
   dW = matrix(0, rows=D+M, cols=4*M)
   db = matrix(0, rows=1, cols=4*M)

--- a/scripts/nn/layers/rnn.dml
+++ b/scripts/nn/layers/rnn.dml
@@ -54,6 +54,11 @@ forward = function(matrix[double] X, matrix[double] W, matrix[double] b, int T, 
    */
   N = nrow(X)
   M = ncol(W)
+  N1 = nrow(out0)
+  if(N < N1) {
+    # Allow for smaller out0 for last batch
+    out0 = out0[1:N,]
+  }
   out_prev = out0
   if (return_sequences) {
     out = matrix(0, rows=N, cols=T*M)
@@ -113,6 +118,12 @@ backward = function(matrix[double] dout, matrix[double] X, matrix[double] W, mat
    */
   N = nrow(X)
   M = ncol(W)
+  N1 = nrow(out0)
+  if(N < N1) {
+    # Allow for smaller out0 for last batch
+    out0 = out0[1:N,]
+    cache_out = cache_out[,1:(N*M)]
+  }
   dX = matrix(0, rows=N, cols=T*D)
   dW = matrix(0, rows=D+M, cols=M)
   db = matrix(0, rows=1, cols=M)

--- a/src/main/proto/caffe/caffe.proto
+++ b/src/main/proto/caffe/caffe.proto
@@ -959,6 +959,12 @@ message RecurrentParameter {
   // blobs.  The number of additional bottom/top blobs required depends on the
   // recurrent architecture -- e.g., 1 for RNNs, 2 for LSTMs.
   optional bool expose_hidden = 5 [default = false];
+
+  // ========================================================================  
+  // SystemML extension:
+  // Whether to return `out` at all timesteps, or just for the final timestep.
+  optional bool return_sequences = 6 [default = false];
+  // ========================================================================
 }
 
 // Message that stores parameters used by ReductionLayer

--- a/src/main/scala/org/apache/sysml/api/dl/CaffeNetwork.scala
+++ b/src/main/scala/org/apache/sysml/api/dl/CaffeNetwork.scala
@@ -246,6 +246,8 @@ class CaffeNetwork(netFilePath: String, val currentPhase: Phase, var numChannels
       case "deconvolution"   => new DeConvolution(param, id, this)
       case "threshold"       => new Threshold(param, id, this)
       case "softmax"         => new Softmax(param, id, this)
+      case "rnn"             => new RNN(param, id, this)
+      case "lstm"            => new LSTM(param, id, this)
       case _                 => throw new LanguageException("Layer of type " + param.getType + " is not supported")
     }
   }


### PR DESCRIPTION
The RNN results match with Keras but not the LSTM. Please look at `test_nn_numpy.py` file in this commit.

@dusenberrymw @prithvirajsen @bertholdreinwald @romeokienzler  Since you had previously worked with lstm.dml, do you have suggestion to fix the `test_nn_numpy.py` test for LSTM ? For example: modify the parameters of Keras.

To test this PR, please follow the below steps:
```
git clone https://github.com/niketanpansare/systemml.git
cd systemml
git checkout caffe2dml_lstm
mvn package -P distribution
pip uninstall systemml
pip install target/systemml-1.1.0-SNAPSHOT-python.tar.gz
```

Then in a pyspark shell, paste following code:
```
from keras.models import Sequential
from keras.layers import LSTM, Dense
import numpy as np

data_dim = 32
timesteps = 8
num_classes = 10
batch_size = 64
model = Sequential()
model.add(LSTM(32, return_sequences=False, recurrent_activation='sigmoid', input_shape=(timesteps, data_dim)))
model.add(Dense(10, activation='softmax'))
x_train = np.random.random((batch_size, timesteps, data_dim))
y_train = np.random.random((batch_size, num_classes))
from systemml.mllearn import Keras2DML
sysml_model = Keras2DML(spark, model, input_shape=(timesteps,data_dim,1), weights='weights_dir').set(debug=True)
keras_preds = model.predict(x_train)
sysml_preds = sysml_model.predict_proba(x_train.reshape((batch_size, -1)))
# Both fail
np.allclose(sysml_preds.argmax(axis=1), keras_preds.argmax(axis=1))
np.allclose(sysml_preds, keras_preds)
```