### PR TITLE
[SYSTEMML-2068] codegen BitwAnd support

### DIFF
--- a/src/main/java/org/apache/sysml/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/BinaryOp.java
@@ -1606,8 +1606,8 @@ public class BinaryOp extends Hop
 				||op==OpOp2.MIN ||op==OpOp2.MAX
 				||op==OpOp2.LOG ||op==OpOp2.POW
 				||op==OpOp2.AND ||op==OpOp2.OR ||op==OpOp2.XOR
-				||op==OpOp2.BW_AND ||op==OpOp2.BW_OR ||op==OpOp2.BW_XOR
-				||op==OpOp2.BW_SHIFTL ||op==OpOp2.BW_SHIFTR);
+				||op==OpOp2.BITWAND ||op==OpOp2.BITWOR ||op==OpOp2.BITWXOR
+				||op==OpOp2.BITWSHIFTL ||op==OpOp2.BITWSHIFTR);
 	}
 	
 	public boolean isPPredOperation()

--- a/src/main/java/org/apache/sysml/hops/Hop.java
+++ b/src/main/java/org/apache/sysml/hops/Hop.java
@@ -1075,7 +1075,7 @@ public abstract class Hop implements ParseInfo
 		MINUS_NZ, //sparse-safe minus: X-(mean*ppred(X,0,!=))
 		LOG_NZ, //sparse-safe log; ppred(X,0,"!=")*log(X,0.5)
 		MINUS1_MULT, //1-X*Y
-		BW_AND, BW_OR, BW_XOR, BW_SHIFTL, BW_SHIFTR, //bitwise operations
+		BITWAND, BITWOR, BITWXOR, BITWSHIFTL, BITWSHIFTR, //bitwise operations
 	}
 
 	// Operations that require 3 operands
@@ -1217,11 +1217,11 @@ public abstract class Hop implements ParseInfo
 		HopsOpOp2LopsB.put(OpOp2.SOLVE, Binary.OperationTypes.SOLVE);
 		HopsOpOp2LopsB.put(OpOp2.POW, Binary.OperationTypes.POW);
 		HopsOpOp2LopsB.put(OpOp2.LOG, Binary.OperationTypes.NOTSUPPORTED);
-		HopsOpOp2LopsB.put(OpOp2.BW_AND, Binary.OperationTypes.BW_AND);
-		HopsOpOp2LopsB.put(OpOp2.BW_OR, Binary.OperationTypes.BW_OR);
-		HopsOpOp2LopsB.put(OpOp2.BW_XOR, Binary.OperationTypes.BW_XOR);
-		HopsOpOp2LopsB.put(OpOp2.BW_SHIFTL, Binary.OperationTypes.BW_SHIFTL);
-		HopsOpOp2LopsB.put(OpOp2.BW_SHIFTR, Binary.OperationTypes.BW_SHIFTR);
+		HopsOpOp2LopsB.put(OpOp2.BITWAND, Binary.OperationTypes.BW_AND);
+		HopsOpOp2LopsB.put(OpOp2.BITWOR, Binary.OperationTypes.BW_OR);
+		HopsOpOp2LopsB.put(OpOp2.BITWXOR, Binary.OperationTypes.BW_XOR);
+		HopsOpOp2LopsB.put(OpOp2.BITWSHIFTL, Binary.OperationTypes.BW_SHIFTL);
+		HopsOpOp2LopsB.put(OpOp2.BITWSHIFTR, Binary.OperationTypes.BW_SHIFTR);
 	}
 
 	protected static final HashMap<Hop.OpOp2, BinaryScalar.OperationTypes> HopsOpOp2LopsBS;
@@ -1247,11 +1247,11 @@ public abstract class Hop implements ParseInfo
 		HopsOpOp2LopsBS.put(OpOp2.LOG, BinaryScalar.OperationTypes.LOG);
 		HopsOpOp2LopsBS.put(OpOp2.POW, BinaryScalar.OperationTypes.POW);
 		HopsOpOp2LopsBS.put(OpOp2.PRINT, BinaryScalar.OperationTypes.PRINT);
-		HopsOpOp2LopsBS.put(OpOp2.BW_AND, BinaryScalar.OperationTypes.BW_AND);
-		HopsOpOp2LopsBS.put(OpOp2.BW_OR, BinaryScalar.OperationTypes.BW_OR);
-		HopsOpOp2LopsBS.put(OpOp2.BW_XOR, BinaryScalar.OperationTypes.BW_XOR);
-		HopsOpOp2LopsBS.put(OpOp2.BW_SHIFTL, BinaryScalar.OperationTypes.BW_SHIFTL);
-		HopsOpOp2LopsBS.put(OpOp2.BW_SHIFTR, BinaryScalar.OperationTypes.BW_SHIFTR);
+		HopsOpOp2LopsBS.put(OpOp2.BITWAND, BinaryScalar.OperationTypes.BW_AND);
+		HopsOpOp2LopsBS.put(OpOp2.BITWOR, BinaryScalar.OperationTypes.BW_OR);
+		HopsOpOp2LopsBS.put(OpOp2.BITWXOR, BinaryScalar.OperationTypes.BW_XOR);
+		HopsOpOp2LopsBS.put(OpOp2.BITWSHIFTL, BinaryScalar.OperationTypes.BW_SHIFTL);
+		HopsOpOp2LopsBS.put(OpOp2.BITWSHIFTR, BinaryScalar.OperationTypes.BW_SHIFTR);
 	}
 
 	protected static final HashMap<Hop.OpOp2, org.apache.sysml.lops.Unary.OperationTypes> HopsOpOp2LopsU;
@@ -1279,11 +1279,11 @@ public abstract class Hop implements ParseInfo
 		HopsOpOp2LopsU.put(OpOp2.POW, org.apache.sysml.lops.Unary.OperationTypes.POW);
 		HopsOpOp2LopsU.put(OpOp2.MINUS_NZ, org.apache.sysml.lops.Unary.OperationTypes.SUBTRACT_NZ);
 		HopsOpOp2LopsU.put(OpOp2.LOG_NZ, org.apache.sysml.lops.Unary.OperationTypes.LOG_NZ);
-		HopsOpOp2LopsU.put(OpOp2.BW_AND, Unary.OperationTypes.BW_AND);
-		HopsOpOp2LopsU.put(OpOp2.BW_OR, Unary.OperationTypes.BW_OR);
-		HopsOpOp2LopsU.put(OpOp2.BW_XOR, Unary.OperationTypes.BW_XOR);
-		HopsOpOp2LopsU.put(OpOp2.BW_SHIFTL, Unary.OperationTypes.BW_SHIFTL);
-		HopsOpOp2LopsU.put(OpOp2.BW_SHIFTR, Unary.OperationTypes.BW_SHIFTR);
+		HopsOpOp2LopsU.put(OpOp2.BITWAND, Unary.OperationTypes.BW_AND);
+		HopsOpOp2LopsU.put(OpOp2.BITWOR, Unary.OperationTypes.BW_OR);
+		HopsOpOp2LopsU.put(OpOp2.BITWXOR, Unary.OperationTypes.BW_XOR);
+		HopsOpOp2LopsU.put(OpOp2.BITWSHIFTL, Unary.OperationTypes.BW_SHIFTL);
+		HopsOpOp2LopsU.put(OpOp2.BITWSHIFTR, Unary.OperationTypes.BW_SHIFTR);
 	}
 
 	protected static final HashMap<Hop.OpOp1, org.apache.sysml.lops.Unary.OperationTypes> HopsOpOp1LopsU;
@@ -1463,11 +1463,11 @@ public abstract class Hop implements ParseInfo
 		HopsOpOp2String.put(OpOp2.RBIND, "rbind");
 		HopsOpOp2String.put(OpOp2.SOLVE, "solve");
 		HopsOpOp2String.put(OpOp2.XOR, "xor");
-		HopsOpOp2String.put(OpOp2.BW_AND, "bitwAnd");
-		HopsOpOp2String.put(OpOp2.BW_OR,  "bitwOr");
-		HopsOpOp2String.put(OpOp2.BW_XOR, "bitwXor");
-		HopsOpOp2String.put(OpOp2.BW_SHIFTL, "bitwShiftL");
-		HopsOpOp2String.put(OpOp2.BW_SHIFTR, "bitwShiftR");
+		HopsOpOp2String.put(OpOp2.BITWAND, "bitwAnd");
+		HopsOpOp2String.put(OpOp2.BITWOR,  "bitwOr");
+		HopsOpOp2String.put(OpOp2.BITWXOR, "bitwXor");
+		HopsOpOp2String.put(OpOp2.BITWSHIFTL, "bitwShiftL");
+		HopsOpOp2String.put(OpOp2.BITWSHIFTR, "bitwShiftR");
 	}
 	
 	public static String getBinaryOpCode(OpOp2 op) {
@@ -1559,11 +1559,11 @@ public abstract class Hop implements ParseInfo
 		else if( "&".equals(op) ) return OpOp2.AND;
 		else if( "log".equals(op) ) return OpOp2.LOG;
 		else if( "^".equals(op) ) return OpOp2.POW;
-		else if("bitwAnd".equals(op) ) return OpOp2.BW_AND;
-		else if("bitwOr".equals(op) ) return OpOp2.BW_OR;
-		else if("bitwXor".equals(op) ) return OpOp2.BW_XOR;
-		else if("bitwShiftL".equals(op) ) return OpOp2.BW_SHIFTL;
-		else if("bitwShiftR".equals(op) ) return OpOp2.BW_SHIFTR;
+		else if("bitwAnd".equals(op) ) return OpOp2.BITWAND;
+		else if("bitwOr".equals(op) ) return OpOp2.BITWOR;
+		else if("bitwXor".equals(op) ) return OpOp2.BITWXOR;
+		else if("bitwShiftL".equals(op) ) return OpOp2.BITWSHIFTL;
+		else if("bitwShiftR".equals(op) ) return OpOp2.BITWSHIFTR;
 		
 		return null;
 	}

--- a/src/main/java/org/apache/sysml/hops/codegen/cplan/CNodeBinary.java
+++ b/src/main/java/org/apache/sysml/hops/codegen/cplan/CNodeBinary.java
@@ -239,7 +239,7 @@ public class CNodeBinary extends CNode
 				|| this == VECT_EQUAL || this == VECT_NOTEQUAL
 				|| this == VECT_LESS || this == VECT_LESSEQUAL
 				|| this == VECT_GREATER || this == VECT_GREATEREQUAL
-				|| this == VECT_XOR || this == VECT_BITWAND_SCALAR;
+				|| this == VECT_XOR || this == VECT_BITWAND;
 		}
 		public boolean isVectorMatrixPrimitive() {
 			return this == VECT_MATRIXMULT

--- a/src/main/java/org/apache/sysml/hops/codegen/cplan/CNodeBinary.java
+++ b/src/main/java/org/apache/sysml/hops/codegen/cplan/CNodeBinary.java
@@ -42,15 +42,16 @@ public class CNodeBinary extends CNode
 		VECT_EQUAL_SCALAR, VECT_NOTEQUAL_SCALAR, VECT_LESS_SCALAR, 
 		VECT_LESSEQUAL_SCALAR, VECT_GREATER_SCALAR, VECT_GREATEREQUAL_SCALAR,
 		VECT_CBIND,
-		VECT_XOR_SCALAR,
+		VECT_XOR_SCALAR, VECT_BITWAND_SCALAR,
 		//vector-vector operations
 		VECT_MULT, VECT_DIV, VECT_MINUS, VECT_PLUS, VECT_MIN, VECT_MAX, VECT_EQUAL, 
 		VECT_NOTEQUAL, VECT_LESS, VECT_LESSEQUAL, VECT_GREATER, VECT_GREATEREQUAL,
-		VECT_XOR,
+		VECT_XOR, VECT_BITWAND,
 		//scalar-scalar operations
 		MULT, DIV, PLUS, MINUS, MODULUS, INTDIV, 
 		LESS, LESSEQUAL, GREATER, GREATEREQUAL, EQUAL,NOTEQUAL,
 		MIN, MAX, AND, OR, XOR, LOG, LOG_NZ, POW,
+		BITWAND,
 		MINUS1_MULT, MINUS_NZ;
 
 		public static boolean contains(String value) {
@@ -116,6 +117,7 @@ public class CNodeBinary extends CNode
 				case VECT_PLUS_SCALAR:
 				case VECT_POW_SCALAR:
 				case VECT_XOR_SCALAR:
+				case VECT_BITWAND_SCALAR:
 				case VECT_MIN_SCALAR:
 				case VECT_MAX_SCALAR:
 				case VECT_EQUAL_SCALAR:
@@ -147,6 +149,7 @@ public class CNodeBinary extends CNode
 				case VECT_MINUS:
 				case VECT_PLUS:
 				case VECT_XOR:
+				case VECT_BITWAND:
 				case VECT_MIN:
 				case VECT_MAX:
 				case VECT_EQUAL:
@@ -206,7 +209,9 @@ public class CNodeBinary extends CNode
 					return "    double %TMP% = (%IN1% != 0) ? %IN1% - %IN2% : 0;\n";
 				case XOR:
 					return "    double %TMP% = ( (%IN1% != 0) != (%IN2% != 0) ) ? 1 : 0;\n";
-					
+				case BITWAND:
+					return "    double %TMP% = ( ((int)%IN1% & (int)%IN2%) );\n";
+
 				default: 
 					throw new RuntimeException("Invalid binary type: "+this.toString());
 			}
@@ -225,7 +230,7 @@ public class CNodeBinary extends CNode
 				|| this == VECT_LESS_SCALAR || this == VECT_LESSEQUAL_SCALAR
 				|| this == VECT_GREATER_SCALAR || this == VECT_GREATEREQUAL_SCALAR
 				|| this == VECT_CBIND
-				|| this == VECT_XOR_SCALAR;
+				|| this == VECT_XOR_SCALAR || this == VECT_BITWAND_SCALAR;
 		}
 		public boolean isVectorVectorPrimitive() {
 			return this == VECT_DIV || this == VECT_MULT 
@@ -234,7 +239,7 @@ public class CNodeBinary extends CNode
 				|| this == VECT_EQUAL || this == VECT_NOTEQUAL
 				|| this == VECT_LESS || this == VECT_LESSEQUAL
 				|| this == VECT_GREATER || this == VECT_GREATEREQUAL
-				|| this == VECT_XOR;
+				|| this == VECT_XOR || this == VECT_BITWAND_SCALAR;
 		}
 		public boolean isVectorMatrixPrimitive() {
 			return this == VECT_MATRIXMULT
@@ -400,6 +405,7 @@ public class CNodeBinary extends CNode
 			case OR:                       return "b(|)";
 			case AND:                      return "b(&)";
 			case XOR:                      return "b(xor)";
+			case BITWAND:                  return "b(bitwAnd)";
 			case MINUS1_MULT:              return "b(1-*)";
 			case MINUS_NZ:                 return "b(-nz)";
 			default: return "b("+_type.name().toLowerCase()+")";
@@ -449,6 +455,7 @@ public class CNodeBinary extends CNode
 			case VECT_MINUS_SCALAR:
 			case VECT_PLUS_SCALAR:
 			case VECT_XOR_SCALAR:
+			case VECT_BITWAND_SCALAR:
 			case VECT_POW_SCALAR:
 			case VECT_MIN_SCALAR:
 			case VECT_MAX_SCALAR:
@@ -464,6 +471,7 @@ public class CNodeBinary extends CNode
 			case VECT_MINUS:
 			case VECT_PLUS:
 			case VECT_XOR:
+			case VECT_BITWAND:
 			case VECT_MIN:
 			case VECT_MAX:
 			case VECT_EQUAL: 
@@ -508,6 +516,7 @@ public class CNodeBinary extends CNode
 			case AND: 
 			case OR:
 			case XOR:
+			case BITWAND:
 			case LOG: 
 			case LOG_NZ:
 			case POW: 

--- a/src/main/java/org/apache/sysml/hops/codegen/template/TemplateRow.java
+++ b/src/main/java/org/apache/sysml/hops/codegen/template/TemplateRow.java
@@ -66,7 +66,9 @@ public class TemplateRow extends TemplateBase
 			OpOp1.CUMSUM, OpOp1.CUMMIN, OpOp1.CUMMAX, OpOp1.SPROP, OpOp1.SIGMOID};
 	private static final Hop.OpOp2[] SUPPORTED_VECT_BINARY = new OpOp2[]{
 			OpOp2.MULT, OpOp2.DIV, OpOp2.MINUS, OpOp2.PLUS, OpOp2.POW, OpOp2.MIN, OpOp2.MAX, OpOp2.XOR,
-			OpOp2.EQUAL, OpOp2.NOTEQUAL, OpOp2.LESS, OpOp2.LESSEQUAL, OpOp2.GREATER, OpOp2.GREATEREQUAL};
+			OpOp2.EQUAL, OpOp2.NOTEQUAL, OpOp2.LESS, OpOp2.LESSEQUAL, OpOp2.GREATER, OpOp2.GREATEREQUAL,
+			OpOp2.BITWAND,
+	};
 	
 	public TemplateRow() {
 		super(TemplateType.ROW);

--- a/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
@@ -447,11 +447,11 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			break;
 		
 		case XOR:
-		case BITWISE_AND:
-		case BITWISE_OR:
-		case BITWISE_XOR:
-		case BITWISE_SHIFTL:
-		case BITWISE_SHIFTR:
+		case BITWAND:
+		case BITWOR:
+		case BITWXOR:
+		case BITWSHIFTL:
+		case BITWSHIFTR:
 		case MIN:
 		case MAX:
 			//min(X), min(X,s), min(s,X), min(s,r), min(X,Y)
@@ -1377,11 +1377,11 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		case FLOOR:
 		case MEDIAN:
 		case XOR:
-		case BITWISE_AND:
-		case BITWISE_OR:
-		case BITWISE_XOR:
-		case BITWISE_SHIFTL:
-		case BITWISE_SHIFTR:
+		case BITWAND:
+		case BITWOR:
+		case BITWXOR:
+		case BITWSHIFTL:
+		case BITWSHIFTR:
 			return true;
 		default:
 			return false;
@@ -1778,15 +1778,15 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		else if ( functionName.equals("xor") )
 			bifop = Expression.BuiltinFunctionOp.XOR;
 		else if ( functionName.equals("bitwAnd") )
-			bifop = Expression.BuiltinFunctionOp.BITWISE_AND;
+			bifop = Expression.BuiltinFunctionOp.BITWAND;
 		else if ( functionName.equals("bitwOr") )
-			bifop = Expression.BuiltinFunctionOp.BITWISE_OR;
+			bifop = Expression.BuiltinFunctionOp.BITWOR;
 		else if ( functionName.equals("bitwXor") )
-			bifop = Expression.BuiltinFunctionOp.BITWISE_XOR;
+			bifop = Expression.BuiltinFunctionOp.BITWXOR;
 		else if ( functionName.equals("bitwShiftL") )
-			bifop = Expression.BuiltinFunctionOp.BITWISE_SHIFTL;
+			bifop = Expression.BuiltinFunctionOp.BITWSHIFTL;
 		else if ( functionName.equals("bitwShiftR") )
-			bifop = Expression.BuiltinFunctionOp.BITWISE_SHIFTR;
+			bifop = Expression.BuiltinFunctionOp.BITWSHIFTR;
 		else if ( functionName.equals("ifelse") )
 			bifop = Expression.BuiltinFunctionOp.IFELSE;
 		else

--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -2680,23 +2680,23 @@ public class DMLTranslator
 			break;
 		case BITWAND:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
-					target.getValueType(), OpOp2.BW_AND, expr, expr2);
+					target.getValueType(), OpOp2.BITWAND, expr, expr2);
 			break;
 		case BITWOR:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
-					target.getValueType(), OpOp2.BW_OR, expr, expr2);
+					target.getValueType(), OpOp2.BITWOR, expr, expr2);
 			break;
 		case BITWXOR:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
-					target.getValueType(), OpOp2.BW_XOR, expr, expr2);
+					target.getValueType(), OpOp2.BITWXOR, expr, expr2);
 			break;
 		case BITWSHIFTL:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
-					target.getValueType(), OpOp2.BW_SHIFTL, expr, expr2);
+					target.getValueType(), OpOp2.BITWSHIFTL, expr, expr2);
 			break;
 		case BITWSHIFTR:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
-					target.getValueType(), OpOp2.BW_SHIFTR, expr, expr2);
+					target.getValueType(), OpOp2.BITWSHIFTR, expr, expr2);
 			break;
 
 		case ABS:

--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -2678,23 +2678,23 @@ public class DMLTranslator
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
 				target.getValueType(), Hop.OpOp2.XOR, expr, expr2);
 			break;
-		case BITWISE_AND:
+		case BITWAND:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
 					target.getValueType(), OpOp2.BW_AND, expr, expr2);
 			break;
-		case BITWISE_OR:
+		case BITWOR:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
 					target.getValueType(), OpOp2.BW_OR, expr, expr2);
 			break;
-		case BITWISE_XOR:
+		case BITWXOR:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
 					target.getValueType(), OpOp2.BW_XOR, expr, expr2);
 			break;
-		case BITWISE_SHIFTL:
+		case BITWSHIFTL:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
 					target.getValueType(), OpOp2.BW_SHIFTL, expr, expr2);
 			break;
-		case BITWISE_SHIFTR:
+		case BITWSHIFTR:
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(),
 					target.getValueType(), OpOp2.BW_SHIFTR, expr, expr2);
 			break;

--- a/src/main/java/org/apache/sysml/parser/Expression.java
+++ b/src/main/java/org/apache/sysml/parser/Expression.java
@@ -138,11 +138,11 @@ public abstract class Expression implements ParseInfo
 		TRANS,
 		VAR,
 		XOR,
-		BITWISE_AND,
-		BITWISE_OR,
-		BITWISE_XOR,
-		BITWISE_SHIFTL,
-		BITWISE_SHIFTR,
+		BITWAND,
+		BITWOR,
+		BITWXOR,
+		BITWSHIFTL,
+		BITWSHIFTR,
 	}
 
 	/**

--- a/src/main/java/org/apache/sysml/runtime/codegen/LibSpoofPrimitives.java
+++ b/src/main/java/org/apache/sysml/runtime/codegen/LibSpoofPrimitives.java
@@ -25,6 +25,7 @@ import org.apache.commons.math3.util.FastMath;
 import org.apache.sysml.runtime.functionobjects.IntegerDivide;
 import org.apache.sysml.runtime.functionobjects.Modulus;
 import org.apache.sysml.runtime.matrix.data.LibMatrixMult;
+import org.apache.sysml.runtime.util.UtilFunctions;
 
 /**
  * This library contains all vector primitives that are used in 
@@ -1978,10 +1979,47 @@ public class LibSpoofPrimitives
 	public static double[] vectBitwandWrite(double[] a, double bval, int ai, int len) {
 		double[] c = allocVector(len, false);
 		for( int j = 0; j < len; j++ )
-			c[j] = ( (int)a[ai+j] & (int)bval );
+			c[j] = (double)( UtilFunctions.toInt(a[ai+j]) & UtilFunctions.toInt(bval) );
 		return c;
 	}
-	
+
+	//2. dense vector vs. scalar
+	public static double[] vectBitwandWrite(double bval, double[] a, int ai, int len) {
+		double[] c = allocVector(len, false);
+		for( int j = 0; j < len; j++ )
+			c[j] = ( UtilFunctions.toInt(bval) & UtilFunctions.toInt(a[ai+j]) );
+		return c;
+	}
+
+	//3. dense vector vs. dense vector
+	public static double[] vectBitwandWrite(double[] a, double[] b, int ai, int bi, int len) {
+		double[] c= allocVector(len, false);
+		for( int j = 0; j < len; j++ )
+			c[j] = (double)( UtilFunctions.toInt(a[ai+j]) & UtilFunctions.toInt(b[bi+j]));
+		return c;
+	}
+
+	//4. sparse vector vs. scalar
+//	public static double[] vectBitwandWrite(double[] a, double bval, int[] aix, int ai, int alen, int len) {
+//		double init = (bval != 0) ? 1 : 0;
+//		double[] c = allocVector(len, true, init);
+//		for( int j = ai; j < ai+alen; j++ )
+//			c[aix[j]] = (a[j])
+//	}
+
+	//6. sparse vector vs. dense vector
+	public static double[] vectBitwandWrite(double[] a, double[] b, int[] aix, int ai, int bi, int alen, int len) {
+		double[] c = allocVector(len, false);
+		for( int j = 0; j < len; j++ )
+			c[j] = (b[bi+j] != 0) ? 1 : 0;
+		for( int j = ai; j < ai+alen; j++ )
+			c[aix[j]] = ( UtilFunctions.toInt(a[j]) & UtilFunctions.toInt(b[bi + aix[j]]) );
+		return c;
+	}
+
+	public static double[] vectBitwandWrite(double[] a, double[] b, int ai, int[] aix, int bi, int alen, int len) {
+		return vectXorWrite(a, b, aix, ai, bi, alen, len);
+	}
 	//complex builtin functions that are not directly generated
 	//(included here in order to reduce the number of imports)
 	

--- a/src/main/java/org/apache/sysml/runtime/codegen/LibSpoofPrimitives.java
+++ b/src/main/java/org/apache/sysml/runtime/codegen/LibSpoofPrimitives.java
@@ -628,11 +628,7 @@ public class LibSpoofPrimitives
 
 	//5. scalar vs. sparse vector
 	public static double[] vectXorWrite(double bval, double[] a, int[] aix, int ai, int alen, int len) {
-		double init = (bval != 0) ? 1 : 0;
-		double[] c = allocVector(len, true, init);
-		for( int j = ai; j < ai+alen; j++ )
-			c[aix[j]] = (a[j] != 0) ? 0 : 1;
-		return c;
+		return vectXorWrite(a, bval, aix, ai, alen, len);
 	}
 
 	//6. sparse vector vs. dense vector
@@ -1972,23 +1968,21 @@ public class LibSpoofPrimitives
 	/**
 	 * BitwiseAnd Operator
 	 *
-	 * @return
 	 */
 
 	//1. dense vector vs. scalar
 	public static double[] vectBitwandWrite(double[] a, double bval, int ai, int len) {
-		double[] c = allocVector(len, false);
+		int init = (bval != 0) ? 1 : 0;
+		double[] c = allocVector(len, true, init);
+		int bval1 =  (int)(bval);
 		for( int j = 0; j < len; j++ )
-			c[j] = (double)( UtilFunctions.toInt(a[ai+j]) & UtilFunctions.toInt(bval) );
+			c[j] = (double)( UtilFunctions.toInt(a[ai+j]) & (bval1) );
 		return c;
 	}
 
 	//2. scalar vs. dense vector
 	public static double[] vectBitwandWrite(double bval, double[] a, int ai, int len) {
-		double[] c = allocVector(len, false);
-		for( int j = 0; j < len; j++ )
-			c[j] = ( UtilFunctions.toInt(bval) & UtilFunctions.toInt(a[ai+j]) );
-		return c;
+		return vectBitwandWrite(a, bval, ai, len);
 	}
 
 	//3. dense vector vs. dense vector
@@ -1999,6 +1993,32 @@ public class LibSpoofPrimitives
 		return c;
 	}
 
+	//4. sparse vector vs. scalar.
+	public static double[] vectBitwandWrite(double[] a, double bval, int[] aix, int ai, int alen, int len) {
+		double[] c = allocVector(len, true, 0);
+		int bval1 = (int)bval;
+		for( int j = ai; j < ai+alen; j++ )
+			c[aix[j]] = (double)( UtilFunctions.toInt(a[j]) & bval1);
+		return c;
+	}
+
+	//5. scalar vs. sparse vector
+	public static double[] vectBitwandWrite(double bval, double[] a, int[] aix, int ai, int alen, int len) {
+		return vectBitwandWrite(a, bval, aix, ai, alen, len);
+	}
+
+	//6. sparse vector vs. dense vector
+	public static double[] vectBitwandWrite(double[] a, double[] b, int[] aix, int ai, int bi, int alen, int len) {
+		double[] c = allocVector(len, true, 0);
+		for( int j = ai; j < ai+alen; j++ )
+			c[aix[j]] = (UtilFunctions.toInt(a[j]) & UtilFunctions.toInt(b[bi+aix[j]]));
+		return c;
+	}
+
+	//6. sparse vector vs. dense vector
+	public static double[] vectBitwandWrite(double[] a, double[] b, int ai, int[] aix, int bi, int alen, int len) {
+		return vectBitwandWrite(a, b, aix, ai, bi, alen, len);
+	}
 
 	//complex builtin functions that are not directly generated
 	//(included here in order to reduce the number of imports)

--- a/src/main/java/org/apache/sysml/runtime/codegen/LibSpoofPrimitives.java
+++ b/src/main/java/org/apache/sysml/runtime/codegen/LibSpoofPrimitives.java
@@ -1965,6 +1965,22 @@ public class LibSpoofPrimitives
 		//invariant to the ordering of inputs
 		return vectLessWrite(b, a, bix, bi, ai, blen, len);
 	}
+
+	//********************* Logical Bitwise Operators ********************//
+
+	/**
+	 * BitwiseAnd Operator
+	 *
+	 * @return
+	 */
+
+	//1. scalar vs. dense vector
+	public static double[] vectBitwandWrite(double[] a, double bval, int ai, int len) {
+		double[] c = allocVector(len, false);
+		for( int j = 0; j < len; j++ )
+			c[j] = ( (int)a[ai+j] & (int)bval );
+		return c;
+	}
 	
 	//complex builtin functions that are not directly generated
 	//(included here in order to reduce the number of imports)

--- a/src/main/java/org/apache/sysml/runtime/codegen/LibSpoofPrimitives.java
+++ b/src/main/java/org/apache/sysml/runtime/codegen/LibSpoofPrimitives.java
@@ -1975,7 +1975,7 @@ public class LibSpoofPrimitives
 	 * @return
 	 */
 
-	//1. scalar vs. dense vector
+	//1. dense vector vs. scalar
 	public static double[] vectBitwandWrite(double[] a, double bval, int ai, int len) {
 		double[] c = allocVector(len, false);
 		for( int j = 0; j < len; j++ )
@@ -1983,7 +1983,7 @@ public class LibSpoofPrimitives
 		return c;
 	}
 
-	//2. dense vector vs. scalar
+	//2. scalar vs. dense vector
 	public static double[] vectBitwandWrite(double bval, double[] a, int ai, int len) {
 		double[] c = allocVector(len, false);
 		for( int j = 0; j < len; j++ )
@@ -1999,27 +1999,7 @@ public class LibSpoofPrimitives
 		return c;
 	}
 
-	//4. sparse vector vs. scalar
-//	public static double[] vectBitwandWrite(double[] a, double bval, int[] aix, int ai, int alen, int len) {
-//		double init = (bval != 0) ? 1 : 0;
-//		double[] c = allocVector(len, true, init);
-//		for( int j = ai; j < ai+alen; j++ )
-//			c[aix[j]] = (a[j])
-//	}
 
-	//6. sparse vector vs. dense vector
-	public static double[] vectBitwandWrite(double[] a, double[] b, int[] aix, int ai, int bi, int alen, int len) {
-		double[] c = allocVector(len, false);
-		for( int j = 0; j < len; j++ )
-			c[j] = (b[bi+j] != 0) ? 1 : 0;
-		for( int j = ai; j < ai+alen; j++ )
-			c[aix[j]] = ( UtilFunctions.toInt(a[j]) & UtilFunctions.toInt(b[bi + aix[j]]) );
-		return c;
-	}
-
-	public static double[] vectBitwandWrite(double[] a, double[] b, int ai, int[] aix, int bi, int alen, int len) {
-		return vectXorWrite(a, b, aix, ai, bi, alen, len);
-	}
 	//complex builtin functions that are not directly generated
 	//(included here in order to reduce the number of imports)
 	

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlock.java
@@ -245,9 +245,19 @@ public abstract class SparseBlock implements Serializable
 	 * @param r  row index starting at 0
 	 * @return true if row does not contain non-zero values
 	 */
-	public abstract boolean isEmpty(int r); 
-	
-	
+	public abstract boolean isEmpty(int r);
+
+	/**
+	 * Validate the correctness of the internal data structures of different
+	 * sparse block implementations.
+	 *
+	 * @param rlen length of rows
+	 * @param clen lenght of cols
+	 * @param strict
+	 * @return
+	 */
+	public abstract boolean checkValidity(int rlen, int clen, boolean strict);
+
 	////////////////////////
 	//obtain indexes/values/positions
 	

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCOO.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCOO.java
@@ -282,6 +282,11 @@ public class SparseBlockCOO extends SparseBlock
 	}
 
 	@Override
+	public boolean checkValidity(int rlen, int clen, boolean strict) {
+		return true;
+	}
+
+	@Override
 	public boolean set(int r, int c, double v) {
 		int pos = pos(r);
 		int len = size(r);

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
@@ -24,6 +24,7 @@ import java.io.DataInput;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.apache.sysml.api.mlcontext.Matrix;
 import org.apache.sysml.runtime.util.SortUtils;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
@@ -51,6 +52,13 @@ public class SparseBlockCSR extends SparseBlock
 	private int[] _indexes = null;   //column index array (size: >=nnz)
 	private double[] _values = null; //value array (size: >=nnz)
 	private int _size = 0;           //actual number of nnz
+
+	//matrix meta data
+	protected int rlen       = -1;
+	protected int clen       = -1;
+	protected boolean sparse = true;
+	protected long nonZeros  = 0;
+
 	
 	public SparseBlockCSR(int rlen) {
 		this(rlen, INIT_CAPACITY);
@@ -69,7 +77,7 @@ public class SparseBlockCSR extends SparseBlock
 		_values = values;
 		_size = nnz;
 	}
-	
+
 	/**
 	 * Copy constructor sparse block abstraction. 
 	 * 
@@ -342,7 +350,54 @@ public class SparseBlockCSR extends SparseBlock
 	public boolean isAllocated(int r) {
 		return true;
 	}
-	
+
+	@Override
+	public boolean checkValidity(int rlen, int clen, boolean strict) {
+		//1. correct meta data
+		if( rlen < 0 || clen < 0 ) {
+			throw new RuntimeException("Invalid block dimensions: "+rlen+" "+clen);
+		}
+
+		//2. correct array lengths
+		long esize = estimateMemory(rlen, clen, MatrixBlock.SPARSITY_TURN_POINT);
+		if(_size < esize) {
+			return false;
+		}
+
+		//3. non-decreasing row pointers
+		int prevRowPointer = 0;
+		for( int i=0; i<rlen; i++ ) {
+			int apos = _ptr[i];
+			if(prevRowPointer > apos)
+				throw new RuntimeException("Row pointers are decreasing.");
+		}
+
+		//4. sorted column indexes per row
+		for( int i=0; i<rlen; i++ ) {
+			int apos = _ptr[i];
+			int alen = _size;
+			int[] aix = _indexes;
+			double[] avals = _values;
+			for( int k=apos+1; k<apos+alen; k++)
+				if( aix[k-1] > aix[k] )
+					throw new RuntimeException("Wrong sparse row ordering: "+k+" "+aix[k-1]+" "+aix[k]);
+			for( int k=apos; k<apos+alen; k++ )
+				if( avals[k] == 0 )
+					throw new RuntimeException("Wrong sparse row: zero at "+k);
+		}
+
+		//5. non-existing zero values
+
+
+		//6. a capacity that is no larger than nnz times resize factor.
+		int capacity = _values.length; int nnz = _size;
+		if(capacity > nnz*RESIZE_FACTOR1) {
+			throw new RuntimeException("capacity is larget than the nnz times a resize factor.");
+		}
+
+		return false;
+	}
+
 	@Override 
 	public void reset() {
 		if( _size > 0 ) {

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockMCSR.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockMCSR.java
@@ -238,6 +238,11 @@ public class SparseBlockMCSR extends SparseBlock
 	}
 
 	@Override
+	public boolean checkValidity(int rlen, int clen, boolean strict) {
+		return true;
+	}
+
+	@Override
 	public boolean set(int r, int c, double v) {
 		if( !isAllocated(r) )
 			_rows[r] = new SparseRowScalar();

--- a/src/main/java/org/apache/sysml/runtime/matrix/operators/BinaryOperator.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/operators/BinaryOperator.java
@@ -91,11 +91,11 @@ public class BinaryOperator  extends Operator implements Serializable
 		else if( fn instanceof And )			return OpOp2.AND;
 		else if( fn instanceof Or )				return OpOp2.OR;
 		else if( fn instanceof Xor )			return OpOp2.XOR;
-		else if( fn instanceof BitwAnd )		return OpOp2.BW_AND;
-		else if( fn instanceof BitwOr )			return OpOp2.BW_OR;
-		else if( fn instanceof BitwXor )		return OpOp2.BW_XOR;
-		else if( fn instanceof BitwShiftL )		return OpOp2.BW_SHIFTL;
-		else if( fn instanceof BitwShiftR )		return OpOp2.BW_SHIFTR;
+		else if( fn instanceof BitwAnd )		return OpOp2.BITWAND;
+		else if( fn instanceof BitwOr )			return OpOp2.BITWOR;
+		else if( fn instanceof BitwXor )		return OpOp2.BITWXOR;
+		else if( fn instanceof BitwShiftL )		return OpOp2.BITWSHIFTL;
+		else if( fn instanceof BitwShiftR )		return OpOp2.BITWSHIFTR;
 		else if( fn instanceof Power )			return OpOp2.POW;
 		else if( fn instanceof MinusNz )		return OpOp2.MINUS_NZ;
 		else if( fn instanceof Builtin ) {

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/CPlanVectorPrimitivesTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/CPlanVectorPrimitivesTest.java
@@ -691,11 +691,6 @@ public class CPlanVectorPrimitivesTest extends AutomatedTestBase
 		testVectorBinaryPrimitive(BinType.VECT_BITWAND, InputType.VECTOR_DENSE, InputType.VECTOR_DENSE);
 	}
 
-	@Test
-	public void testVectorVectorBitwAndSparseDense() {
-		testVectorBinaryPrimitive(BinType.BITWAND, InputType.VECTOR_SPARSE, InputType.VECTOR_DENSE);
-	}
-
 	@SuppressWarnings("incomplete-switch")
 	private static void testVectorAggPrimitive(UnaryType aggtype, InputType type1)
 	{

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/CPlanVectorPrimitivesTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/CPlanVectorPrimitivesTest.java
@@ -682,6 +682,20 @@ public class CPlanVectorPrimitivesTest extends AutomatedTestBase
 		testVectorBinaryPrimitive(BinType.VECT_BITWAND_SCALAR, InputType.VECTOR_DENSE, InputType.SCALAR);
 	}
 
+	@Test
+	public void testScalarVectorBitwAndDense() {
+		testVectorBinaryPrimitive(BinType.VECT_BITWAND_SCALAR, InputType.SCALAR, InputType.VECTOR_DENSE);
+	}
+	@Test
+	public void testVectorVectorBitwAndDenseDense() {
+		testVectorBinaryPrimitive(BinType.VECT_BITWAND, InputType.VECTOR_DENSE, InputType.VECTOR_DENSE);
+	}
+
+	@Test
+	public void testVectorVectorBitwAndSparseDense() {
+		testVectorBinaryPrimitive(BinType.BITWAND, InputType.VECTOR_SPARSE, InputType.VECTOR_DENSE);
+	}
+
 	@SuppressWarnings("incomplete-switch")
 	private static void testVectorAggPrimitive(UnaryType aggtype, InputType type1)
 	{

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/CPlanVectorPrimitivesTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/CPlanVectorPrimitivesTest.java
@@ -656,39 +656,55 @@ public class CPlanVectorPrimitivesTest extends AutomatedTestBase
 	}
 
 	@Test
-	public void testVectorVectorDenseDense() {
+	public void testVectorVectorXorDenseDense() {
 		testVectorBinaryPrimitive(BinType.VECT_XOR, InputType.VECTOR_DENSE, InputType.VECTOR_DENSE);
 	}
 
 	@Test
-	public void testVectorScalarSparse() {
+	public void testVectorScalarXorSparse() {
 		testVectorBinaryPrimitive(BinType.VECT_XOR_SCALAR, InputType.VECTOR_SPARSE, InputType.SCALAR);
 	}
 
 	@Test
-	public void testScalarVectorSparse() {
+	public void testScalarVectorXorSparse() {
 		testVectorBinaryPrimitive(BinType.VECT_XOR_SCALAR, InputType.SCALAR, InputType.VECTOR_SPARSE);
 	}
 
 	@Test
-	public void testVectorVectorSparseDense() {
+	public void testVectorVectorXorSparseDense() {
 		testVectorBinaryPrimitive(BinType.VECT_XOR, InputType.VECTOR_SPARSE, InputType.VECTOR_DENSE);
 	}
 
 	//***************** Logical Bitwise Operators ********************//
 
-	@Test
+	@Test //1.
 	public void testVectorScalarBitwAndDense() {
 		testVectorBinaryPrimitive(BinType.VECT_BITWAND_SCALAR, InputType.VECTOR_DENSE, InputType.SCALAR);
 	}
 
-	@Test
+	@Test //2.
 	public void testScalarVectorBitwAndDense() {
 		testVectorBinaryPrimitive(BinType.VECT_BITWAND_SCALAR, InputType.SCALAR, InputType.VECTOR_DENSE);
 	}
-	@Test
+
+	@Test //3.
 	public void testVectorVectorBitwAndDenseDense() {
 		testVectorBinaryPrimitive(BinType.VECT_BITWAND, InputType.VECTOR_DENSE, InputType.VECTOR_DENSE);
+	}
+
+	@Test //4.
+	public void testVectorScalarBitwAndSparse() {
+		testVectorBinaryPrimitive(BinType.VECT_BITWAND, InputType.VECTOR_SPARSE, InputType.SCALAR);
+	}
+
+	@Test //5.
+	public void testScalarVectorBitwAndSparse() {
+		testVectorBinaryPrimitive(BinType.VECT_BITWAND, InputType.SCALAR, InputType.VECTOR_SPARSE);
+	}
+
+	@Test //6.
+	public void testVectorVectorBitwAndSparseDense() {
+		testVectorBinaryPrimitive(BinType.VECT_BITWAND, InputType.VECTOR_SPARSE, InputType.VECTOR_DENSE);
 	}
 
 	@SuppressWarnings("incomplete-switch")

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/CPlanVectorPrimitivesTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/CPlanVectorPrimitivesTest.java
@@ -675,6 +675,13 @@ public class CPlanVectorPrimitivesTest extends AutomatedTestBase
 		testVectorBinaryPrimitive(BinType.VECT_XOR, InputType.VECTOR_SPARSE, InputType.VECTOR_DENSE);
 	}
 
+	//***************** Logical Bitwise Operators ********************//
+
+	@Test
+	public void testVectorScalarBitwAndDense() {
+		testVectorBinaryPrimitive(BinType.VECT_BITWAND_SCALAR, InputType.VECTOR_DENSE, InputType.SCALAR);
+	}
+
 	@SuppressWarnings("incomplete-switch")
 	private static void testVectorAggPrimitive(UnaryType aggtype, InputType type1)
 	{

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/CellwiseTmplTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/CellwiseTmplTest.java
@@ -55,6 +55,7 @@ public class CellwiseTmplTest extends AutomatedTestBase
 	private static final String TEST_NAME17 = TEST_NAME+17; //xor operation
 	private static final String TEST_NAME18 = TEST_NAME+18; //sum(ifelse(X,Y,Z))
 	private static final String TEST_NAME19 = TEST_NAME+19; //sum(ifelse(true,Y,Z))+sum(ifelse(false,Y,Z))
+	private static final String TEST_NAME20 = TEST_NAME+20; //bitwAnd() operation
 	
 	private static final String TEST_DIR = "functions/codegen/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + CellwiseTmplTest.class.getSimpleName() + "/";
@@ -67,7 +68,7 @@ public class CellwiseTmplTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		for( int i=1; i<=19; i++ ) {
+		for( int i=1; i<=20; i++ ) {
 			addTestConfiguration( TEST_NAME+i, new TestConfiguration(
 					TEST_CLASS_DIR, TEST_NAME+i, new String[] {String.valueOf(i)}) );
 		}
@@ -334,7 +335,21 @@ public class CellwiseTmplTest extends AutomatedTestBase
 	public void testCodegenCellwiseRewrite19_sp() {
 		testCodegenIntegration( TEST_NAME19, true, ExecType.SPARK );
 	}
-	
+
+	@Test
+	public void testCodegenCellwiseRewrite20() {
+		testCodegenIntegration( TEST_NAME20, true, ExecType.CP );
+	}
+
+	@Test
+	public void testCodegenCellwise20() {
+		testCodegenIntegration( TEST_NAME20, false, ExecType.CP );
+	}
+
+	@Test
+	public void testCodegenCellwiseRewrite20_sp() {
+		testCodegenIntegration( TEST_NAME20, true, ExecType.SPARK );
+	}
 	
 	private void testCodegenIntegration( String testname, boolean rewrites, ExecType instType )
 	{

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegen/RowAggTmplTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegen/RowAggTmplTest.java
@@ -75,6 +75,7 @@ public class RowAggTmplTest extends AutomatedTestBase
 	private static final String TEST_NAME36 = TEST_NAME+"36"; //xor operation
 	private static final String TEST_NAME37 = TEST_NAME+"37"; //sprop(X/rowSums)
 	private static final String TEST_NAME38 = TEST_NAME+"38"; //sigmoid(X/rowSums)
+	private static final String TEST_NAME39 = TEST_NAME+"39"; //BitwAnd operation
 	
 	private static final String TEST_DIR = "functions/codegen/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + RowAggTmplTest.class.getSimpleName() + "/";
@@ -86,7 +87,7 @@ public class RowAggTmplTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		for(int i=1; i<=38; i++)
+		for(int i=1; i<=39; i++)
 			addTestConfiguration( TEST_NAME+i, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME+i, new String[] { String.valueOf(i) }) );
 	}
 	
@@ -659,7 +660,22 @@ public class RowAggTmplTest extends AutomatedTestBase
 	public void testCodegenRowAgg38SP() {
 		testCodegenIntegration( TEST_NAME38, false, ExecType.SPARK );
 	}
-	
+
+	@Test
+	public void testCodegenRowAggRewrite39CP() {
+		testCodegenIntegration( TEST_NAME39, true, ExecType.CP );
+	}
+
+	@Test
+	public void testCodegenRowAgg39CP() {
+		testCodegenIntegration( TEST_NAME39, false, ExecType.CP );
+	}
+
+	@Test
+	public void testCodegenRowAgg39SP() {
+		testCodegenIntegration( TEST_NAME39, false, ExecType.SPARK );
+	}
+
 	private void testCodegenIntegration( String testname, boolean rewrites, ExecType instType )
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;

--- a/src/test/java/org/apache/sysml/test/integration/functions/sparse/SparseBlockCheckValidity.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/sparse/SparseBlockCheckValidity.java
@@ -1,0 +1,81 @@
+package org.apache.sysml.test.integration.functions.sparse;
+
+import org.apache.sysml.runtime.matrix.data.SparseBlock;
+import org.apache.sysml.runtime.matrix.data.SparseBlockCSR;
+import org.apache.sysml.test.integration.AutomatedTestBase;
+import org.apache.sysml.test.utils.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SparseBlockCheckValidity extends AutomatedTestBase
+{
+	private final static int rows = 632;
+	private final static int cols = 454;
+	private final static double sparsity1 = 0.11;
+	private final static double sparsity2 = 0.21;
+	private final static double sparsity3 = 0.31;
+
+	private enum InitType {
+		SEQ_SET,
+		RAND_SET,
+	}
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+	}
+
+	@Test
+	public void testSparseBlockCSR1Seq() {
+		runSparseBlockValidityTest(SparseBlock.Type.CSR, sparsity1, InitType.SEQ_SET);
+	}
+
+	private void runSparseBlockValidityTest( SparseBlock.Type btype, double sparsity, InitType itype) {
+		{
+			try {
+				//data generation
+
+				double[][] A = getRandomMatrix(rows, cols, -10, 10, sparsity, 7654321);
+
+				//init sparse block
+				SparseBlock sblock = null;
+				switch (btype) {
+					case CSR:
+						sblock = new SparseBlockCSR(rows, cols);
+						break;
+				}
+
+				if (itype == InitType.SEQ_SET) {
+					for (int i = 0; i < rows; i++)
+						for (int j = 0; j < cols; j++)
+							sblock.append(i, j, A[i][j]);
+				}
+
+				//check for correct number of non-zeroes
+				int[] rnnz = new int[rows];
+				int nnz = 0;
+				for (int i = 0; i < rows; i++) {
+					for (int j = 0; j < cols; j++)
+						rnnz[i] += (A[i][j] != 0) ? 1 : 0;
+					nnz += rnnz[i];
+				}
+
+				//check correct values
+				for (int i = 0; i < rows; i++)
+					if (!sblock.isEmpty(i))
+						for (int j = 0; j < cols; j++) {
+							double tmp = sblock.get(i, j);
+							if (tmp != A[i][j])
+								Assert.fail("Wrong get value for cell (" + i + "," + j + "): " + tmp + ", expected: " + A[i][j]);
+						}
+
+
+			}
+			catch(Exception ex) {
+				ex.printStackTrace();
+				throw new RuntimeException(ex);
+			}
+		}
+	}
+
+}

--- a/src/test/scripts/functions/codegen/cellwisetmpl20.R
+++ b/src/test/scripts/functions/codegen/cellwisetmpl20.R
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+args<-commandArgs(TRUE)
+options(digits=22)
+library("Matrix")
+
+X = matrix(seq(7, 1006), 500, 2, byrow=TRUE);
+
+R1 = (X/3) %% 0.6;
+R2 = (X/3) %/% 0.6;
+R = bitwAnd(R1, R2);
+
+writeMM(as(R,"CsparseMatrix"), paste(args[2], "S", sep=""));

--- a/src/test/scripts/functions/codegen/cellwisetmpl20.dml
+++ b/src/test/scripts/functions/codegen/cellwisetmpl20.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = matrix(seq(7, 1006), 500, 2);
+
+R1 = (X/3) %% 0.6;
+R2 = (X/3) %/% 0.6;
+R = bitwAnd(R1, R2);
+
+write(R, $1)

--- a/src/test/scripts/functions/codegen/rowAggPattern39.R
+++ b/src/test/scripts/functions/codegen/rowAggPattern39.R
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+args<-commandArgs(TRUE)
+options(digits=22)
+library("Matrix")
+library("matrixStats")
+
+X = matrix(seq(1, 6000)/600, 300, 20, byrow=TRUE);
+
+Y = X/(rowSums(X)%*%matrix(1,1,ncol(X)))
+S = bitwAnd(X, Y);
+
+writeMM(as(S, "CsparseMatrix"), paste(args[2], "S", sep=""));

--- a/src/test/scripts/functions/codegen/rowAggPattern39.dml
+++ b/src/test/scripts/functions/codegen/rowAggPattern39.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = matrix(seq(1, 6000)/600, 300, 20);
+
+Y = X/rowSums(X)
+S = bitwAnd(X, Y);
+
+write(S, $1);


### PR DESCRIPTION
_what is here?_
1. change of opcode's naming to trigger builtin function `hop.OpOp2.BITWAND` to validate against.
2. `dense-dense` matrix primitive for `BitwAnd` operation.
