### PR TITLE
[SYSTEMML-2066] JMLC test for candidate exploration with unknowns

### DIFF
--- a/src/main/java/org/apache/sysml/hops/codegen/SpoofCompiler.java
+++ b/src/main/java/org/apache/sysml/hops/codegen/SpoofCompiler.java
@@ -107,14 +107,15 @@ public class SpoofCompiler
 	private static final Log LOG = LogFactory.getLog(SpoofCompiler.class.getName());
 	
 	//internal configuration flags
-	public static boolean LDEBUG                      = false;
+	public static boolean LDEBUG                      = true;
 	public static CompilerType JAVA_COMPILER          = CompilerType.JANINO; 
 	public static PlanSelector PLAN_SEL_POLICY        = PlanSelector.FUSE_COST_BASED_V2; 
 	public static IntegrationType INTEGRATION         = IntegrationType.RUNTIME;
 	public static final boolean RECOMPILE_CODEGEN     = true;
 	public static final boolean PRUNE_REDUNDANT_PLANS = true;
 	public static PlanCachePolicy PLAN_CACHE_POLICY   = PlanCachePolicy.CSLH;
-	public static final int PLAN_CACHE_SIZE           = 1024; //max 1K classes 
+	public static final int PLAN_CACHE_SIZE           = 1024; //max 1K classes
+	public static final boolean ALLOW_ONLY_SAFE_CAND  = true;
 	
 	public enum CompilerType {
 		AUTO,

--- a/src/main/java/org/apache/sysml/hops/codegen/template/TemplateCell.java
+++ b/src/main/java/org/apache/sysml/hops/codegen/template/TemplateCell.java
@@ -33,6 +33,7 @@ import org.apache.sysml.hops.DataOp;
 import org.apache.sysml.hops.Hop;
 import org.apache.sysml.hops.UnaryOp;
 import org.apache.sysml.hops.Hop.AggOp;
+import org.apache.sysml.hops.Hop.OpOp1;
 import org.apache.sysml.hops.Hop.OpOp2;
 import org.apache.sysml.hops.Hop.OpOp3;
 import org.apache.sysml.hops.Hop.ParamBuiltinOp;
@@ -40,6 +41,7 @@ import org.apache.sysml.hops.IndexingOp;
 import org.apache.sysml.hops.LiteralOp;
 import org.apache.sysml.hops.ParameterizedBuiltinOp;
 import org.apache.sysml.hops.TernaryOp;
+import org.apache.sysml.hops.codegen.SpoofCompiler;
 import org.apache.sysml.hops.codegen.cplan.CNode;
 import org.apache.sysml.hops.codegen.cplan.CNodeBinary;
 import org.apache.sysml.hops.codegen.cplan.CNodeBinary.BinType;
@@ -59,6 +61,9 @@ public class TemplateCell extends TemplateBase
 {	
 	private static final AggOp[] SUPPORTED_AGG = 
 			new AggOp[]{AggOp.SUM, AggOp.SUM_SQ, AggOp.MIN, AggOp.MAX};
+
+	private static final OpOp1[] SUPPORTED_UNARY =
+			SpoofCompiler.ALLOW_ONLY_SAFE_CAND ? new OpOp1[]{OpOp1.LOG} : null;
 	
 	public TemplateCell() {
 		super(TemplateType.CELL);
@@ -103,6 +108,7 @@ public class TemplateCell extends TemplateBase
 	public CloseType close(Hop hop) {
 		//need to close cell tpl after aggregation, see fuse for exact properties
 		if( HopRewriteUtils.isAggUnaryOp(hop, SUPPORTED_AGG)
+			|| HopRewriteUtils.isUnary(hop, SUPPORTED_UNARY)
 			|| (HopRewriteUtils.isMatrixMultiply(hop) && hop.getDim1()==1 && hop.getDim2()==1) )
 			return CloseType.CLOSED_VALID;
 		else if( hop instanceof AggUnaryOp || hop instanceof AggBinaryOp )

--- a/src/test/java/org/apache/sysml/test/integration/functions/jmlc/NoCostCandExploreTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/jmlc/NoCostCandExploreTest.java
@@ -1,0 +1,59 @@
+package org.apache.sysml.test.integration.functions.jmlc;
+
+import org.apache.sysml.api.DMLException;
+import org.apache.sysml.api.DMLScript;
+import org.apache.sysml.api.jmlc.Connection;
+import org.apache.sysml.api.jmlc.PreparedScript;
+import org.apache.sysml.conf.CompilerConfig.ConfigType;
+import org.apache.sysml.runtime.matrix.data.MatrixBlock;
+import org.apache.sysml.runtime.util.DataConverter;
+import org.apache.sysml.test.integration.AutomatedTestBase;
+import org.apache.sysml.utils.Explain;
+import org.apache.sysml.utils.Statistics;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Candidate Exploration test for unknown sizes.
+ * Validity constraints and cost comparisons require size information,
+ * for now test a new candidate exploration mode for Unary operations.
+ */
+
+public class NoCostCandExploreTest extends AutomatedTestBase {
+	private final static String TEST_NAME = "NoCostCandExploreTest";
+	private final static String TEST_DIR  = "functions/jmlc";
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_DIR, TEST_NAME);
+		getAndLoadTestConfiguration(TEST_NAME);
+	}
+
+	@Test
+	public void TestUnaryOp() throws IOException, DMLException {
+
+		DMLScript.STATISTICS = true;
+		DMLScript.ENABLE_DEBUG_MODE = true;
+
+		double[][] X = getRandomMatrix(10000, 1600, -10, 10, 0.001, 76543);
+		MatrixBlock mX = DataConverter.convertToMatrixBlock(X);
+
+		Connection conn = new Connection(ConfigType.CODEGEN_ENABLED, ConfigType.ALLOW_DYN_RECOMPILATION);
+		String str = conn.readScript(baseDirectory + File.separator + "cand-explore.dml");
+		PreparedScript script = conn.prepareScript(str, new String[] { "inScalar1", "X" }, new String[] {},
+				false);
+
+		double inScalar1 = 1;
+
+		script.setMatrix("X", mX, false);
+		script.setScalar("inScalar1", inScalar1);
+		setExpectedStdOut("0");
+		script.executeScript();
+		conn.close();
+		System.out.println(Statistics.display());
+	//	System.out.println(Explain.display());
+	}
+
+}

--- a/src/test/java/org/apache/sysml/test/integration/functions/jmlc/NoCostCandExploreTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/jmlc/NoCostCandExploreTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.sysml.test.integration.functions.jmlc;
 
 import org.apache.sysml.api.DMLException;

--- a/src/test/scripts/functions/jmlc/cand-explore.dml
+++ b/src/test/scripts/functions/jmlc/cand-explore.dml
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+inScalar1 = read("./tmp/doesntexist1", data_type="scalar");
+
+X = read("./tmp/doesntexist2");
+
+S = exp(log(X))
+print(as.scalar(S[1,1]))
+
+#write(S, "tmp4");


### PR DESCRIPTION
_what is here?_
1. A test for JMLC, enabled codegen and dyn_recompile

_Questions_
-- sorry for these silly questions.
1. The codegen through JMLC, working the same way as in the normal case.
2. what are the candidates, unary and matrix-scalar are already in our codegen, right?

Thanks, Matthias.