### PR TITLE
[SYSTEMML-1626] x = solve(A,b) should report an error when it is an underdetermined system (in CP mode)

### DIFF
--- a/src/main/java/org/apache/sysml/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/BinaryOp.java
@@ -920,6 +920,8 @@ public class BinaryOp extends Hop
 				return new long[]{ldim1, ldim2, lnnz};
 		}
 		else if ( op == OpOp2.SOLVE ) {
+			if (mc[0].getRows() != mc[0].getCols())
+				throw new RuntimeException("The A matrix, in solve(A,b) should have squared dimensions.");
 			// Output is a (likely to be dense) vector of size number of columns in the first input
 			if ( mc[0].getCols() >= 0 ) {
 				ret = new long[]{ mc[0].getCols(), 1, mc[0].getCols()};

--- a/src/main/java/org/apache/sysml/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysml/hops/BinaryOp.java
@@ -920,8 +920,6 @@ public class BinaryOp extends Hop
 				return new long[]{ldim1, ldim2, lnnz};
 		}
 		else if ( op == OpOp2.SOLVE ) {
-			if (mc[0].getRows() != mc[0].getCols())
-				throw new RuntimeException("The A matrix, in solve(A,b) should have squared dimensions.");
 			// Output is a (likely to be dense) vector of size number of columns in the first input
 			if ( mc[0].getCols() >= 0 ) {
 				ret = new long[]{ mc[0].getCols(), 1, mc[0].getCols()};

--- a/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysml/parser/BuiltinFunctionExpression.java
@@ -1096,7 +1096,8 @@ public class BuiltinFunctionExpression extends DataIdentifier
 				raiseValidateError("Second input to solve() must be a vector", conditional);
 			
 			if ( getFirstExpr().getOutput().dimsKnown() && getSecondExpr().getOutput().dimsKnown() && 
-					getFirstExpr().getOutput().getDim1() != getSecondExpr().getOutput().getDim1() )
+					getFirstExpr().getOutput().getDim1() != getSecondExpr().getOutput().getDim1() &&
+					getFirstExpr().getOutput().getDim1() != getFirstExpr().getOutput().getDim2())
 				raiseValidateError("Dimension mismatch in a call to solve()", conditional);
 			
 			output.setDataType(DataType.MATRIX);

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/LibCommonsMath.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/LibCommonsMath.java
@@ -78,8 +78,11 @@ public class LibCommonsMath
 	}
 	
 	public static MatrixBlock matrixMatrixOperations(MatrixObject in1, MatrixObject in2, String opcode) {
-		if(opcode.equals("solve"))
+		if(opcode.equals("solve")) {
+			if (in1.getNumRows() != in1.getNumColumns())
+				throw new RuntimeException("The A matrix, in solve(A,b) should have squared dimensions.");
 			return computeSolve(in1, in2);
+		}
 		return null;
 	}
 	


### PR DESCRIPTION
**What is the change?**
The hop (BinaryOp), throws an error - if the A matrix in solve(A, b) do not have squared dimensions.