### PR TITLE
[SYSTEMML-1931] Support logical operators XOR over matrices, and scalars

### DIFF
--- a/scripts/test.dml
+++ b/scripts/test.dml
@@ -1,0 +1,42 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+test = function() {
+  A = matrix("1 1
+              0 0", rows=2, cols=2);
+
+  B = matrix("1 0
+              0 1", rows=2, cols=2);
+
+ #x = xor(TRUE,TRUE);
+  n = 1.0;
+  m = TRUE;
+  x2 = xor(n,A);
+  y = x2[1,1]
+  #print(x2)
+  #print(as.scalar(x2[1,1]))
+  #print(as.scalar(x2[2,1]))
+  #print(as.scalar(x2[1,2]))
+  #print(as.scalar(x2[2,2]))
+  print(toString(y))
+}
+
+tmp = test()

--- a/src/main/java/org/apache/sysml/hops/Hop.java
+++ b/src/main/java/org/apache/sysml/hops/Hop.java
@@ -1218,9 +1218,9 @@ public abstract class Hop implements ParseInfo
 		HopsOpOp2LopsB.put(OpOp2.NOTEQUAL, Binary.OperationTypes.NOT_EQUALS);
 		HopsOpOp2LopsB.put(OpOp2.MIN, Binary.OperationTypes.MIN);
 		HopsOpOp2LopsB.put(OpOp2.MAX, Binary.OperationTypes.MAX);
-		HopsOpOp2LopsB.put(OpOp2.AND, Binary.OperationTypes.OR);
+		HopsOpOp2LopsB.put(OpOp2.AND, Binary.OperationTypes.AND);
 		HopsOpOp2LopsB.put(OpOp2.XOR, Binary.OperationTypes.XOR);
-		HopsOpOp2LopsB.put(OpOp2.OR, Binary.OperationTypes.AND);
+		HopsOpOp2LopsB.put(OpOp2.OR, Binary.OperationTypes.OR);
 		HopsOpOp2LopsB.put(OpOp2.SOLVE, Binary.OperationTypes.SOLVE);
 		HopsOpOp2LopsB.put(OpOp2.POW, Binary.OperationTypes.POW);
 		HopsOpOp2LopsB.put(OpOp2.LOG, Binary.OperationTypes.NOTSUPPORTED);

--- a/src/main/java/org/apache/sysml/hops/LiteralOp.java
+++ b/src/main/java/org/apache/sysml/hops/LiteralOp.java
@@ -223,6 +223,8 @@ public class LiteralOp extends Hop
 				return value_double;
 			case STRING:
 				return Double.parseDouble(value_string);
+			case BOOLEAN:
+				return value_boolean ? 1 : 0;
 			default:
 				throw new HopsException("Can not coerce an object of type " + getValueType() + " into Double.");
 		}

--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -2664,7 +2664,7 @@ public class DMLTranslator
 
 		case XOR:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
-				ValueType.BOOLEAN, Hop.OpOp2.XOR, expr, expr2);
+				target.getValueType(), Hop.OpOp2.XOR, expr, expr2);
 			break;
 
 		case ABS:

--- a/src/main/java/org/apache/sysml/runtime/functionobjects/And.java
+++ b/src/main/java/org/apache/sysml/runtime/functionobjects/And.java
@@ -41,4 +41,9 @@ public class And extends ValueFunction implements Serializable
 	public boolean execute(boolean in1, boolean in2) {
 		return in1 && in2;
 	}
+
+	@Override
+	public double execute(double in1, double in2) {
+		return ((in1>0) && (in2>0)) ? 1 : 0;
+	}
 }

--- a/src/main/java/org/apache/sysml/runtime/functionobjects/Not.java
+++ b/src/main/java/org/apache/sysml/runtime/functionobjects/Not.java
@@ -39,4 +39,9 @@ public class Not extends ValueFunction
 	public boolean execute(boolean in) {
 		return !in;
 	}
+
+	@Override
+	public double execute(double in) {
+		return (in>0) ? 0 : 1;
+	}
 }

--- a/src/main/java/org/apache/sysml/runtime/functionobjects/Or.java
+++ b/src/main/java/org/apache/sysml/runtime/functionobjects/Or.java
@@ -41,4 +41,9 @@ public class Or extends ValueFunction implements Serializable
 	public boolean execute(boolean in1, boolean in2) {
 		return in1 || in2;
 	}
+
+	@Override
+	public double execute(double in1, double in2) {
+		return ((in1>0) && (in2>0)) ? 1 : 0;
+	}
 }

--- a/src/main/java/org/apache/sysml/runtime/functionobjects/Xor.java
+++ b/src/main/java/org/apache/sysml/runtime/functionobjects/Xor.java
@@ -41,4 +41,16 @@ public class Xor extends ValueFunction implements Serializable
 	public boolean execute(boolean in1, boolean in2) {
 		return in1 != in2;
 	}
+
+	@Override
+	public double execute(double in1, double in2) {
+
+		return (in1 != in2) ? 1 : 0;
+	}
+
+/*	@Override
+	public boolean compute(double in1, boolean in2) {
+
+		return ((in1>0) != in2);
+	}*/
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/SPInstructionParser.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/SPInstructionParser.java
@@ -203,7 +203,10 @@ public class SPInstructionParser extends InstructionParser
 		// Builtin Instruction Opcodes 
 		String2SPInstructionType.put( "log"  , SPINSTRUCTION_TYPE.Builtin);
 		String2SPInstructionType.put( "log_nz"  , SPINSTRUCTION_TYPE.Builtin);
-		
+
+		// Boolean Binary builtin
+		String2SPInstructionType.put( "xor"  , SPINSTRUCTION_TYPE.BuiltinBinary);
+
 		String2SPInstructionType.put( "max"  , SPINSTRUCTION_TYPE.BuiltinBinary);
 		String2SPInstructionType.put( "min"  , SPINSTRUCTION_TYPE.BuiltinBinary);
 		String2SPInstructionType.put( "mapmax"  , SPINSTRUCTION_TYPE.BuiltinBinary);

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/BooleanBinaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/BooleanBinaryCPInstruction.java
@@ -26,15 +26,19 @@ import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysml.runtime.matrix.operators.Operator;
+import org.apache.sysml.runtime.functionobjects.ValueFunction;
+import org.apache.sysml.runtime.functionobjects.Builtin;
 
-public class BooleanBinaryCPInstruction extends BinaryCPInstruction {
+import java.io.OutputStream;
 
-	private BooleanBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+public abstract class BooleanBinaryCPInstruction extends BinaryCPInstruction {
+
+	protected BooleanBinaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
 			String istr) {
 		super(CPType.BooleanBinary, op, in1, in2, out, opcode, istr);
 	}
 
-	public static BooleanBinaryCPInstruction parseInstruction (String str) 
+	public static BooleanBinaryCPInstruction parseInstruction (String str)
 		throws DMLRuntimeException 
 	{
 		CPOperand in1 = new CPOperand("", ValueType.UNKNOWN, DataType.UNKNOWN);
@@ -42,30 +46,22 @@ public class BooleanBinaryCPInstruction extends BinaryCPInstruction {
 		CPOperand out = new CPOperand("", ValueType.UNKNOWN, DataType.UNKNOWN);
 		String opcode = parseBinaryInstruction(str, in1, in2, out);
 		
-		// Boolean operations must be performed on BOOLEAN
+		// Boolean operations must be performed on BOOLEAN, so try converting double or int to boolean
 		ValueType vt1 = in1.getValueType();
 		ValueType vt2 = in2.getValueType();
 		ValueType vt3 = out.getValueType();
-		if ( vt1 != ValueType.BOOLEAN || vt3 != ValueType.BOOLEAN 
-				|| (vt2 != null && vt2 != ValueType.BOOLEAN) )
-			throw new DMLRuntimeException("Unexpected ValueType in ArithmeticInstruction.");
+	//	if ( vt1 != ValueType.BOOLEAN || vt3 != ValueType.BOOLEAN
+	//			|| (vt2 != null && vt2 != ValueType.BOOLEAN) )
+	//		throw new DMLRuntimeException("Unexpected ValueType in ArithmeticInstruction.");
 		
-		// Determine appropriate Function Object based on opcode	
+		// Determine appropriate Function Object based on opcode
 		BinaryOperator bop = InstructionUtils.parseBinaryOperator(opcode);
-		return new BooleanBinaryCPInstruction(bop, in1, in2, out, opcode, str);
-	}
-	
-	@Override
-	public void processInstruction(ExecutionContext ec) 
-		throws DMLRuntimeException 
-	{
-		ScalarObject so1 = ec.getScalarInput( input1.getName(), input1.getValueType(), input1.isLiteral() );
-		ScalarObject so2 = ec.getScalarInput( input2.getName(), input2.getValueType(), input2.isLiteral() );
-		
-		BinaryOperator dop = (BinaryOperator) _optr;
-		boolean rval = dop.fn.execute(so1.getBooleanValue(), so2.getBooleanValue());
-		ScalarObject sores = (ScalarObject) new BooleanObject(rval);
-		
-		ec.setScalarOutput(output.getName(), sores);
+
+		if ( in1.getDataType() == DataType.SCALAR && in2.getDataType() == DataType.SCALAR )
+			return new ScalaScalarBooleanCPInstruction(bop, in1, in2, out, opcode, str);
+		else if ( in1.getDataType() == DataType.MATRIX && in2.getDataType() == DataType.MATRIX )
+			return new MatrixMatrixBooleanCPInstruction(bop, in1, in2, out, opcode, str);
+		else
+			return new MatrixScalarBooleanCPInstruction(bop, in1, in2, out, opcode, str);
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/BooleanUnaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/BooleanUnaryCPInstruction.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,8 +23,9 @@ import org.apache.sysml.parser.Expression.DataType;
 import org.apache.sysml.parser.Expression.ValueType;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.operators.Operator;
-import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
+import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
 public class BooleanUnaryCPInstruction extends UnaryCPInstruction {
 
@@ -40,29 +41,50 @@ public class BooleanUnaryCPInstruction extends UnaryCPInstruction {
 		String opcode = parseUnaryInstruction(str, in, out);
 		
 		// Boolean operations must be performed on BOOLEAN
-		ValueType vt1 = in.getValueType();
-		ValueType vt2 = out.getValueType();
-		if ( vt1 != ValueType.BOOLEAN || vt2 != ValueType.BOOLEAN )
-			throw new DMLRuntimeException("Unexpected ValueType in ArithmeticInstruction.");
+	//	ValueType vt1 = in.getValueType();
+	//	ValueType vt2 = out.getValueType();
+	//	if ( (vt1 != ValueType.BOOLEAN || vt2 != ValueType.BOOLEAN) )
+	//		throw new DMLRuntimeException("Unexpected ValueType in ArithmeticInstruction.");
 		
 		// Determine appropriate Function Object based on opcode	
-		return new BooleanUnaryCPInstruction(getSimpleUnaryOperator(opcode), in, out, opcode, str);
+		return new BooleanUnaryCPInstruction(getUnaryOperator(opcode), in, out, opcode, str);
 	}
 	
 	@Override
 	public void processInstruction(ExecutionContext ec) 
 		throws DMLRuntimeException 
 	{
-		// 1) Obtain data objects associated with inputs 
-		ScalarObject so = ec.getScalarInput(input1.getName(), input1.getValueType(), input1.isLiteral());
-		
-		// 2) Compute the result value & make an appropriate data object 
-		SimpleOperator dop = (SimpleOperator) _optr;
-		boolean rval = dop.fn.execute(so.getBooleanValue());
-		
-		ScalarObject sores = (ScalarObject) new BooleanObject(rval);
-		
-		// 3) Put the result value into ProgramBlock
-		ec.setScalarOutput(output.getName(), sores);
+		if(input1.getDataType() == DataType.SCALAR ) {
+			// 1) Obtain data objects associated with inputs
+			ScalarObject so = ec.getScalarInput(input1.getName(), input1.getValueType(), input1.isLiteral());
+
+			// 2) Compute the result value & make an appropriate data object
+			UnaryOperator dop = (UnaryOperator) _optr;
+			boolean rval = dop.fn.execute(so.getBooleanValue());
+
+			ScalarObject sores = (ScalarObject) new BooleanObject(rval);
+
+			// 3) Put the result value into ProgramBlock
+			ec.setScalarOutput(output.getName(), sores);
+		}
+		else // for the matrix datatype
+		{
+			// 1) Obtain data objects associated with inputs
+			String opcode = getOpcode();
+
+			MatrixBlock inBlock1 = ec.getMatrixInput(input1.getName(), getExtendedOpcode());
+
+			// 2) Compute the result value & make an appropriate data object
+			UnaryOperator dop = (UnaryOperator) _optr;
+			String ouput_name = output.getName();
+
+			MatrixBlock retBlock = (MatrixBlock) inBlock1.unaryOperations(dop, new MatrixBlock());
+
+			ec.releaseMatrixInput(input1.getName(), getExtendedOpcode());
+
+			// 3) Put the result value into ProgramBlock
+			ec.setMatrixOutput(ouput_name, retBlock, getExtendedOpcode());
+		}
+
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixMatrixBooleanCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixMatrixBooleanCPInstruction.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.runtime.instructions.cp;
+
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.matrix.data.MatrixBlock;
+import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
+import org.apache.sysml.runtime.matrix.operators.Operator;
+
+public class MatrixMatrixBooleanCPInstruction extends BooleanBinaryCPInstruction {
+	public MatrixMatrixBooleanCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+		String opcode, String instr) {
+		super(op, in1, in2, out, opcode, instr);
+	}
+
+	@Override
+	public void processInstruction(ExecutionContext ec)
+		throws DMLRuntimeException
+	{
+		String opcode = getOpcode();
+
+		String ouput_name = output.getName();
+		BinaryOperator dop = (BinaryOperator) _optr;
+
+		MatrixBlock inBlock1 = ec.getMatrixInput(input1.getName(), getExtendedOpcode());
+		MatrixBlock inBlock2 = ec.getMatrixInput(input2.getName(), getExtendedOpcode());
+
+		MatrixBlock retBlock = (MatrixBlock) inBlock1.binaryOperations(dop, inBlock2, new MatrixBlock());
+
+		ec.releaseMatrixInput(input1.getName(), getExtendedOpcode());
+		ec.releaseMatrixInput(input2.getName(), getExtendedOpcode());
+
+		//Ensure right dense/sparse output representation (guarded by released input memory)
+		if( checkGuardedRepresentationChange(inBlock1, inBlock2, retBlock) ) {
+			retBlock.examSparsity();
+		}
+
+		ec.setMatrixOutput(ouput_name, retBlock, getExtendedOpcode());
+	}
+}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixScalarBooleanCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/MatrixScalarBooleanCPInstruction.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.runtime.instructions.cp;
+
+import org.apache.sysml.parser.Expression.DataType;
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.matrix.data.MatrixBlock;
+import org.apache.sysml.runtime.matrix.operators.Operator;
+import org.apache.sysml.runtime.matrix.operators.ScalarOperator;
+
+public class MatrixScalarBooleanCPInstruction extends BooleanBinaryCPInstruction {
+
+	protected MatrixScalarBooleanCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+		String opcode, String instr) {
+		super(op, in1, in2, out, opcode, instr);
+	}
+
+	@Override
+	public void processInstruction(ExecutionContext ec)
+			throws DMLRuntimeException
+	{
+		CPOperand mat    = ( input1.getDataType() == DataType.MATRIX) ? input1 : input2;
+		CPOperand scalar = ( input1.getDataType() == DataType.MATRIX) ? input2 : input1;
+
+		MatrixBlock inBlock = ec.getMatrixInput(mat.getName(), getExtendedOpcode());
+		ScalarObject constant = (ScalarObject) ec.getScalarInput(scalar.getName(), scalar.getValueType(),
+				scalar.isLiteral());
+
+		ScalarOperator sc_op = (ScalarOperator) _optr;
+		sc_op = sc_op.setConstant(constant.getDoubleValue());
+
+		MatrixBlock retBlock = (MatrixBlock) inBlock.scalarOperations(sc_op, new MatrixBlock());
+
+		ec.releaseMatrixInput(mat.getName(), getExtendedOpcode());
+
+		// Ensure right dense/sparse output representation (guarded by released input memory)
+		if( checkGuardedRepresentationChange(inBlock, retBlock) ) {
+			retBlock.examSparsity();
+		}
+
+		ec.setMatrixOutput(output.getName(), retBlock, getExtendedOpcode());
+	}
+}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalaScalarBooleanCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ScalaScalarBooleanCPInstruction.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysml.runtime.instructions.cp;
+
+import org.apache.sysml.parser.Expression;
+import org.apache.sysml.runtime.DMLRuntimeException;
+import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysml.runtime.matrix.operators.BinaryOperator;
+import org.apache.sysml.runtime.matrix.operators.Operator;
+
+public class ScalaScalarBooleanCPInstruction extends BooleanBinaryCPInstruction {
+
+	protected ScalaScalarBooleanCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode,
+			String instr) {
+		super(op, in1, in2, out, opcode, instr);
+	}
+
+	@Override
+	public void processInstruction(ExecutionContext ec)
+		throws DMLRuntimeException
+	{
+		// 1) Obtain data objects associated with inputs
+		ScalarObject so1 = ec.getScalarInput(input1.getName(), input1.getValueType(), input1.isLiteral() );
+		ScalarObject so2 = ec.getScalarInput(input2.getName(), input2.getValueType(), input2.isLiteral() );
+
+		// 2) Compute the result value & make an appropriate data object
+		BinaryOperator dop = (BinaryOperator) _optr;
+		ScalarObject sores = null;
+
+		//compute output value, incl implicit type if necessary
+		if( so1 instanceof StringObject || so2 instanceof StringObject )
+			throw new DMLRuntimeException("Binary builtin '"+getOpcode()+"' not supported over string inputs.");
+		else if( so1 instanceof DoubleObject || so2 instanceof DoubleObject || output.getValueType()== Expression.ValueType.DOUBLE)
+			sores = new DoubleObject(dop.fn.execute( so1.getDoubleValue(), so2.getDoubleValue() ));
+		else if( so1 instanceof IntObject || so2 instanceof IntObject )
+			sores = new DoubleObject(dop.fn.execute( so1.getDoubleValue(), so2.getDoubleValue() ));
+		else if( so1 instanceof BooleanObject || so2 instanceof BooleanObject )
+			sores = new BooleanObject(dop.fn.execute( so1.getBooleanValue(), so2.getBooleanValue() ));
+		else //integers may not be supported
+			throw new DMLRuntimeException("Binary builtin '"+getOpcode()+"' not supported over some inputs.");
+
+		// 3) Put the result value into ProgramBlock
+		ec.setScalarOutput(output.getName(), sores);
+	}
+}

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/UnaryCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/UnaryCPInstruction.java
@@ -24,6 +24,7 @@ import org.apache.sysml.runtime.functionobjects.Not;
 import org.apache.sysml.runtime.instructions.InstructionUtils;
 import org.apache.sysml.runtime.matrix.operators.Operator;
 import org.apache.sysml.runtime.matrix.operators.SimpleOperator;
+import org.apache.sysml.runtime.matrix.operators.UnaryOperator;
 
 public abstract class UnaryCPInstruction extends ComputationCPInstruction {
 
@@ -87,11 +88,20 @@ public abstract class UnaryCPInstruction extends ComputationCPInstruction {
 		}
 		return opcode;
 	}
-	
+
+	@SuppressWarnings("deprecated") // now we may not need this
 	static SimpleOperator getSimpleUnaryOperator(String opcode)
 			throws DMLRuntimeException {
 		if (opcode.equalsIgnoreCase("!"))
 			return new SimpleOperator(Not.getNotFnObject());
+
+		throw new DMLRuntimeException("Unknown unary operator " + opcode);
+	}
+
+	static UnaryOperator getUnaryOperator(String opcode)
+		throws DMLRuntimeException {
+		if (opcode.equalsIgnoreCase("!"))
+			return new UnaryOperator(Not.getNotFnObject());
 
 		throw new DMLRuntimeException("Unknown unary operator " + opcode);
 	}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixBincell.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibMatrixBincell.java
@@ -788,9 +788,9 @@ public class LibMatrixBincell
 	 * 
 	 * This will do cell wise operation for &lt;, &lt;=, &gt;, &gt;=, == and != operators.
 	 * 
-	 * @param mbLeft left matrix
-	 * @param mbRight right matrix
-	 * @param mbOut output matrix
+	 * @param m1 left matrix
+	 * @param m2 right matrix
+	 * @param ret output matrix
 	 * @param bOp binary operator
 	 * 
 	 */
@@ -989,7 +989,7 @@ public class LibMatrixBincell
 	 * Since this operation is sparse-unsafe, ret should always be passed in dense representation.
 	 * 
 	 * @param m1 input matrix
-	 * @param m2 result matrix
+	 * @param ret result matrix
 	 * @param op scalar operator
 	 * @throws DMLRuntimeException if DMLRuntimeException occurs
 	 */

--- a/src/main/java/org/apache/sysml/runtime/matrix/operators/BinaryOperator.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/operators/BinaryOperator.java
@@ -55,7 +55,7 @@ public class BinaryOperator  extends Operator implements Serializable
 	public BinaryOperator(ValueFunction p) {
 		//binaryop is sparse-safe iff (0 op 0) == 0
 		super (p instanceof Plus || p instanceof Multiply || p instanceof Minus
-			|| p instanceof And || p instanceof Or
+			|| p instanceof And || p instanceof Or || p instanceof Xor
 			|| p instanceof PlusMultiply || p instanceof MinusMultiply);
 		fn = p;
 	}

--- a/src/main/java/org/apache/sysml/runtime/matrix/operators/UnaryOperator.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/operators/UnaryOperator.java
@@ -21,7 +21,9 @@
 package org.apache.sysml.runtime.matrix.operators;
 
 import org.apache.sysml.runtime.functionobjects.Builtin;
+import org.apache.sysml.runtime.functionobjects.Not;
 import org.apache.sysml.runtime.functionobjects.ValueFunction;
+import org.apache.sysml.runtime.functionobjects.Xor;
 
 public class UnaryOperator extends Operator 
 {
@@ -35,18 +37,18 @@ public class UnaryOperator extends Operator
 	}
 	
 	public UnaryOperator(ValueFunction p, int numThreads) {
-		super(p instanceof Builtin && 
+		super(p instanceof Not || (p instanceof Builtin &&
 			((Builtin)p).bFunc==Builtin.BuiltinCode.SIN || ((Builtin)p).bFunc==Builtin.BuiltinCode.TAN 
 			// sinh and tanh are zero only at zero, else they are nnz
 			|| ((Builtin)p).bFunc==Builtin.BuiltinCode.SINH || ((Builtin)p).bFunc==Builtin.BuiltinCode.TANH
 			|| ((Builtin)p).bFunc==Builtin.BuiltinCode.ROUND || ((Builtin)p).bFunc==Builtin.BuiltinCode.ABS
 			|| ((Builtin)p).bFunc==Builtin.BuiltinCode.SQRT || ((Builtin)p).bFunc==Builtin.BuiltinCode.SPROP
 			|| ((Builtin)p).bFunc==Builtin.BuiltinCode.SELP || ((Builtin)p).bFunc==Builtin.BuiltinCode.LOG_NZ
-			|| ((Builtin)p).bFunc==Builtin.BuiltinCode.SIGN );
+			|| ((Builtin)p).bFunc==Builtin.BuiltinCode.SIGN ));
 		fn = p;
 		k = numThreads;
 	}
-	
+
 	public int getNumThreads() {
 		return k;
 	}

--- a/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix/ElementwiseXorTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/binary/matrix/ElementwiseXorTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.sysml.test.integration.functions.binary.matrix;
+
+
+import org.apache.sysml.api.DMLScript;
+import org.apache.sysml.api.DMLScript.RUNTIME_PLATFORM;
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
+import org.apache.sysml.runtime.matrix.data.MatrixValue.CellIndex;
+import org.apache.sysml.test.integration.AutomatedTestBase;
+import org.apache.sysml.test.integration.TestConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+/**
+ * This tests elementwise xor operations
+ *
+ *
+ */
+public class ElementwiseXorTest extends AutomatedTestBase{
+
+	private final static String TEST_NAME1 = "ElementwiseXorTest";
+	private final static String TEST_DIR   = "functions/binary/matrix/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ElementwiseXorTest.class.getSimpleName() + "/";
+
+	private final static int rows1 = 10;
+	private final static int rows2 = 2500;
+	private final static int cols1 = 10;
+	private final static int cols2 = 2500;
+	private final static double sparsity1 = 0.9;//dense
+	private final static double sparsity2 = 0.1;//sparse
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(
+				TEST_NAME1,
+				new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1,
+				new String[] { "D" }));
+	}
+
+	@Test
+	public void testXorDenseCP() {
+		runXor(rows1, cols1, false, RUNTIME_PLATFORM.SINGLE_NODE);
+	}
+
+	@Test
+	public void testXorDenseSP() {
+		runXor(rows1, cols1, false, RUNTIME_PLATFORM.SPARK);
+	}
+
+	@Test
+	public void testXorDenseMR() {
+		runXor(rows1, cols1, false, RUNTIME_PLATFORM.HADOOP);
+	}
+
+	@Test
+	public void testXorDenseHybrid() {
+		runXor(rows1, cols1, false, RUNTIME_PLATFORM.HYBRID_SPARK);
+	}
+
+	@Test
+	public void testXorSparseCP() {
+		runXor(rows1, cols1, true, RUNTIME_PLATFORM.SINGLE_NODE);
+	}
+
+	@Test
+	public void testXorSparseSP() {
+		runXor(rows1, cols1, true, RUNTIME_PLATFORM.SPARK);
+	}
+
+	@Test
+	public void testXorSparseMR() {
+		runXor(rows1, cols1, true, RUNTIME_PLATFORM.HADOOP);
+	}
+
+	@Test
+	public void testXorSparseHybrid() {
+		runXor(rows1, cols1, true, RUNTIME_PLATFORM.HYBRID_SPARK);
+	}
+
+	@Test
+	public void testLargeXorDenseCP() {
+		runXor(rows2, cols2, false, RUNTIME_PLATFORM.SINGLE_NODE);
+	}
+
+	@Test
+	public void testLargeXorDenseSP() {
+		runXor(rows2, cols2, false, RUNTIME_PLATFORM.SPARK);
+	}
+
+	@Test
+	public void testLargeXorDenseMR() {
+		runXor(rows2, cols2, false, RUNTIME_PLATFORM.HADOOP);
+	}
+
+	@Test
+	public void testLargeXorDenseHybrid() {
+		runXor(rows2, cols2, false, RUNTIME_PLATFORM.HYBRID_SPARK);
+	}
+
+	@Test
+	public void testLargeXorSparseCP() {
+		runXor(rows2, cols2, true, RUNTIME_PLATFORM.SINGLE_NODE);
+	}
+
+	@Test
+	public void testLargeXorSparseSP() {
+		runXor(rows2, cols2, true, RUNTIME_PLATFORM.SPARK);
+	}
+
+	@Test
+	public void testLargeXorSparseMR() {
+		runXor(rows2, cols2, true, RUNTIME_PLATFORM.HADOOP);
+	}
+
+	@Test
+	public void testLargeXorSparseHybrid() {
+		runXor(rows2, cols2, true, RUNTIME_PLATFORM.HYBRID_SPARK);
+	}
+
+	private void runXor(int rows, int cols, boolean sparsity, RUNTIME_PLATFORM rt) {
+		RUNTIME_PLATFORM rtold = rtplatform;
+		rtplatform = rt;
+
+		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+		if (rtplatform == RUNTIME_PLATFORM.SPARK)
+			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+
+		try {
+
+			String TEST_NAME = TEST_NAME1;
+			getAndLoadTestConfiguration(TEST_NAME);
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-args", input("A"), input("B"), input("computedMatrix"),output("D")};
+
+			//get a random matrix of values with (-0.5, 0, 1]
+			double[][] A = getRandomMatrix(rows, cols, -0.5, 1, sparsity ? sparsity1 : sparsity2, -1);
+			double[][] B = getRandomMatrix(rows, cols, -0.5, 1, sparsity ? sparsity1 : sparsity2, -1);
+
+			double[][] A1 = new double[rows][cols];
+			double[][] B1 = new double[rows][cols];
+			double[][] computedMatrix = new double[rows][cols];
+
+			for(int i = 0; i < rows; i++) {
+				for(int j = 0; j < cols; j++) {
+					//Ceil tries to round up the cell values to either "0.0", or "1.0"
+					A1[i][j] = Math.ceil(A[i][j]);
+					B1[i][j] = Math.ceil(B[i][j]);
+					computedMatrix[i][j] = (A1[i][j] != B1[i][j]) ? 1 : 0; // use operator(xor, and, not, or), depending on the checking
+				}
+			}
+
+			MatrixCharacteristics mc = new MatrixCharacteristics(rows, cols, -1, -1, -1);
+			writeInputMatrixWithMTD("A", A1, false, mc);
+			writeInputMatrixWithMTD("B", B1, false, mc);
+			writeInputMatrixWithMTD("computedMatrix", computedMatrix, false, mc);
+
+			//run tests
+			runTest(true, false, null, -1);
+
+			Assert.assertEquals(0, readDMLMatrixFromHDFS("D").get(new CellIndex(1,1)), 1e-5);
+		}
+		finally {
+			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+			rtplatform = rtold;
+		}
+	}
+}

--- a/src/test/scripts/functions/binary/matrix/ElementwiseXorTest.dml
+++ b/src/test/scripts/functions/binary/matrix/ElementwiseXorTest.dml
@@ -19,24 +19,15 @@
 #
 #-------------------------------------------------------------
 
-test = function() {
-  A = matrix("1 1
-              0 0", rows=2, cols=2);
+A = read($1);
+B = read($2);
+computedMatrix = read($3)
 
-  B = matrix("1 0
-              0 1", rows=2, cols=2);
+C1 = xor(A, B);
 
- #x = xor(TRUE,TRUE);
-  n = 1.0;
-  m = TRUE;
-  x2 = xor(A , B);
- # y = x2[1,1]
-  print(as.scalar(x2[1,1]))
-  print(as.scalar(x2[1,1]))
-  print(as.scalar(x2[2,1]))
-  print(as.scalar(x2[1,2]))
-  print(as.scalar(x2[2,2]))
-  #print(toString(x2))
-}
+diff = sum(computedMatrix - C1)
+Answer = as.matrix(1);
+D = Answer * diff
+write(D, $4);
 
-tmp = test()
+


### PR DESCRIPTION
_what is here?_
**Supports:**
operations over scalars, all combinations for `AND`, `XOR`, `NOT`, `XOR` are working, such as 
``` 
say A = matrix("1 1
                0 0", rows=2, cols=2);
      n = 1.0;
      m = TRUE;
     1. xor(m,n) gives 0.0
     2. xor( m, !n) gives TRUE
     3. ( m & !n) gives FALSE
     4. ( m | !n) gives TRUE
     5. xor(A, A) gives all zeros

     6. xor(A,m) or xor(A, n) - not working
     7. (A & A), (A | A), (!A) - not working
```

**what I've tried to change?**
1. changed function objects, to support `(double, double)` to return `double` -- all operators
2. Tried to handle `BuiltinBinary` as `BooleanBinary` operations, and added separted classes `MatrixMatrixBooleanCPInstruction`, `MatrixScalarBooleanCPInstruction`, `ScalaScalarBooleanCPInstruction`. 
 
3. Handled the `!` case (`BuiltinUnary`), as `BooleanUnaryCPInstruction`, for the matrix case.
4. At the end added a `junit` test, `ElementwiseXorTest`
   - I've done some mistake instruction gen for spark
   - runtime error in mr case, for all xor over matrices

   
 
