### PR TITLE
[SYSTEMML-2130] Primitives to check the validity of sparse block representations (CSR)

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
@@ -348,7 +348,7 @@ public class ProgramBlock implements ParseInfo
 			}
 	}
 	
-	private void checkSparsity( Instruction lastInst, LocalVariableMap vars )
+	private static void checkSparsity( Instruction lastInst, LocalVariableMap vars )
 		throws DMLRuntimeException
 	{
 		for( String varname : vars.keySet() )

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
@@ -63,6 +63,7 @@ public class ProgramBlock implements ParseInfo
 	protected ArrayList<Instruction> _inst;
 
 	protected SparseBlock sparseBlock = null;
+	protected SparseBlockCSR sparseBlockCSR = null;
 
 	//additional attributes for recompile
 	protected StatementBlock _sb = null;
@@ -367,14 +368,16 @@ public class ProgramBlock implements ParseInfo
 					synchronized( mb ) { //potential state change
 						mb.recomputeNonZeros();
 						mb.examSparsity();
-						if(sparse1) {
-							int rlen = mb.getNumRows();
-							int clen = mb.getNumColumns();
-							long nnz = mb.getNonZeros();
-							sparseBlock.checkValidity(rlen, clen, nnz, true);
-						}
 
 					}
+					if(sparse1) {
+						int rlen = mb.getNumRows();
+						int clen = mb.getNumColumns();
+						long nnz = mb.getNonZeros();
+						sparseBlock = mb.getSparseBlock();
+						sparseBlock.checkValidity(rlen, clen, nnz, true);
+					}
+
 					boolean sparse2 = mb.isInSparseFormat();
 					long nnz2 = mb.getNonZeros();
 					mo.release();

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
@@ -46,6 +46,8 @@ import org.apache.sysml.runtime.instructions.cp.IntObject;
 import org.apache.sysml.runtime.instructions.cp.ScalarObject;
 import org.apache.sysml.runtime.instructions.cp.StringObject;
 import org.apache.sysml.runtime.matrix.data.MatrixBlock;
+import org.apache.sysml.runtime.matrix.data.SparseBlock;
+import org.apache.sysml.runtime.matrix.data.SparseBlockCSR;
 import org.apache.sysml.utils.Statistics;
 import org.apache.sysml.yarn.DMLAppMasterUtils;
 
@@ -363,6 +365,11 @@ public class ProgramBlock implements ParseInfo
 					synchronized( mb ) { //potential state change
 						mb.recomputeNonZeros();
 						mb.examSparsity();
+//						if(sparse1) {
+//							int rlen = mb.getNumRows();
+//							int clen = mb.getNumColumns();
+//							long nnz = mb.getNonZeros();
+//						}
 					}
 					boolean sparse2 = mb.isInSparseFormat();
 					long nnz2 = mb.getNonZeros();

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
@@ -62,9 +62,6 @@ public class ProgramBlock implements ParseInfo
 	protected Program _prog;		// pointer to Program this ProgramBlock is part of
 	protected ArrayList<Instruction> _inst;
 
-	protected SparseBlock sparseBlock = null;
-	protected SparseBlockCSR sparseBlockCSR = null;
-
 	//additional attributes for recompile
 	protected StatementBlock _sb = null;
 	protected long _tid = 0; //by default _t0
@@ -370,12 +367,11 @@ public class ProgramBlock implements ParseInfo
 						mb.examSparsity();
 
 					}
-					if(sparse1) {
+					if(mb.isInSparseFormat()) {
 						int rlen = mb.getNumRows();
 						int clen = mb.getNumColumns();
 						long nnz = mb.getNonZeros();
-						sparseBlock = mb.getSparseBlock();
-						sparseBlock.checkValidity(rlen, clen, nnz, true);
+						mb.getSparseBlock().checkValidity(rlen, clen, nnz, true);
 					}
 
 					boolean sparse2 = mb.isInSparseFormat();

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
@@ -57,10 +57,12 @@ public class ProgramBlock implements ParseInfo
 	public static final String PRED_VAR = "__pred";
 	
 	protected static final Log LOG = LogFactory.getLog(ProgramBlock.class.getName());
-	private static final boolean CHECK_MATRIX_SPARSITY = false;
+	private static final boolean CHECK_MATRIX_SPARSITY = true;
 
 	protected Program _prog;		// pointer to Program this ProgramBlock is part of
 	protected ArrayList<Instruction> _inst;
+
+	protected SparseBlock sparseBlock = null;
 
 	//additional attributes for recompile
 	protected StatementBlock _sb = null;
@@ -348,7 +350,7 @@ public class ProgramBlock implements ParseInfo
 			}
 	}
 	
-	private static void checkSparsity( Instruction lastInst, LocalVariableMap vars )
+	private void checkSparsity( Instruction lastInst, LocalVariableMap vars )
 		throws DMLRuntimeException
 	{
 		for( String varname : vars.keySet() )
@@ -365,11 +367,13 @@ public class ProgramBlock implements ParseInfo
 					synchronized( mb ) { //potential state change
 						mb.recomputeNonZeros();
 						mb.examSparsity();
-//						if(sparse1) {
-//							int rlen = mb.getNumRows();
-//							int clen = mb.getNumColumns();
-//							long nnz = mb.getNonZeros();
-//						}
+						if(sparse1) {
+							int rlen = mb.getNumRows();
+							int clen = mb.getNumColumns();
+							long nnz = mb.getNonZeros();
+							sparseBlock.checkValidity(rlen, clen, nnz, true);
+						}
+
 					}
 					boolean sparse2 = mb.isInSparseFormat();
 					long nnz2 = mb.getNonZeros();

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlock.java
@@ -247,6 +247,20 @@ public abstract class SparseBlock implements Serializable
 	 */
 	public abstract boolean isEmpty(int r);
 
+	/**
+	 * Validate the correctness of the internal data structures of the different
+	 * sparse block implementations.
+	 *
+	 * @param rlen number of rows
+	 * @param clen number of columns
+	 * @param nnz number of non zeroes
+	 * @param strict
+	 * @return true if the spasity block is a valid one, wrt the corresponding format
+	 *         such as COO, CSR, MCSR.
+	 */
+
+	public abstract boolean checkValidity(int rlen, int clen, long nnz, boolean strict);
+
 	////////////////////////
 	//obtain indexes/values/positions
 	

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlock.java
@@ -254,8 +254,8 @@ public abstract class SparseBlock implements Serializable
 	 * @param rlen number of rows
 	 * @param clen number of columns
 	 * @param nnz number of non zeroes
-	 * @param strict
-	 * @return true if the spasity block is a valid one, wrt the corresponding format
+	 * @param strict enforce optional properties
+	 * @return true if the sparse block is a valid one, wrt the corresponding format
 	 *         such as COO, CSR, MCSR.
 	 */
 

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCOO.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCOO.java
@@ -191,7 +191,13 @@ public class SparseBlockCOO extends SparseBlock
 	public boolean isAllocated(int r) {
 		return true;
 	}
-	
+
+	@Override
+	public boolean checkValidity(int rlen, int clen, long nnz, boolean strict) {
+		//empty implementation
+		return true;
+	}
+
 	@Override 
 	public void reset() {
 		_size = 0;

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
@@ -850,7 +850,7 @@ public class SparseBlockCSR extends SparseBlock
 		}
 
 		//2. correct array lengths
-		if(_size == nnz && _ptr.length > rlen && _values.length  >= nnz && _indexes.length >= nnz ) {
+		if(_size != nnz && _ptr.length < rlen+1 && _values.length < nnz && _indexes.length < nnz ) {
 			throw new RuntimeException("Incorrect array lengths.");
 		}
 

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
@@ -856,8 +856,8 @@ public class SparseBlockCSR extends SparseBlock
 
 		//3. non-decreasing row pointers
 		for( int i=1; i<rlen; i++ ) {
-			if(_ptr[i-1] > _ptr[i])
-				throw new RuntimeException("Row pointers are decreasing at row: "+i+". with pointers"+_ptr[i-1]+" > "+_ptr[i]);
+			if(_ptr[i-1] > _ptr[i] && strict)
+				throw new RuntimeException("Row pointers are decreasing at row: "+i+", with pointers "+_ptr[i-1]+" > "+_ptr[i]);
 		}
 
 		//4. sorted column indexes per row
@@ -869,22 +869,23 @@ public class SparseBlockCSR extends SparseBlock
 					throw new RuntimeException("Wrong sparse row ordering: "+k+" "+_indexes[k-1]+" "+_indexes[k]);
 			for( int k=apos; k<apos+alen; k++ )
 				if( _values[k] == 0 )
-					throw new RuntimeException("Wrong sparse row: zero at "+k+" at col index"+_indexes[k]);
+					throw new RuntimeException("Wrong sparse row: zero at "+k+" at col index "+_indexes[k]);
 		}
 
 		//5. non-existing zero values
 		for( int i=0; i<_values.length; i++ ) {
 			if( _values[i] == 0 ) {
-				throw new RuntimeException("The values array should not contain zeros. The "+i+" the value is "+_values[i]);
+				throw new RuntimeException("The values array should not contain zeros. The "+i+"th value is "+_values[i]);
 			}
 		}
-		
+
 		//6. a capacity that is no larger than nnz times resize factor.
 		int capacity = _values.length;
 		if(capacity > nnz*RESIZE_FACTOR1 ) {
-			throw new RuntimeException("Capacity is larger than the nnz times a resize factor. Current size:"+capacity+", while Expected size:"+nnz*RESIZE_FACTOR1);
+			throw new RuntimeException("Capacity is larger than the nnz times a resize factor. Current size: "+capacity+
+					", while Expected size:"+nnz*RESIZE_FACTOR1);
 		}
-
+		
 		return true;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
@@ -885,7 +885,7 @@ public class SparseBlockCSR extends SparseBlock
 			throw new RuntimeException("Capacity is larger than the nnz times a resize factor. Current size: "+capacity+
 					", while Expected size:"+nnz*RESIZE_FACTOR1);
 		}
-		
+
 		return true;
 	}
 

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockCSR.java
@@ -857,16 +857,15 @@ public class SparseBlockCSR extends SparseBlock
 		}
 
 		//2. correct array lengths
+		int nnz = _size;
 		long esize = estimateMemory(rlen, clen, MatrixBlock.SPARSITY_TURN_POINT);
-		if(_size < esize) {
-			return false;
+		if(_size < esize && _ptr.length > rlen+1 && _values.length  >= nnz && _indexes.length >= nnz ) {
+			throw new RuntimeException("Incorrect array lengths.");
 		}
 
 		//3. non-decreasing row pointers
-		int prevRowPointer = 0;
-		for( int i=0; i<rlen; i++ ) {
-			int apos = _ptr[i];
-			if(prevRowPointer > apos)
+		for( int i=1; i<rlen; i++ ) {
+			if(_ptr[i-1] > _ptr[i])
 				throw new RuntimeException("Row pointers are decreasing.");
 		}
 
@@ -885,15 +884,19 @@ public class SparseBlockCSR extends SparseBlock
 		}
 
 		//5. non-existing zero values
-
-
+		for( int i=0; i<_values.length; i++ ) {
+			if( _values[i] != 0 ) {
+				throw new RuntimeException("The values array should not contain zeros.");
+			}
+		}
+		
 		//6. a capacity that is no larger than nnz times resize factor.
-		int capacity = _values.length; int nnz = _size;
-		if(capacity > nnz*RESIZE_FACTOR1) {
-			throw new RuntimeException("capacity is larget than the nnz times a resize factor.");
+		int capacity = _values.length;
+		if(capacity > nnz*RESIZE_FACTOR1 ) {
+			throw new RuntimeException("capacity is larger than the nnz times a resize factor.");
 		}
 
-		return false;
+		return true;
 	}
 
 	///////////////////////////

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockMCSR.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/SparseBlockMCSR.java
@@ -157,7 +157,13 @@ public class SparseBlockMCSR extends SparseBlock
 	public boolean isAllocated(int r) {
 		return (_rows[r] != null);
 	}
-	
+
+	@Override
+	public boolean checkValidity(int rlen, int clen, long nnz, boolean strict) {
+		// empty implementation
+		return true;
+	}
+
 	@Override 
 	public void reset() {
 		for( SparseRow row : _rows )


### PR DESCRIPTION
Contains `checkValidity()` method for `SparseBlockCSR` class