### PR TITLE
[WIP][SYSTEMML-2110] Codegen support for relu operation

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/CellwiseTmplTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/CellwiseTmplTest.java
@@ -56,6 +56,7 @@ public class CellwiseTmplTest extends AutomatedTestBase
 	private static final String TEST_NAME18 = TEST_NAME+18; //sum(ifelse(X,Y,Z))
 	private static final String TEST_NAME19 = TEST_NAME+19; //sum(ifelse(true,Y,Z))+sum(ifelse(false,Y,Z))
 	private static final String TEST_NAME20 = TEST_NAME+20; //bitwAnd() operation
+	private static final String TEST_NAME21 = TEST_NAME+21; //relu operation, (X>0)*dout
 	
 	private static final String TEST_DIR = "functions/codegen/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + CellwiseTmplTest.class.getSimpleName() + "/";
@@ -68,7 +69,7 @@ public class CellwiseTmplTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		for( int i=1; i<=20; i++ ) {
+		for( int i=1; i<=21; i++ ) {
 			addTestConfiguration( TEST_NAME+i, new TestConfiguration(
 					TEST_CLASS_DIR, TEST_NAME+i, new String[] {String.valueOf(i)}) );
 		}
@@ -350,7 +351,22 @@ public class CellwiseTmplTest extends AutomatedTestBase
 	public void testCodegenCellwiseRewrite20_sp() {
 		testCodegenIntegration( TEST_NAME20, true, ExecType.SPARK );
 	}
-	
+
+	@Test
+	public void testCodegenCellwiseRewrite21() {
+		testCodegenIntegration( TEST_NAME21, true, ExecType.CP );
+	}
+
+	@Test
+	public void testCodegenCellwise21() {
+		testCodegenIntegration( TEST_NAME21, false, ExecType.CP );
+	}
+
+	@Test
+	public void testCodegenCellwiseRewrite21_sp() {
+		testCodegenIntegration( TEST_NAME21, true, ExecType.SPARK );
+	}
+
 	private void testCodegenIntegration( String testname, boolean rewrites, ExecType instType )
 	{
 		boolean oldRewrites = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/RowAggTmplTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/RowAggTmplTest.java
@@ -76,6 +76,7 @@ public class RowAggTmplTest extends AutomatedTestBase
 	private static final String TEST_NAME37 = TEST_NAME+"37"; //sprop(X/rowSums)
 	private static final String TEST_NAME38 = TEST_NAME+"38"; //sigmoid(X/rowSums)
 	private static final String TEST_NAME39 = TEST_NAME+"39"; //BitwAnd operation
+	private static final String TEST_NAME40 = TEST_NAME+"40"; //relu operation -> (X>0)* dout
 	
 	private static final String TEST_DIR = "functions/codegen/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + RowAggTmplTest.class.getSimpleName() + "/";
@@ -87,7 +88,7 @@ public class RowAggTmplTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		for(int i=1; i<=39; i++)
+		for(int i=1; i<=40; i++)
 			addTestConfiguration( TEST_NAME+i, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME+i, new String[] { String.valueOf(i) }) );
 	}
 	
@@ -674,6 +675,21 @@ public class RowAggTmplTest extends AutomatedTestBase
 	@Test
 	public void testCodegenRowAgg39SP() {
 		testCodegenIntegration( TEST_NAME39, false, ExecType.SPARK );
+	}
+
+	@Test
+	public void testCodegenRowAggRewrite40CP() {
+		testCodegenIntegration( TEST_NAME40, true, ExecType.CP );
+	}
+
+	@Test
+	public void testCodegenRowAgg40CP() {
+		testCodegenIntegration( TEST_NAME40, false, ExecType.CP );
+	}
+
+	@Test
+	public void testCodegenRowAgg40SP() {
+		testCodegenIntegration( TEST_NAME40, false, ExecType.SPARK );
 	}
 
 	private void testCodegenIntegration( String testname, boolean rewrites, ExecType instType )

--- a/src/test/scripts/functions/codegen/cellwisetmpl21.R
+++ b/src/test/scripts/functions/codegen/cellwisetmpl21.R
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+args<-commandArgs(TRUE)
+options(digits=22)
+library("Matrix")
+
+X = matrix(seq(7, 1006), 500, 2, byrow=TRUE);
+
+R1 = (X/3) %% 0.6;
+R2 = (X/3) %/% 0.6;
+R = (R1 > 0) * R2
+
+writeMM(as(R,"CsparseMatrix"), paste(args[2], "S", sep=""));

--- a/src/test/scripts/functions/codegen/cellwisetmpl21.dml
+++ b/src/test/scripts/functions/codegen/cellwisetmpl21.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = matrix(seq(7, 1006), 500, 2);
+
+R1 = (X/3) %% 0.6;
+R2 = (X/3) %/% 0.6;
+R = (R1 > 0) * R2;
+
+write(R, $1)

--- a/src/test/scripts/functions/codegen/rowAggPattern40.R
+++ b/src/test/scripts/functions/codegen/rowAggPattern40.R
@@ -1,0 +1,33 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+args<-commandArgs(TRUE)
+options(digits=22)
+library("Matrix")
+library("matrixStats")
+
+X = matrix(seq(1, 6000)/600, 300, 20, byrow=TRUE);
+
+Y = X/(rowSums(X)%*%matrix(1,1,ncol(X)))
+
+R = (X>0) * Y;
+
+writeMM(as(R, "CsparseMatrix"), paste(args[2], "S", sep=""));

--- a/src/test/scripts/functions/codegen/rowAggPattern40.dml
+++ b/src/test/scripts/functions/codegen/rowAggPattern40.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = matrix(seq(1, 6000)/600, 300, 20);
+
+Y = X/rowSums(X)
+
+R = (X>0) * Y;
+
+write(R, $1)


### PR DESCRIPTION
`(X > 0) * Y`,  integration support for codegeneration.

1. spoof primitives.
2. tests

**Question**
But, how `libmatrixDNN` class's operator can be invoked, is it a rewrite or is there any function name such as `relu_backward()` .