### PR TITLE
[minor] [doc] jira issue tracker, for beginner label for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,7 @@ To get started, please consult the
 [SystemML Documentation](http://systemml.apache.org/documentation).  We
 recommend using the [Spark MLContext API](http://apache.github.io/systemml/spark-mlcontext-programming-guide.html)
 to run SystemML from Scala or Python using `spark-shell`, `pyspark`, or `spark-submit`.
+
+## Want to contribute.
+
+Let's try to dive into the project development by solving a good first issue at [JIRA](https://issues.apache.org/jira/issues/?jql=project%20%3D%20SYSTEMML%20AND%20labels%20%3D%20beginner) issue tracker. 


### PR DESCRIPTION
_what is here?_
  a link for redirecting to `beginner` label for our jira issue tracker, which otherwise would be difficult to search for in large project management across apache's all projects.