### PR TITLE
[SYSTEMML-2159] Extend test cases for FA and FNR

### DIFF
--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmARIMA.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmARIMA.java
@@ -31,9 +31,17 @@ import org.apache.sysml.test.integration.applications.ArimaTest;
 public class AlgorithmARIMA extends ArimaTest 
 {
 	private final static String LOCAL_TEST_DIR = "functions/codegenalg/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + LOCAL_TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + LOCAL_TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + LOCAL_TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + LOCAL_TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	public AlgorithmARIMA(int m, int p, int d, int q, int P, int D, int Q, int s, int include_mean, int useJacobi) {
 		super(m, p, d, q, P, D, Q, s, include_mean, useJacobi);
 		TEST_CLASS_DIR = TEST_DIR + AlgorithmARIMA.class.getSimpleName() + "/";
@@ -41,12 +49,35 @@ public class AlgorithmARIMA extends ArimaTest
 
 	@Test
 	public void testArimaDml() {
+		testArima(ScriptType.DML, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testArimaDmlFuseAll() {
+		testArima(ScriptType.DML, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testArimaDmlFuseNoRedundancy() {
+		testArima(ScriptType.DML, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	private void testArima(ScriptType scriptType, TestType testType){
 		testArima(ScriptType.DML);
 	}
 	
 	@Override
 	protected File getConfigTemplateFile() {
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmAutoEncoder.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmAutoEncoder.java
@@ -36,9 +36,17 @@ public class AlgorithmAutoEncoder extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_AutoEncoder";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmAutoEncoder.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	private final static int rows = 2468;
 	private final static int cols = 784;
 	
@@ -57,42 +65,42 @@ public class AlgorithmAutoEncoder extends AutomatedTestBase
 
 	@Test
 	public void testAutoEncoder256DenseCP() {
-		runGLMTest(256, false, false, ExecType.CP);
+		runAutoEncoderTest(256, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder256DenseRewritesCP() {
-		runGLMTest(256, false, true, ExecType.CP);
+		runAutoEncoderTest(256, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder256SparseCP() {
-		runGLMTest(256, true, false, ExecType.CP);
+		runAutoEncoderTest(256, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder256SparseRewritesCP() {
-		runGLMTest(256, true, true, ExecType.CP);
+		runAutoEncoderTest(256, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder512DenseCP() {
-		runGLMTest(512, false, false, ExecType.CP);
+		runAutoEncoderTest(512, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder512DenseRewritesCP() {
-		runGLMTest(512, false, true, ExecType.CP);
+		runAutoEncoderTest(512, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder512SparseCP() {
-		runGLMTest(512, true, false, ExecType.CP);
+		runAutoEncoderTest(512, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder512SparseRewritesCP() {
-		runGLMTest(512, true, true, ExecType.CP);
+		runAutoEncoderTest(512, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	//Note: limited cases for SPARK, as lazy evaluation 
@@ -100,25 +108,98 @@ public class AlgorithmAutoEncoder extends AutomatedTestBase
 	
 	@Test
 	public void testAutoEncoder256DenseRewritesSpark() {
-		runGLMTest(256, false, true, ExecType.SPARK);
+		runAutoEncoderTest(256, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder256SparseRewritesSpark() {
-		runGLMTest(256, true, true, ExecType.SPARK);
+		runAutoEncoderTest(256, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder512DenseRewritesSpark() {
-		runGLMTest(512, false, true, ExecType.SPARK);
+		runAutoEncoderTest(512, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testAutoEncoder512SparseRewritesSpark() {
-		runGLMTest(512, true, true, ExecType.SPARK);
+		runAutoEncoderTest(512, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
-	
-	private void runGLMTest(int batchsize, boolean sparse, boolean rewrites, ExecType instType)
+
+	@Test
+	public void testAutoEncoder512DenseCPFuseAll() {
+		runAutoEncoderTest(512, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testAutoEncoder512DenseRewritesCPFuseAll() {
+		runAutoEncoderTest(512, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testAutoEncoder512SparseCPFuseAll() {
+		runAutoEncoderTest(512, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testAutoEncoder512SparseRewritesCPFuseAll() {
+		runAutoEncoderTest(512, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testAutoEncoder512DenseRewritesSparkFuseAll() {
+		runAutoEncoderTest(512, false, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testAutoEncoder512SparseRewritesSparkFuseAll() {
+		runAutoEncoderTest(512, true, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testAutoEncoder512DenseCPFuseNoRedundancy() {
+		runAutoEncoderTest(512, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testAutoEncoder512DenseRewritesCPFuseNoRedundancy() {
+		runAutoEncoderTest(512, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testAutoEncoder512SparseCFuseNoRedundancyP() {
+		runAutoEncoderTest(512, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testAutoEncoder512SparseRewritesCPFuseNoRedundancy() {
+		runAutoEncoderTest(512, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	//Note: limited cases for SPARK, as lazy evaluation
+	//causes very long execution time for this algorithm
+
+	@Test
+	public void testAutoEncoder256DenseRewritesSparkFuseNoRedundancy() {
+		runAutoEncoderTest(256, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testAutoEncoder256SparseRewritesSparkFuseNoRedundancy() {
+		runAutoEncoderTest(256, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testAutoEncoder512DenseRewritesSparkFuseNoRedundancy() {
+		runAutoEncoderTest(512, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testAutoEncoder512SparseRewritesSparkFuseNoRedundancy() {
+		runAutoEncoderTest(512, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	private void runAutoEncoderTest(int batchsize, boolean sparse, boolean rewrites, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -127,7 +208,9 @@ public class AlgorithmAutoEncoder extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
-	
+
+		currentTestType = testType;
+
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
@@ -174,7 +257,16 @@ public class AlgorithmAutoEncoder extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmDatagen.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmDatagen.java
@@ -36,9 +36,17 @@ public class AlgorithmDatagen extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_Datagen";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmDatagen.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	private final static int rows = 2468;
 	private final static int cols = 200;
 	
@@ -58,85 +66,245 @@ public class AlgorithmDatagen extends AutomatedTestBase
 
 	@Test
 	public void testDatagenLinregDenseRewritesCP() {
-		runStepwiseTest(DatagenType.LINREG, false, true, ExecType.CP);
+		runStepwiseTest(DatagenType.LINREG, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLinregSparseRewritesCP() {
-		runStepwiseTest(DatagenType.LINREG, true, true, ExecType.CP);
+		runStepwiseTest(DatagenType.LINREG, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLinregDenseNoRewritesCP() {
-		runStepwiseTest(DatagenType.LINREG, false, false, ExecType.CP);
+		runStepwiseTest(DatagenType.LINREG, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLinregSparseNoRewritesCP() {
-		runStepwiseTest(DatagenType.LINREG, true, false, ExecType.CP);
+		runStepwiseTest(DatagenType.LINREG, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLogregDenseRewritesCP() {
-		runStepwiseTest(DatagenType.LOGREG, false, true, ExecType.CP);
+		runStepwiseTest(DatagenType.LOGREG, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLogregSparseRewritesCP() {
-		runStepwiseTest(DatagenType.LOGREG, true, true, ExecType.CP);
+		runStepwiseTest(DatagenType.LOGREG, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLogregDenseNoRewritesCP() {
-		runStepwiseTest(DatagenType.LOGREG, false, false, ExecType.CP);
+		runStepwiseTest(DatagenType.LOGREG, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLogregSparseNoRewritesCP() {
-		runStepwiseTest(DatagenType.LOGREG, true, false, ExecType.CP);
+		runStepwiseTest(DatagenType.LOGREG, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 
 	@Test
 	public void testDatagenLinregDenseRewritesSP() {
-		runStepwiseTest(DatagenType.LINREG, false, true, ExecType.SPARK);
+		runStepwiseTest(DatagenType.LINREG, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLinregSparseRewritesSP() {
-		runStepwiseTest(DatagenType.LINREG, true, true, ExecType.SPARK);
+		runStepwiseTest(DatagenType.LINREG, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLinregDenseNoRewritesSP() {
-		runStepwiseTest(DatagenType.LINREG, false, false, ExecType.SPARK);
+		runStepwiseTest(DatagenType.LINREG, false, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLinregSparseNoRewritesSP() {
-		runStepwiseTest(DatagenType.LINREG, true, false, ExecType.SPARK);
+		runStepwiseTest(DatagenType.LINREG, true, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLogregDenseRewritesSP() {
-		runStepwiseTest(DatagenType.LOGREG, false, true, ExecType.SPARK);
+		runStepwiseTest(DatagenType.LOGREG, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLogregSparseRewritesSP() {
-		runStepwiseTest(DatagenType.LOGREG, true, true, ExecType.SPARK);
+		runStepwiseTest(DatagenType.LOGREG, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLogregDenseNoRewritesSP() {
-		runStepwiseTest(DatagenType.LOGREG, false, false, ExecType.SPARK);
+		runStepwiseTest(DatagenType.LOGREG, false, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testDatagenLogregSparseNoRewritesSP() {
-		runStepwiseTest(DatagenType.LOGREG, true, false, ExecType.SPARK);
+		runStepwiseTest(DatagenType.LOGREG, true, false, ExecType.SPARK, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testDatagenLinregDenseRewritesCPFuseAll() {
+		runStepwiseTest(DatagenType.LINREG, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLinregSparseRewritesCPFuseAll() {
+		runStepwiseTest(DatagenType.LINREG, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLinregDenseNoRewritesCPFuseAll() {
+		runStepwiseTest(DatagenType.LINREG, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLinregSparseNoRewritesCPFuseAll() {
+		runStepwiseTest(DatagenType.LINREG, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLogregDenseRewritesCPFuseAll() {
+		runStepwiseTest(DatagenType.LOGREG, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLogregSparseRewritesCPFuseAll() {
+		runStepwiseTest(DatagenType.LOGREG, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLogregDenseNoRewritesCPFuseAll() {
+		runStepwiseTest(DatagenType.LOGREG, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLogregSparseNoRewritesCPFuseAll() {
+		runStepwiseTest(DatagenType.LOGREG, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLinregDenseRewritesSPFuseAll() {
+		runStepwiseTest(DatagenType.LINREG, false, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLinregSparseRewritesSPFuseAll() {
+		runStepwiseTest(DatagenType.LINREG, true, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLinregDenseNoRewritesSPFuseAll() {
+		runStepwiseTest(DatagenType.LINREG, false, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLinregSparseNoRewritesSPFuseAll() {
+		runStepwiseTest(DatagenType.LINREG, true, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testDatagenLogregDenseRewritesSPFuseAll() {
+		runStepwiseTest(DatagenType.LOGREG, false, true, ExecType.SPARK, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testDatagenLogregSparseRewritesSPFuseAll() {
+		runStepwiseTest(DatagenType.LOGREG, true, true, ExecType.SPARK, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testDatagenLogregDenseNoRewritesSPFuseAll() {
+		runStepwiseTest(DatagenType.LOGREG, false, false, ExecType.SPARK, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testDatagenLogregSparseNoRewritesSPFuseAll() {
+		runStepwiseTest(DatagenType.LOGREG, true, false, ExecType.SPARK, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testDatagenLinregDenseRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LINREG, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLinregSparseRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LINREG, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLinregDenseNoRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LINREG, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLinregSparseNoRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LINREG, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLogregDenseRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LOGREG, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLogregSparseRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LOGREG, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLogregDenseNoRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LOGREG, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLogregSparseNoRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LOGREG, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLinregDenseRewritesSPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LINREG, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLinregSparseRewritesSPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LINREG, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLinregDenseNoRewritesSPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LINREG, false, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLinregSparseNoRewritesSPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LINREG, true, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLogregDenseRewritesSPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LOGREG, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLogregSparseRewritesSPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LOGREG, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLogregDenseNoRewritesSPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LOGREG, false, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testDatagenLogregSparseNoRewritesSPFuseNoRedundancy() {
+		runStepwiseTest(DatagenType.LOGREG, true, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
 	}
 	
-	private void runStepwiseTest( DatagenType type, boolean sparse, boolean rewrites, ExecType instType)
+	private void runStepwiseTest( DatagenType type, boolean sparse, boolean rewrites, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -144,7 +312,7 @@ public class AlgorithmDatagen extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
-		
+		currentTestType = testType;
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
@@ -193,7 +361,16 @@ public class AlgorithmDatagen extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmGLM.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmGLM.java
@@ -36,9 +36,17 @@ public class AlgorithmGLM extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_GLM";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmGLM.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	//private final static double eps = 1e-5;
 	
 	private final static int rows = 2468;
@@ -65,125 +73,364 @@ public class AlgorithmGLM extends AutomatedTestBase
 
 	@Test
 	public void testGLMPoissonDenseRewritesCP() {
-		runGLMTest(GLMType.POISSON_LOG, true, false, ExecType.CP);
+		runGLMTest(GLMType.POISSON_LOG, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMPoissonSparseRewritesCP() {
-		runGLMTest(GLMType.POISSON_LOG, true, true, ExecType.CP);
+		runGLMTest(GLMType.POISSON_LOG, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMPoissonDenseCP() {
-		runGLMTest(GLMType.POISSON_LOG, false, false, ExecType.CP);
+		runGLMTest(GLMType.POISSON_LOG, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMPoissonSparseCP() {
-		runGLMTest(GLMType.POISSON_LOG, false, true, ExecType.CP);
+		runGLMTest(GLMType.POISSON_LOG, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMGammaDenseRewritesCP() {
-		runGLMTest(GLMType.GAMMA_LOG, true, false, ExecType.CP);
+		runGLMTest(GLMType.GAMMA_LOG, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMGammaSparseRewritesCP() {
-		runGLMTest(GLMType.GAMMA_LOG, true, true, ExecType.CP);
+		runGLMTest(GLMType.GAMMA_LOG, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMGammaDenseCP() {
-		runGLMTest(GLMType.GAMMA_LOG, false, false, ExecType.CP);
+		runGLMTest(GLMType.GAMMA_LOG, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMGammaSparseCP() {
-		runGLMTest(GLMType.GAMMA_LOG, false, true, ExecType.CP);
+		runGLMTest(GLMType.GAMMA_LOG, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMBinomialDenseRewritesCP() {
-		runGLMTest(GLMType.BINOMIAL_PROBIT, true, false, ExecType.CP);
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMBinomialSparseRewritesCP() {
-		runGLMTest(GLMType.BINOMIAL_PROBIT, true, true, ExecType.CP);
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMBinomialDenseCP() {
-		runGLMTest(GLMType.BINOMIAL_PROBIT, false, false, ExecType.CP);
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMBinomialSparseCP() {
-		runGLMTest(GLMType.BINOMIAL_PROBIT, false, true, ExecType.CP);
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMPoissonDenseRewritesSP() {
-		runGLMTest(GLMType.POISSON_LOG, true, false, ExecType.SPARK);
+		runGLMTest(GLMType.POISSON_LOG, true, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMPoissonSparseRewritesSP() {
-		runGLMTest(GLMType.POISSON_LOG, true, true, ExecType.SPARK);
+		runGLMTest(GLMType.POISSON_LOG, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMPoissonDenseSP() {
-		runGLMTest(GLMType.POISSON_LOG, false, false, ExecType.SPARK);
+		runGLMTest(GLMType.POISSON_LOG, false, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMPoissonSparseSP() {
-		runGLMTest(GLMType.POISSON_LOG, false, true, ExecType.SPARK);
+		runGLMTest(GLMType.POISSON_LOG, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMGammaDenseRewritesSP() {
-		runGLMTest(GLMType.GAMMA_LOG, true, false, ExecType.SPARK);
+		runGLMTest(GLMType.GAMMA_LOG, true, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMGammaSparseRewritesSP() {
-		runGLMTest(GLMType.GAMMA_LOG, true, true, ExecType.SPARK);
+		runGLMTest(GLMType.GAMMA_LOG, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMGammaDenseSP() {
-		runGLMTest(GLMType.GAMMA_LOG, false, false, ExecType.SPARK);
+		runGLMTest(GLMType.GAMMA_LOG, false, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMGammaSparseSP() {
-		runGLMTest(GLMType.GAMMA_LOG, false, true, ExecType.SPARK);
+		runGLMTest(GLMType.GAMMA_LOG, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMBinomialDenseRewritesSP() {
-		runGLMTest(GLMType.BINOMIAL_PROBIT, true, false, ExecType.SPARK);
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMBinomialSparseRewritesSP() {
-		runGLMTest(GLMType.BINOMIAL_PROBIT, true, true, ExecType.SPARK);
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMBinomialDenseSP() {
-		runGLMTest(GLMType.BINOMIAL_PROBIT, false, false, ExecType.SPARK);
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testGLMBinomialSparseSP() {
-		runGLMTest(GLMType.BINOMIAL_PROBIT, false, true, ExecType.SPARK);
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
-	
-	private void runGLMTest( GLMType type, boolean rewrites, boolean sparse, ExecType instType)
+
+	@Test
+	public void testGLMPoissonDenseRewritesCPFuseAll() {
+		runGLMTest(GLMType.POISSON_LOG, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMPoissonSparseRewritesCPFuseAll() {
+		runGLMTest(GLMType.POISSON_LOG, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMPoissonDenseCPFuseAll() {
+		runGLMTest(GLMType.POISSON_LOG, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMPoissonSparseCPFuseAll() {
+		runGLMTest(GLMType.POISSON_LOG, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMGammaDenseRewritesCPFuseAll() {
+		runGLMTest(GLMType.GAMMA_LOG, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMGammaSparseRewritesCPFuseAll() {
+		runGLMTest(GLMType.GAMMA_LOG, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMGammaDenseCPFuseAll() {
+		runGLMTest(GLMType.GAMMA_LOG, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMGammaSparseCPFuseAll() {
+		runGLMTest(GLMType.GAMMA_LOG, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMBinomialDenseRewritesCPFuseAll() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMBinomialSparseRewritesCPFuseAll() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMBinomialDenseCPFuseAll() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMBinomialSparseCPFuseAll() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMPoissonDenseRewritesSPFuseAll() {
+		runGLMTest(GLMType.POISSON_LOG, true, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMPoissonSparseRewritesSPFuseAll() {
+		runGLMTest(GLMType.POISSON_LOG, true, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMPoissonDenseSPFuseAll() {
+		runGLMTest(GLMType.POISSON_LOG, false, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMPoissonSparseSPFuseAll() {
+		runGLMTest(GLMType.POISSON_LOG, false, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMGammaDenseRewritesSPFuseAll() {
+		runGLMTest(GLMType.GAMMA_LOG, true, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMGammaSparseRewritesSPFuseAll() {
+		runGLMTest(GLMType.GAMMA_LOG, true, true, ExecType.SPARK, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testGLMGammaDenseSPFuseAll() {
+		runGLMTest(GLMType.GAMMA_LOG, false, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMGammaSparseSPFuseAll() {
+		runGLMTest(GLMType.GAMMA_LOG, false, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMBinomialDenseRewritesSPFuseAll() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMBinomialSparseRewritesSPFuseAll() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMBinomialDenseSPFuseAll() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMBinomialSparseSPFuseAll() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testGLMPoissonDenseRewritesCPFuseNoRedundancy() {
+		runGLMTest(GLMType.POISSON_LOG, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMPoissonSparseRewritesCPFuseNoRedundancy() {
+		runGLMTest(GLMType.POISSON_LOG, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMPoissonDenseCPFuseNoRedundancy() {
+		runGLMTest(GLMType.POISSON_LOG, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMPoissonSparseCPFuseNoRedundancy() {
+		runGLMTest(GLMType.POISSON_LOG, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMGammaDenseRewritesCPFuseNoRedundancy() {
+		runGLMTest(GLMType.GAMMA_LOG, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMGammaSparseRewritesCPFuseNoRedundancy() {
+		runGLMTest(GLMType.GAMMA_LOG, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMGammaDenseCPFuseNoRedundancy() {
+		runGLMTest(GLMType.GAMMA_LOG, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMGammaSparseCPFuseNoRedundancy() {
+		runGLMTest(GLMType.GAMMA_LOG, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMBinomialDenseRewritesCPFuseNoRedundancy() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMBinomialSparseRewritesCPFuseNoRedundancy() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMBinomialDenseCPFuseNoRedundancy() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMBinomialSparseCPFuseNoRedundancy() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMPoissonDenseRewritesSPFuseNoRedundancy() {
+		runGLMTest(GLMType.POISSON_LOG, true, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMPoissonSparseRewritesSPFuseNoRedundancy() {
+		runGLMTest(GLMType.POISSON_LOG, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMPoissonDenseSPFuseNoRedundancy() {
+		runGLMTest(GLMType.POISSON_LOG, false, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMPoissonSparseSPFuseNoRedundancy() {
+		runGLMTest(GLMType.POISSON_LOG, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMGammaDenseRewritesSPFuseNoRedundancy() {
+		runGLMTest(GLMType.GAMMA_LOG, true, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMGammaSparseRewritesSPFuseNoRedundancy() {
+		runGLMTest(GLMType.GAMMA_LOG, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMGammaDenseSPFuseNoRedundancy() {
+		runGLMTest(GLMType.GAMMA_LOG, false, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMGammaSparseSPFuseNoRedundancy() {
+		runGLMTest(GLMType.GAMMA_LOG, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMBinomialDenseRewritesSPFuseNoRedundancy() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMBinomialSparseRewritesSPFuseNoRedundancy() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMBinomialDenseSPFuseNoRedundancy() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testGLMBinomialSparseSPFuseNoRedundancy() {
+		runGLMTest(GLMType.BINOMIAL_PROBIT, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+	private void runGLMTest( GLMType type, boolean rewrites, boolean sparse, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -192,7 +439,7 @@ public class AlgorithmGLM extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
-	
+		currentTestType = testType;
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
@@ -260,7 +507,16 @@ public class AlgorithmGLM extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmKMeans.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmKMeans.java
@@ -36,9 +36,17 @@ public class AlgorithmKMeans extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_KMeans";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmKMeans.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	//private final static double eps = 1e-5;
 	
 	private final static int rows = 3972;
@@ -58,85 +66,245 @@ public class AlgorithmKMeans extends AutomatedTestBase
 
 	@Test
 	public void testKMeansDenseBinSingleRewritesCP() {
-		runKMeansTest(TEST_NAME1, true, false, 2, 1, ExecType.CP);
+		runKMeansTest(TEST_NAME1, true, false, 2, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansSparseBinSingleRewritesCP() {
-		runKMeansTest(TEST_NAME1, true, true, 2, 1, ExecType.CP);
+		runKMeansTest(TEST_NAME1, true, true, 2, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansDenseBinSingleCP() {
-		runKMeansTest(TEST_NAME1, false, false, 2, 1, ExecType.CP);
+		runKMeansTest(TEST_NAME1, false, false, 2, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansSparseBinSingleCP() {
-		runKMeansTest(TEST_NAME1, false, true, 2, 1, ExecType.CP);
+		runKMeansTest(TEST_NAME1, false, true, 2, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansDenseBinMultiRewritesCP() {
-		runKMeansTest(TEST_NAME1, true, false, 2, 10, ExecType.CP);
+		runKMeansTest(TEST_NAME1, true, false, 2, 10, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansSparseBinMultiRewritesCP() {
-		runKMeansTest(TEST_NAME1, true, true, 2, 10, ExecType.CP);
+		runKMeansTest(TEST_NAME1, true, true, 2, 10, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansDenseBinMultiCP() {
-		runKMeansTest(TEST_NAME1, false, false, 2, 10, ExecType.CP);
+		runKMeansTest(TEST_NAME1, false, false, 2, 10, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansSparseBinMultiCP() {
-		runKMeansTest(TEST_NAME1, false, true, 2, 10, ExecType.CP);
+		runKMeansTest(TEST_NAME1, false, true, 2, 10, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansDenseMulSingleRewritesCP() {
-		runKMeansTest(TEST_NAME1, true, false, 20, 1, ExecType.CP);
+		runKMeansTest(TEST_NAME1, true, false, 20, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansSparseMulSingleRewritesCP() {
-		runKMeansTest(TEST_NAME1, true, true, 20, 1, ExecType.CP);
+		runKMeansTest(TEST_NAME1, true, true, 20, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansDenseMulSingleCP() {
-		runKMeansTest(TEST_NAME1, false, false, 20, 1, ExecType.CP);
+		runKMeansTest(TEST_NAME1, false, false, 20, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansSparseMulSingleCP() {
-		runKMeansTest(TEST_NAME1, false, true, 20, 1, ExecType.CP);
+		runKMeansTest(TEST_NAME1, false, true, 20, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansDenseMulMultiRewritesCP() {
-		runKMeansTest(TEST_NAME1, true, false, 20, 10, ExecType.CP);
+		runKMeansTest(TEST_NAME1, true, false, 20, 10, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansSparseMulMultiRewritesCP() {
-		runKMeansTest(TEST_NAME1, true, true, 20, 10, ExecType.CP);
+		runKMeansTest(TEST_NAME1, true, true, 20, 10, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansDenseMulMultiCP() {
-		runKMeansTest(TEST_NAME1, false, false, 20, 10, ExecType.CP);
+		runKMeansTest(TEST_NAME1, false, false, 20, 10, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testKMeansSparseMulMultiCP() {
-		runKMeansTest(TEST_NAME1, false, true, 20, 10, ExecType.CP);
+		runKMeansTest(TEST_NAME1, false, true, 20, 10, ExecType.CP, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testKMeansDenseBinSingleRewritesCPFuseAll() {
+		runKMeansTest(TEST_NAME1, true, false, 2, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansSparseBinSingleRewritesCPFuseAll() {
+		runKMeansTest(TEST_NAME1, true, true, 2, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansDenseBinSingleCPFuseAll() {
+		runKMeansTest(TEST_NAME1, false, false, 2, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansSparseBinSingleCPFuseAll() {
+		runKMeansTest(TEST_NAME1, false, true, 2, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansDenseBinMultiRewritesCPFuseAll() {
+		runKMeansTest(TEST_NAME1, true, false, 2, 10, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansSparseBinMultiRewritesCPFuseAll() {
+		runKMeansTest(TEST_NAME1, true, true, 2, 10, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansDenseBinMultiCPFuseAll() {
+		runKMeansTest(TEST_NAME1, false, false, 2, 10, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansSparseBinMultiCPFuseAll() {
+		runKMeansTest(TEST_NAME1, false, true, 2, 10, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansDenseMulSingleRewritesCPFuseAll() {
+		runKMeansTest(TEST_NAME1, true, false, 20, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansSparseMulSingleRewritesCPFuseAll() {
+		runKMeansTest(TEST_NAME1, true, true, 20, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansDenseMulSingleCPFuseAll() {
+		runKMeansTest(TEST_NAME1, false, false, 20, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansSparseMulSingleCPFuseAll() {
+		runKMeansTest(TEST_NAME1, false, true, 20, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansDenseMulMultiRewritesCPFuseAll() {
+		runKMeansTest(TEST_NAME1, true, false, 20, 10, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansSparseMulMultiRewritesCPFuseAll() {
+		runKMeansTest(TEST_NAME1, true, true, 20, 10, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansDenseMulMultiCPFuseAll() {
+		runKMeansTest(TEST_NAME1, false, false, 20, 10, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansSparseMulMultiCPFuseAll() {
+		runKMeansTest(TEST_NAME1, false, true, 20, 10, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testKMeansDenseBinSingleRewritesCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, true, false, 2, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansSparseBinSingleRewritesCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, true, true, 2, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansDenseBinSingleCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, false, false, 2, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansSparseBinSingleCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, false, true, 2, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansDenseBinMultiRewritesCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, true, false, 2, 10, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansSparseBinMultiRewritesCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, true, true, 2, 10, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansDenseBinMultiCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, false, false, 2, 10, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansSparseBinMultiCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, false, true, 2, 10, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansDenseMulSingleRewritesCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, true, false, 20, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansSparseMulSingleRewritesCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, true, true, 20, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansDenseMulSingleCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, false, false, 20, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansSparseMulSingleCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, false, true, 20, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansDenseMulMultiRewritesCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, true, false, 20, 10, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansSparseMulMultiRewritesCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, true, true, 20, 10, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansDenseMulMultiCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, false, false, 20, 10, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testKMeansSparseMulMultiCPFuseNoRedundancy() {
+		runKMeansTest(TEST_NAME1, false, true, 20, 10, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
 	}
 	
-	private void runKMeansTest( String testname, boolean rewrites, boolean sparse, int centroids, int runs, ExecType instType)
+	private void runKMeansTest( String testname, boolean rewrites, boolean sparse, int centroids, int runs, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -145,7 +313,7 @@ public class AlgorithmKMeans extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
-	
+		currentTestType = testType;
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
@@ -191,7 +359,16 @@ public class AlgorithmKMeans extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmL2SVM.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmL2SVM.java
@@ -38,8 +38,16 @@ public class AlgorithmL2SVM extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_L2SVM";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmL2SVM.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
 	
 	private final static double eps = 1e-5;
 	
@@ -62,45 +70,126 @@ public class AlgorithmL2SVM extends AutomatedTestBase
 
 	@Test
 	public void testL2SVMDenseRewritesCP() {
-		runL2SVMTest(TEST_NAME1, true, false, ExecType.CP);
+		runL2SVMTest(TEST_NAME1, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testL2SVMSparseRewritesCP() {
-		runL2SVMTest(TEST_NAME1, true, true, ExecType.CP);
+		runL2SVMTest(TEST_NAME1, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testL2SVMDenseCP() {
-		runL2SVMTest(TEST_NAME1, false, false, ExecType.CP);
+		runL2SVMTest(TEST_NAME1, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testL2SVMSparseCP() {
-		runL2SVMTest(TEST_NAME1, false, true, ExecType.CP);
+		runL2SVMTest(TEST_NAME1, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 
 	@Test
 	public void testL2SVMDenseRewritesSP() {
-		runL2SVMTest(TEST_NAME1, true, false, ExecType.SPARK);
+		runL2SVMTest(TEST_NAME1, true, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testL2SVMSparseRewritesSP() {
-		runL2SVMTest(TEST_NAME1, true, true, ExecType.SPARK);
+		runL2SVMTest(TEST_NAME1, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testL2SVMDenseSP() {
-		runL2SVMTest(TEST_NAME1, false, false, ExecType.SPARK);
+		runL2SVMTest(TEST_NAME1, false, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testL2SVMSparseSP() {
-		runL2SVMTest(TEST_NAME1, false, true, ExecType.SPARK);
+		runL2SVMTest(TEST_NAME1, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
+
+	@Test
+	public void testL2SVMDenseRewritesCPFuseAll() {
+		runL2SVMTest(TEST_NAME1, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testL2SVMSparseRewritesCPFuseAll() {
+		runL2SVMTest(TEST_NAME1, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testL2SVMDenseCPFuseAll() {
+		runL2SVMTest(TEST_NAME1, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testL2SVMSparseCPFuseAll() {
+		runL2SVMTest(TEST_NAME1, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testL2SVMDenseRewritesSPFuseAll() {
+		runL2SVMTest(TEST_NAME1, true, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testL2SVMSparseRewritesSPFuseAll() {
+		runL2SVMTest(TEST_NAME1, true, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testL2SVMDenseSPFuseAll() {
+		runL2SVMTest(TEST_NAME1, false, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testL2SVMSparseSPFuseAll() {
+		runL2SVMTest(TEST_NAME1, false, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testL2SVMDenseRewritesCPFuseNoRedundancy() {
+		runL2SVMTest(TEST_NAME1, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testL2SVMSparseRewritesCPFuseNoRedundancy() {
+		runL2SVMTest(TEST_NAME1, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testL2SVMDenseCPFuseNoRedundancy() {
+		runL2SVMTest(TEST_NAME1, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testL2SVMSparseCPFuseNoRedundancy() {
+		runL2SVMTest(TEST_NAME1, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testL2SVMDenseRewritesSPFuseNoRedundancy() {
+		runL2SVMTest(TEST_NAME1, true, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testL2SVMSparseRewritesSPFuseNoRedundancy() {
+		runL2SVMTest(TEST_NAME1, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testL2SVMDenseSPFuseNoRedundancy() {
+		runL2SVMTest(TEST_NAME1, false, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testL2SVMSparseSPFuseNoRedundancy() {
+		runL2SVMTest(TEST_NAME1, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
 	
-	private void runL2SVMTest( String testname, boolean rewrites, boolean sparse, ExecType instType)
+	private void runL2SVMTest( String testname, boolean rewrites, boolean sparse, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -109,6 +198,7 @@ public class AlgorithmL2SVM extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
+		currentTestType = testType;
 	
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
@@ -162,7 +252,16 @@ public class AlgorithmL2SVM extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmLinregCG.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmLinregCG.java
@@ -38,9 +38,17 @@ public class AlgorithmLinregCG extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_LinregCG";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmLinregCG.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	private final static double eps = 1e-1;
 	
 	private final static int rows = 2468;
@@ -60,125 +68,365 @@ public class AlgorithmLinregCG extends AutomatedTestBase
 
 	@Test
 	public void testLinregCG0DenseRewritesCP() {
-		runLinregCGTest(TEST_NAME1, true, false, 0, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, true, false, 0, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG0SparseRewritesCP() {
-		runLinregCGTest(TEST_NAME1, true, true, 0, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, true, true, 0, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG0DenseCP() {
-		runLinregCGTest(TEST_NAME1, false, false, 0, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, false, false, 0, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG0SparseCP() {
-		runLinregCGTest(TEST_NAME1, false, true, 0, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, false, true, 0, ExecType.CP, TestType.DEFAULT);
 	}
 
 	@Test
 	public void testLinregCG0DenseRewritesSP() {
-		runLinregCGTest(TEST_NAME1, true, false, 0, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, true, false, 0, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG0SparseRewritesSP() {
-		runLinregCGTest(TEST_NAME1, true, true, 0, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, true, true, 0, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG0DenseSP() {
-		runLinregCGTest(TEST_NAME1, false, false, 0, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, false, false, 0, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG0SparseSP() {
-		runLinregCGTest(TEST_NAME1, false, true, 0, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, false, true, 0, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG1DenseRewritesCP() {
-		runLinregCGTest(TEST_NAME1, true, false, 1, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, true, false, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG1SparseRewritesCP() {
-		runLinregCGTest(TEST_NAME1, true, true, 1, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, true, true, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG1DenseCP() {
-		runLinregCGTest(TEST_NAME1, false, false, 1, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, false, false, 1, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG1SparseCP() {
-		runLinregCGTest(TEST_NAME1, false, true, 1, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, false, true, 1, ExecType.CP, TestType.DEFAULT);
 	}
 
 	@Test
 	public void testLinregCG1DenseRewritesSP() {
-		runLinregCGTest(TEST_NAME1, true, false, 1, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, true, false, 1, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG1SparseRewritesSP() {
-		runLinregCGTest(TEST_NAME1, true, true, 1, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, true, true, 1, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG1DenseSP() {
-		runLinregCGTest(TEST_NAME1, false, false, 1, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, false, false, 1, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG1SparseSP() {
-		runLinregCGTest(TEST_NAME1, false, true, 1, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, false, true, 1, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG2DenseRewritesCP() {
-		runLinregCGTest(TEST_NAME1, true, false, 2, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, true, false, 2, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG2SparseRewritesCP() {
-		runLinregCGTest(TEST_NAME1, true, true, 2, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, true, true, 2, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG2DenseCP() {
-		runLinregCGTest(TEST_NAME1, false, false, 2, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, false, false, 2, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG2SparseCP() {
-		runLinregCGTest(TEST_NAME1, false, true, 2, ExecType.CP);
+		runLinregCGTest(TEST_NAME1, false, true, 2, ExecType.CP, TestType.DEFAULT);
 	}
 
 	@Test
 	public void testLinregCG2DenseRewritesSP() {
-		runLinregCGTest(TEST_NAME1, true, false, 2, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, true, false, 2, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG2SparseRewritesSP() {
-		runLinregCGTest(TEST_NAME1, true, true, 2, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, true, true, 2, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG2DenseSP() {
-		runLinregCGTest(TEST_NAME1, false, false, 2, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, false, false, 2, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testLinregCG2SparseSP() {
-		runLinregCGTest(TEST_NAME1, false, true, 2, ExecType.SPARK);
+		runLinregCGTest(TEST_NAME1, false, true, 2, ExecType.SPARK, TestType.DEFAULT);
 	}
-	
-	private void runLinregCGTest( String testname, boolean rewrites, boolean sparse, int intercept, ExecType instType)
+
+	@Test
+	public void testLinregCG0DenseRewritesCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, false, 0, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG0SparseRewritesCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, true, 0, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG0DenseCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, false, 0, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG0SparseCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, true, 0, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG0DenseRewritesSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, false, 0, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG0SparseRewritesSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, true, 0, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG0DenseSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, false, 0, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG0SparseSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, true, 0, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG1DenseRewritesCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, false, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG1SparseRewritesCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, true, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG1DenseCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, false, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG1SparseCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, true, 1, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG1DenseRewritesSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, false, 1, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG1SparseRewritesSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, true, 1, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG1DenseSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, false, 1, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG1SparseSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, true, 1, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG2DenseRewritesCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, false, 2, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG2SparseRewritesCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, true, 2, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG2DenseCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, false, 2, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG2SparseCPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, true, 2, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG2DenseRewritesSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, false, 2, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG2SparseRewritesSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, true, true, 2, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG2DenseSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, false, 2, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG2SparseSPFuseAll() {
+		runLinregCGTest(TEST_NAME1, false, true, 2, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testLinregCG0DenseRewritesCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, false, 0, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG0SparseRewritesCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, true, 0, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG0DenseCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, false, 0, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG0SparseCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, true, 0, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG0DenseRewritesSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, false, 0, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG0SparseRewritesSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, true, 0, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG0DenseSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, false, 0, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG0SparseSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, true, 0, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG1DenseRewritesCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, false, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG1SparseRewritesCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, true, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG1DenseCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, false, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG1SparseCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, true, 1, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG1DenseRewritesSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, false, 1, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG1SparseRewritesSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, true, 1, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG1DenseSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, false, 1, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG1SparseSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, true, 1, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG2DenseRewritesCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, false, 2, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG2SparseRewritesCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, true, 2, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG2DenseCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, false, 2, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG2SparseCPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, true, 2, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG2DenseRewritesSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, false, 2, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG2SparseRewritesSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, true, true, 2, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG2DenseSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, false, 2, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testLinregCG2SparseSPFuseNoRedundancy() {
+		runLinregCGTest(TEST_NAME1, false, true, 2, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	private void runLinregCGTest( String testname, boolean rewrites, boolean sparse, int intercept, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -187,7 +435,7 @@ public class AlgorithmLinregCG extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
-	
+		currentTestType = testType;
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
@@ -240,7 +488,16 @@ public class AlgorithmLinregCG extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmMDABivar.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmMDABivar.java
@@ -31,9 +31,17 @@ import org.apache.sysml.test.integration.applications.MDABivariateStatsTest;
 public class AlgorithmMDABivar extends MDABivariateStatsTest 
 {
 	private final static String LOCAL_TEST_DIR = "functions/codegenalg/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + LOCAL_TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + LOCAL_TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + LOCAL_TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + LOCAL_TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	public AlgorithmMDABivar(int n, int m, int li, int lml) {
 		super(n, m, li, lml);
 		TEST_CLASS_DIR = TEST_DIR + AlgorithmMDABivar.class.getSimpleName() + "/";
@@ -41,12 +49,36 @@ public class AlgorithmMDABivar extends MDABivariateStatsTest
 
 	@Test
 	public void testMDABivariateStatsDml() {
-		testMDABivariateStats(ScriptType.DML);
+		testMDABivariateStats(ScriptType.DML,TestType.DEFAULT);
+	}
+
+	@Test
+	public void testMDABivariateStatsDmlFuseAll() {
+		testMDABivariateStats(ScriptType.DML,TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMDABivariateStatsDmlFuseNoRedundancy() {
+		testMDABivariateStats(ScriptType.DML,TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	private void testMDABivariateStats(ScriptType scriptType, TestType testType) {
+		currentTestType = testType;
+		testMDABivariateStats(scriptType);
 	}
 	
 	@Override
 	protected File getConfigTemplateFile() {
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmMLogreg.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmMLogreg.java
@@ -38,9 +38,17 @@ public class AlgorithmMLogreg extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_MLogreg";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmMLogreg.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	private final static double eps = 1e-5;
 	
 	private final static int rows = 2468;
@@ -60,165 +68,485 @@ public class AlgorithmMLogreg extends AutomatedTestBase
 
 	@Test
 	public void testMlogregBin0DenseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 2, 0, true, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 0, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin0SparseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 2, 0, true, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 0, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin0DenseCP() {
-		runMlogregTest(TEST_NAME1, 2, 0, false, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 0, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin0SparseCP() {
-		runMlogregTest(TEST_NAME1, 2, 0, false, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 0, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul0DenseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 5, 0, true, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 0, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul0SparseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 5, 0, true, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 0, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul0DenseCP() {
-		runMlogregTest(TEST_NAME1, 5, 0, false, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 0, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul0SparseCP() {
-		runMlogregTest(TEST_NAME1, 5, 0, false, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 0, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 
 	@Test
 	public void testMlogregBin0DenseRewritesSP() {
-		runMlogregTest(TEST_NAME1, 2, 0, true, false, ExecType.SPARK);
+		runMlogregTest(TEST_NAME1, 2, 0, true, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin0SparseRewritesSP() {
-		runMlogregTest(TEST_NAME1, 2, 0, true, true, ExecType.SPARK);
+		runMlogregTest(TEST_NAME1, 2, 0, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin0DenseSP() {
-		runMlogregTest(TEST_NAME1, 2, 0, false, false, ExecType.SPARK);
+		runMlogregTest(TEST_NAME1, 2, 0, false, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin0SparseSP() {
-		runMlogregTest(TEST_NAME1, 2, 0, false, true, ExecType.SPARK);
+		runMlogregTest(TEST_NAME1, 2, 0, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul0DenseRewritesSP() {
-		runMlogregTest(TEST_NAME1, 5, 0, true, false, ExecType.SPARK);
+		runMlogregTest(TEST_NAME1, 5, 0, true, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul0SparseRewritesSP() {
-		runMlogregTest(TEST_NAME1, 5, 0, true, true, ExecType.SPARK);
+		runMlogregTest(TEST_NAME1, 5, 0, true, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul0DenseSP() {
-		runMlogregTest(TEST_NAME1, 5, 0, false, false, ExecType.SPARK);
+		runMlogregTest(TEST_NAME1, 5, 0, false, false, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul0SparseSP() {
-		runMlogregTest(TEST_NAME1, 5, 0, false, true, ExecType.SPARK);
+		runMlogregTest(TEST_NAME1, 5, 0, false, true, ExecType.SPARK, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin1DenseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 2, 1, true, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 1, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin1SparseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 2, 1, true, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 1, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin1DenseCP() {
-		runMlogregTest(TEST_NAME1, 2, 1, false, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 1, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin1SparseCP() {
-		runMlogregTest(TEST_NAME1, 2, 1, false, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 1, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul1DenseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 5, 1, true, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 1, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul1SparseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 5, 1, true, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 1, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul1DenseCP() {
-		runMlogregTest(TEST_NAME1, 5, 1, false, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 1, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul1SparseCP() {
-		runMlogregTest(TEST_NAME1, 5, 1, false, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 1, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 
 	@Test
 	public void testMlogregBin2DenseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 2, 2, true, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 2, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin2SparseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 2, 2, true, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 2, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin2DenseCP() {
-		runMlogregTest(TEST_NAME1, 2, 2, false, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 2, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregBin2SparseCP() {
-		runMlogregTest(TEST_NAME1, 2, 2, false, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 2, 2, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul2DenseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 5, 2, true, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 2, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul2SparseRewritesCP() {
-		runMlogregTest(TEST_NAME1, 5, 2, true, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 2, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul2DenseCP() {
-		runMlogregTest(TEST_NAME1, 5, 2, false, false, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 2, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMlogregMul2SparseCP() {
-		runMlogregTest(TEST_NAME1, 5, 2, false, true, ExecType.CP);
+		runMlogregTest(TEST_NAME1, 5, 2, false, true, ExecType.CP, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testMlogregBin0DenseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 0, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin0SparseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 0, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin0DenseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 0, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin0SparseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 0, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul0DenseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 0, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul0SparseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 0, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul0DenseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 0, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul0SparseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 0, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin0DenseRewritesSPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 0, true, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin0SparseRewritesSPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 0, true, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin0DenseSPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 0, false, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin0SparseSPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 0, false, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul0DenseRewritesSPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 0, true, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul0SparseRewritesSPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 0, true, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul0DenseSPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 0, false, false, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul0SparseSPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 0, false, true, ExecType.SPARK, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin1DenseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 1, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin1SparseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 1, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin1DenseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 1, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin1SparseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 1, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul1DenseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 1, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul1SparseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 1, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul1DenseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 1, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul1SparseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 1, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin2DenseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 2, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin2SparseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 2, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin2DenseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 2, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin2SparseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 2, 2, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul2DenseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 2, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul2SparseRewritesCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 2, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul2DenseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 2, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregMul2SparseCPFuseAll() {
+		runMlogregTest(TEST_NAME1, 5, 2, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMlogregBin0DenseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 0, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin0SparseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 0, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin0DenseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 0, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin0SparseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 0, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul0DenseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 0, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul0SparseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 0, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul0DenseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 0, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul0SparseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 0, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin0DenseRewritesSPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 0, true, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin0SparseRewritesSPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 0, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin0DenseSPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 0, false, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin0SparseSPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 0, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul0DenseRewritesSPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 0, true, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul0SparseRewritesSPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 0, true, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul0DenseSPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 0, false, false, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul0SparseSPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 0, false, true, ExecType.SPARK, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin1DenseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 1, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin1SparseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 1, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin1DenseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 1, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin1SparseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 1, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul1DenseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 1, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul1SparseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 1, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul1DenseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 1, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul1SparseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 1, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin2DenseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 2, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin2SparseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 2, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin2DenseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 2, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregBin2SparseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 2, 2, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul2DenseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 2, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul2SparseRewritesCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 2, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul2DenseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 2, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMlogregMul2SparseCPFuseNoRedundancy() {
+		runMlogregTest(TEST_NAME1, 5, 2, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
 	}
 	
-	private void runMlogregTest( String testname, int classes, int intercept, boolean rewrites, boolean sparse, ExecType instType)
+	private void runMlogregTest( String testname, int classes, int intercept, boolean rewrites, boolean sparse, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -227,7 +555,7 @@ public class AlgorithmMLogreg extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
-	
+		currentTestType = testType;
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
@@ -280,7 +608,16 @@ public class AlgorithmMLogreg extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmMSVM.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmMSVM.java
@@ -38,9 +38,17 @@ public class AlgorithmMSVM extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_MSVM";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmMSVM.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	private final static double eps = 1e-5;
 	
 	private final static int rows = 1468;
@@ -61,45 +69,125 @@ public class AlgorithmMSVM extends AutomatedTestBase
 
 	@Test
 	public void testMSVMDenseBinRewritesCP() {
-		runMSVMTest(TEST_NAME1, true, false, 2, ExecType.CP);
+		runMSVMTest(TEST_NAME1, true, false, 2, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMSVMSparseBinRewritesCP() {
-		runMSVMTest(TEST_NAME1, true, true, 2, ExecType.CP);
+		runMSVMTest(TEST_NAME1, true, true, 2, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMSVMDenseBinCP() {
-		runMSVMTest(TEST_NAME1, false, false, 2, ExecType.CP);
+		runMSVMTest(TEST_NAME1, false, false, 2, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMSVMSparseBinCP() {
-		runMSVMTest(TEST_NAME1, false, true, 2, ExecType.CP);
+		runMSVMTest(TEST_NAME1, false, true, 2, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMSVMDenseMulRewritesCP() {
-		runMSVMTest(TEST_NAME1, true, false, 4, ExecType.CP);
+		runMSVMTest(TEST_NAME1, true, false, 4, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMSVMSparseMulRewritesCP() {
-		runMSVMTest(TEST_NAME1, true, true, 4, ExecType.CP);
+		runMSVMTest(TEST_NAME1, true, true, 4, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMSVMDenseMulCP() {
-		runMSVMTest(TEST_NAME1, false, false, 4, ExecType.CP);
+		runMSVMTest(TEST_NAME1, false, false, 4, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testMSVMSparseMulCP() {
-		runMSVMTest(TEST_NAME1, false, true, 4, ExecType.CP);
+		runMSVMTest(TEST_NAME1, false, true, 4, ExecType.CP, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testMSVMDenseBinRewritesCPFuseAll() {
+		runMSVMTest(TEST_NAME1, true, false, 2, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMSVMSparseBinRewritesCPFuseAll() {
+		runMSVMTest(TEST_NAME1, true, true, 2, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMSVMDenseBinCPFuseAll() {
+		runMSVMTest(TEST_NAME1, false, false, 2, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMSVMSparseBinCPFuseAll() {
+		runMSVMTest(TEST_NAME1, false, true, 2, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMSVMDenseMulRewritesCPFuseAll() {
+		runMSVMTest(TEST_NAME1, true, false, 4, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMSVMSparseMulRewritesCPFuseAll() {
+		runMSVMTest(TEST_NAME1, true, true, 4, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMSVMDenseMulCPFuseAll() {
+		runMSVMTest(TEST_NAME1, false, false, 4, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMSVMSparseMulCPFuseAll() {
+		runMSVMTest(TEST_NAME1, false, true, 4, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testMSVMDenseBinRewritesCPFuseNoRedundancy() {
+		runMSVMTest(TEST_NAME1, true, false, 2, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMSVMSparseBinRewritesCPFuseNoRedundancy() {
+		runMSVMTest(TEST_NAME1, true, true, 2, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMSVMDenseBinCPFuseNoRedundancy() {
+		runMSVMTest(TEST_NAME1, false, false, 2, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMSVMSparseBinCPFuseNoRedundancy() {
+		runMSVMTest(TEST_NAME1, false, true, 2, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMSVMDenseMulRewritesCPFuseNoRedundancy() {
+		runMSVMTest(TEST_NAME1, true, false, 4, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMSVMSparseMulRewritesCPFuseNoRedundancy() {
+		runMSVMTest(TEST_NAME1, true, true, 4, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMSVMDenseMulCPFuseNoRedundancy() {
+		runMSVMTest(TEST_NAME1, false, false, 4, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testMSVMSparseMulCPFuseNoRedundancy() {
+		runMSVMTest(TEST_NAME1, false, true, 4, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
 	}
 	
-	private void runMSVMTest( String testname, boolean rewrites, boolean sparse, int numClasses, ExecType instType)
+	private void runMSVMTest( String testname, boolean rewrites, boolean sparse, int numClasses, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -108,7 +196,7 @@ public class AlgorithmMSVM extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
-	
+		currentTestType = testType;
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
@@ -160,7 +248,16 @@ public class AlgorithmMSVM extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmPNMF.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmPNMF.java
@@ -38,9 +38,17 @@ public class AlgorithmPNMF extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_PNMF";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmPNMF.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	private final static double eps = 1e-5;
 	
 	private final static int rows = 1468;
@@ -61,12 +69,32 @@ public class AlgorithmPNMF extends AutomatedTestBase
 
 	@Test
 	public void testPNMFDenseCP() {
-		runPNMFTest(TEST_NAME1, false, false, ExecType.CP);
+		runPNMFTest(TEST_NAME1, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testPNMFSparseCP() {
-		runPNMFTest(TEST_NAME1, false, true, ExecType.CP);
+		runPNMFTest(TEST_NAME1, false, true, ExecType.CP, TestType.DEFAULT);
+	}
+
+	@Test
+	public void testPNMFDenseCPFuseAll() {
+		runPNMFTest(TEST_NAME1, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testPNMFSparseCPFuseAll() {
+		runPNMFTest(TEST_NAME1, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testPNMFDenseCPFuseNoRedundancy() {
+		runPNMFTest(TEST_NAME1, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testPNMFSparseCPFuseNoRedundancy() {
+		runPNMFTest(TEST_NAME1, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
 	}
 	
 	//TODO requires proper handling of blocksize constraints
@@ -80,7 +108,7 @@ public class AlgorithmPNMF extends AutomatedTestBase
 	//	runPNMFTest(TEST_NAME1, false, true, ExecType.SPARK);
 	//}
 
-	private void runPNMFTest( String testname, boolean rewrites, boolean sparse, ExecType instType)
+	private void runPNMFTest( String testname, boolean rewrites, boolean sparse, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -89,7 +117,7 @@ public class AlgorithmPNMF extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
-	
+		currentTestType = testType;
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
@@ -146,7 +174,16 @@ public class AlgorithmPNMF extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmStepwiseRegression.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/codegenalg/AlgorithmStepwiseRegression.java
@@ -36,9 +36,17 @@ public class AlgorithmStepwiseRegression extends AutomatedTestBase
 	private final static String TEST_NAME1 = "Algorithm_Stepwise";
 	private final static String TEST_DIR = "functions/codegenalg/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + AlgorithmStepwiseRegression.class.getSimpleName() + "/";
-	private final static String TEST_CONF = "SystemML-config-codegen.xml";
-	private final static File   TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-	
+	private final static String TEST_CONF_DEFAULT = "SystemML-config-codegen.xml";
+	private final static File TEST_CONF_FILE_DEFAULT = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_DEFAULT);
+	private final static String TEST_CONF_FUSE_ALL = "SystemML-config-codegen-fuse-all.xml";
+	private final static File TEST_CONF_FILE_FUSE_ALL = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF_FUSE_ALL);
+	private final static String TEST_CONF_FUSE_NO_REDUNDANCY = "SystemML-config-codegen-fuse-no-redundancy.xml";
+	private final static File TEST_CONF_FILE_FUSE_NO_REDUNDANCY = new File(SCRIPT_DIR + TEST_DIR,
+			TEST_CONF_FUSE_NO_REDUNDANCY);
+
+	private enum TestType { DEFAULT,FUSE_ALL,FUSE_NO_REDUNDANCY }
+	private static TestType currentTestType = TestType.DEFAULT;
+
 	private final static int rows = 2468;
 	private final static int cols = 200;
 	
@@ -61,22 +69,22 @@ public class AlgorithmStepwiseRegression extends AutomatedTestBase
 
 	@Test
 	public void testStepwiseGLMDenseRewritesCP() {
-		runStepwiseTest(StepwiseType.GLM_PROBIT, false, true, ExecType.CP);
+		runStepwiseTest(StepwiseType.GLM_PROBIT, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testStepwiseGLMSparseRewritesCP() {
-		runStepwiseTest(StepwiseType.GLM_PROBIT, true, true, ExecType.CP);
+		runStepwiseTest(StepwiseType.GLM_PROBIT, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testStepwiseGLMDenseNoRewritesCP() {
-		runStepwiseTest(StepwiseType.GLM_PROBIT, false, false, ExecType.CP);
+		runStepwiseTest(StepwiseType.GLM_PROBIT, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testStepwiseGLMSparseNoRewritesCP() {
-		runStepwiseTest(StepwiseType.GLM_PROBIT, true, false, ExecType.CP);
+		runStepwiseTest(StepwiseType.GLM_PROBIT, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 //	@Test
@@ -101,22 +109,22 @@ public class AlgorithmStepwiseRegression extends AutomatedTestBase
 	
 	@Test
 	public void testStepwiseLinregDSDenseRewritesCP() {
-		runStepwiseTest(StepwiseType.LINREG_DS, false, true, ExecType.CP);
+		runStepwiseTest(StepwiseType.LINREG_DS, false, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testStepwiseLinregDSSparseRewritesCP() {
-		runStepwiseTest(StepwiseType.LINREG_DS, true, true, ExecType.CP);
+		runStepwiseTest(StepwiseType.LINREG_DS, true, true, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testStepwiseLinregDSDenseNoRewritesCP() {
-		runStepwiseTest(StepwiseType.LINREG_DS, false, false, ExecType.CP);
+		runStepwiseTest(StepwiseType.LINREG_DS, false, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 	@Test
 	public void testStepwiseLinregDSSparseNoRewritesCP() {
-		runStepwiseTest(StepwiseType.LINREG_DS, true, false, ExecType.CP);
+		runStepwiseTest(StepwiseType.LINREG_DS, true, false, ExecType.CP, TestType.DEFAULT);
 	}
 	
 //	@Test
@@ -138,8 +146,89 @@ public class AlgorithmStepwiseRegression extends AutomatedTestBase
 //	public void testStepwiseLinregDSSparseNoRewritesSP() {
 //		runStepwiseTest(StepwiseType.LINREG_DS, true, false, ExecType.SPARK);
 //	}
+
+	@Test
+	public void testStepwiseGLMDenseRewritesCPFuseAll() {
+		runStepwiseTest(StepwiseType.GLM_PROBIT, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testStepwiseGLMSparseRewritesCPFuseAll() {
+		runStepwiseTest(StepwiseType.GLM_PROBIT, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testStepwiseGLMDenseNoRewritesCPFuseAll() {
+		runStepwiseTest(StepwiseType.GLM_PROBIT, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testStepwiseGLMSparseNoRewritesCPFuseAll() {
+		runStepwiseTest(StepwiseType.GLM_PROBIT, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testStepwiseLinregDSDenseRewritesCPFuseAll() {
+		runStepwiseTest(StepwiseType.LINREG_DS, false, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testStepwiseLinregDSSparseRewritesCPFuseAll() {
+		runStepwiseTest(StepwiseType.LINREG_DS, true, true, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testStepwiseLinregDSDenseNoRewritesCPFuseAll() {
+		runStepwiseTest(StepwiseType.LINREG_DS, false, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testStepwiseLinregDSSparseNoRewritesCPFuseAll() {
+		runStepwiseTest(StepwiseType.LINREG_DS, true, false, ExecType.CP, TestType.FUSE_ALL);
+	}
+
+	@Test
+	public void testStepwiseGLMDenseRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(StepwiseType.GLM_PROBIT, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testStepwiseGLMSparseRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(StepwiseType.GLM_PROBIT, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testStepwiseGLMDenseNoRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(StepwiseType.GLM_PROBIT, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testStepwiseGLMSparseNoRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(StepwiseType.GLM_PROBIT, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testStepwiseLinregDSDenseRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(StepwiseType.LINREG_DS, false, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testStepwiseLinregDSSparseRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(StepwiseType.LINREG_DS, true, true, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testStepwiseLinregDSDenseNoRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(StepwiseType.LINREG_DS, false, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
+	@Test
+	public void testStepwiseLinregDSSparseNoRewritesCPFuseNoRedundancy() {
+		runStepwiseTest(StepwiseType.LINREG_DS, true, false, ExecType.CP, TestType.FUSE_NO_REDUNDANCY);
+	}
+
 	
-	private void runStepwiseTest( StepwiseType type, boolean sparse, boolean rewrites, ExecType instType)
+	private void runStepwiseTest( StepwiseType type, boolean sparse, boolean rewrites, ExecType instType, TestType testType)
 	{
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		RUNTIME_PLATFORM platformOld = rtplatform;
@@ -147,7 +236,7 @@ public class AlgorithmStepwiseRegression extends AutomatedTestBase
 			case SPARK: rtplatform = RUNTIME_PLATFORM.SPARK; break;
 			default: rtplatform = RUNTIME_PLATFORM.HYBRID_SPARK; break;
 		}
-	
+		currentTestType = testType;
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		if( rtplatform == RUNTIME_PLATFORM.SPARK || rtplatform == RUNTIME_PLATFORM.HYBRID_SPARK )
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
@@ -201,7 +290,16 @@ public class AlgorithmStepwiseRegression extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
-		return TEST_CONF_FILE;
+		String message = "This test case overrides default configuration with ";
+		if(currentTestType == TestType.FUSE_ALL){
+			System.out.println(message + TEST_CONF_FILE_FUSE_ALL.getPath());
+			return TEST_CONF_FILE_FUSE_ALL;
+		} else if(currentTestType == TestType.FUSE_NO_REDUNDANCY){
+			System.out.println(message + TEST_CONF_FILE_FUSE_NO_REDUNDANCY.getPath());
+			return TEST_CONF_FILE_FUSE_NO_REDUNDANCY;
+		} else {
+			System.out.println(message + TEST_CONF_FILE_DEFAULT.getPath());
+			return TEST_CONF_FILE_DEFAULT;
+		}
 	}
 }

--- a/src/test/scripts/functions/codegenalg/SystemML-config-codegen-fuse-all.xml
+++ b/src/test/scripts/functions/codegenalg/SystemML-config-codegen-fuse-all.xml
@@ -1,0 +1,28 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<root>
+   <sysml.localtmpdir>/tmp/systemml</sysml.localtmpdir>
+   <sysml.scratch>scratch_space</sysml.scratch>
+   <sysml.optlevel>7</sysml.optlevel>
+   <sysml.codegen.enabled>true</sysml.codegen.enabled>
+   <sysml.codegen.plancache>true</sysml.codegen.plancache>
+   <sysml.codegen.literals>1</sysml.codegen.literals>
+   <sysml.codegen.optimizer>fuse_all</sysml.codegen.optimizer>
+</root>

--- a/src/test/scripts/functions/codegenalg/SystemML-config-codegen-fuse-no-redundancy.xml
+++ b/src/test/scripts/functions/codegenalg/SystemML-config-codegen-fuse-no-redundancy.xml
@@ -1,0 +1,28 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<root>
+   <sysml.localtmpdir>/tmp/systemml</sysml.localtmpdir>
+   <sysml.scratch>scratch_space</sysml.scratch>
+   <sysml.optlevel>7</sysml.optlevel>
+   <sysml.codegen.enabled>true</sysml.codegen.enabled>
+   <sysml.codegen.plancache>true</sysml.codegen.plancache>
+   <sysml.codegen.literals>1</sysml.codegen.literals>
+   <sysml.codegen.optimizer>fuse_no_redundancy</sysml.codegen.optimizer>
+</root>


### PR DESCRIPTION
This is to extend test cases. Added two new configuration files for Fuse_all and fuse_no_redundancy. And from getConfigTemplateFile select the configuration files for current iteration. 