### PR TITLE
[WIP][SYSTEMML-976] Add explain and stats option to Python DSL

### DIFF
--- a/src/main/python/systemml/defmatrix.py
+++ b/src/main/python/systemml/defmatrix.py
@@ -309,7 +309,7 @@ def solve(A, b):
     """
     return binaryMatrixFunction(A, b, 'solve')
 
-def eval(outputs, execute=True):
+def eval(outputs, execute=True, explain=True, stats=True):
     """
     Executes the unevaluated DML script and computes the matrices specified by outputs.
 
@@ -325,6 +325,10 @@ def eval(outputs, execute=True):
     if not execute:
         reset_output_flag(outputs)
         return matrix.script.scriptString
+    if explain:
+        return ' '.join(-explain);
+    if stats:
+        return ' '.join(-stats);
     results = matrix.ml.execute(matrix.script)
     for m in outputs:
         m.eval_data = results._java_results.get(m.ID)


### PR DESCRIPTION
- [x] Extend `def eval(outputs, outputDF=False, execute=True):` method to accept explain and statistics options and pass them before `results = matrix.ml.execute(matrix.script)`.

- [ ] Expose these options through user facing APIs: `eval()` and methods that invoke eval (such as `toPandas`, `toNumPyArray`, `toDataFrame`, etc)