### PR TITLE
[SYSTEMML-540] [WIP] Improve the performance of LSTM forward on GPU

### DIFF
--- a/scripts/nn/layers/lstm.dml
+++ b/scripts/nn/layers/lstm.dml
@@ -108,7 +108,7 @@ forward = function(matrix[double] X, matrix[double] W, matrix[double] b, int T, 
     c_prev = c
     cache_out[t,] = matrix(out_t, rows=1, cols=N*M)  # reshape
     cache_c[t,] = matrix(c, rows=1, cols=N*M)  # reshape
-    cache_ifog[t,] = matrix(ifog, rows=1, cols=N*4*M)  # reshape
+    cache_ifog[t,] = matrix(cbind(ifo, g), rows=1, cols=N*4*M)  # reshape
   }
 }
 

--- a/scripts/nn/layers/lstm.dml
+++ b/scripts/nn/layers/lstm.dml
@@ -90,12 +90,12 @@ forward = function(matrix[double] X, matrix[double] W, matrix[double] b, int T, 
     X_t = X[,(t-1)*D+1:t*D]  # shape (N, D)
     input = cbind(X_t, out_prev)  # shape (N, D+M)
     ifog = input %*% W + b  # input, forget, output, and g gates; shape (N, 4M)
-    ifog[,1:3*M] = sigmoid::forward(ifog[,1:3*M])  # i,f,o gates squashed with sigmoid
-    ifog[,3*M+1:4*M] = tanh::forward(ifog[,3*M+1:4*M])  # g gate squashed with tanh
+    ifo = sigmoid::forward(ifog[,1:3*M])  # i,f,o gates squashed with sigmoid
+    g = tanh::forward(ifog[,3*M+1:4*M])  # g gate squashed with tanh
     # c_t = f*prev_c + i*g
-    c = ifog[,M+1:2*M]*c_prev + ifog[,1:M]*ifog[,3*M+1:4*M]  # shape (N, M)
+    c = ifo[,M+1:2*M]*c_prev + ifo[,1:M]*g  # shape (N, M)
     # out_t = o*tanh(c)
-    out_t = ifog[,2*M+1:3*M] * tanh::forward(c)  # shape (N, M)
+    out_t = ifo[,2*M+1:3*M] * tanh::forward(c)  # shape (N, M)
 
     # store
     if (return_sequences) {


### PR DESCRIPTION
- This commit improves the performance of LSTM forward by reducing unnecessary ping pongs between CPU-GPU due to left indexing.
- There is no performance gains for CPU execution.
- There is potential for further improvements by changing the shapes of `cache_ifog`.
- I am marking this as WIP to discuss this further until we add support for CuDNN LSTM kernel. In specific, should we support left indexing on GPU (which complicates parfor/memory management on GPU due to update in-place) or use the approach in this PR ?

The setup is as follows:
- LSTM forward invoked 5 times.
- return_sequence = TRUE
- minibatch size = 32
- number of input features = 169
- number of neurons = 128
- sequence length = 3506 

This PR on GPU:
```
SystemML Statistics:
Total elapsed time:             71.266 sec.
Total compilation time:         2.948 sec.
Total execution time:           68.318 sec.
Number of compiled Spark inst:  7.
Number of executed Spark inst:  0.
CUDA/CuLibraries init time:     7.041/2.571 sec.
Number of executed GPU inst:    280481.
GPU mem tx time  (alloc/dealloc/set0/toDev/fromDev/evict):      0.141/0.000/1.807/1.798/5.785/0.000 sec.
GPU mem tx count (alloc/dealloc/set0/toDev/fromDev/evict):      315535/0/315535/0/35054/52590/0.
GPU conversion time  (sparseConv/sp2dense/dense2sp):    0.000/0.000/0.000 sec.
GPU conversion count (sparseConv/sp2dense/dense2sp):    0/0/0.
Cache hits (Mem, WB, FS, HDFS): 227901/0/0/4.
Cache writes (WB, FS, HDFS):    175300/0/0.
Cache times (ACQr/m, RLS, EXP): 6.479/0.102/0.712/0.000 sec.
HOP DAGs recompiled (PRED, SB): 0/17536.
HOP DAGs recompile time:        17.402 sec.
Functions recompiled:           5.
Functions recompile time:       0.076 sec.
Spark ctx create time (lazy):   0.925 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         43.665 sec.
Total JVM GC count:             25.
Total JVM GC time:              3.857 sec.
Heavy hitter instructions:
  #  Instruction     Time(s)   Count
  1  forward          61.150       5
  2  leftIndex        19.368   70120
  3  gpu_rightIndex    6.326  105181
  4  rshape            4.460   52590
  5  gpu_*             3.696   52590
  6  gpu_append        2.514   35060
  7  gpu_ba+*          2.037   17530
  8  gpu_tanh          1.445   35060
  9  gpu_+             1.019   17530
 10  gpu_sigmoid       0.839   17530
```

Current master on GPU:
```
SystemML Statistics:
Total elapsed time:             83.646 sec.
Total compilation time:         4.229 sec.
Total execution time:           79.417 sec.
Number of compiled Spark inst:  7.
Number of executed Spark inst:  0.
CUDA/CuLibraries init time:     6.628/2.542 sec.
Number of executed GPU inst:    280481.
GPU mem tx time  (alloc/dealloc/set0/toDev/fromDev/evict):      0.174/0.000/2.083/2.955/10.508/0.000 sec.
GPU mem tx count (alloc/dealloc/set0/toDev/fromDev/evict):      350595/0/350595/0/70114/87650/0.
GPU conversion time  (sparseConv/sp2dense/dense2sp):    0.000/0.000/0.000 sec.
GPU conversion count (sparseConv/sp2dense/dense2sp):    0/0/0.
Cache hits (Mem, WB, FS, HDFS): 333081/0/0/4.
Cache writes (WB, FS, HDFS):    245420/0/0.
Cache times (ACQr/m, RLS, EXP): 11.082/0.142/0.987/0.000 sec.
HOP DAGs recompiled (PRED, SB): 0/17536.
HOP DAGs recompile time:        19.176 sec.
Functions recompiled:           5.
Functions recompile time:       0.070 sec.
Spark ctx create time (lazy):   1.747 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         47.462 sec.
Total JVM GC count:             25.
Total JVM GC time:              3.514 sec.
Heavy hitter instructions:
  #  Instruction     Time(s)   Count
  1  forward          72.674       5
  2  leftIndex        29.100  105180
  3  gpu_rightIndex    8.910  122711
  4  gpu_*             3.099   52590
  5  gpu_ba+*          2.917   17530
  6  rshape            1.914   52590
  7  gpu_append        1.641   17530
  8  gpu_tanh          1.596   35060
  9  gpu_+             1.110   17530
 10  gpu_sigmoid       0.879   17530
```

This PR on CPU:
```
SystemML Statistics:
Total elapsed time:             206.914 sec.
Total compilation time:         1.752 sec.
Total execution time:           205.162 sec.
Number of compiled Spark inst:  7.
Number of executed Spark inst:  0.
Cache hits (Mem, WB, FS, HDFS): 596038/0/0/4.
Cache writes (WB, FS, HDFS):    403191/0/0.
Cache times (ACQr/m, RLS, EXP): 0.724/0.086/1.344/0.000 sec.
HOP DAGs recompiled (PRED, SB): 0/17536.
HOP DAGs recompile time:        14.889 sec.
Functions recompiled:           5.
Functions recompile time:       0.080 sec.
Spark ctx create time (lazy):   0.967 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         39.554 sec.
Total JVM GC count:             624.
Total JVM GC time:              14.859 sec.
Heavy hitter instructions:
  #  Instruction  Time(s)   Count
  1  forward      205.049       5
  2  ba+*         156.760   17530
  3  leftIndex     15.152   70120
  4  sigmoid        7.839   17530
  5  rightIndex     3.780  105181
  6  tanh           2.061   35060
  7  append         1.459   35060
  8  *              1.107  210338
  9  rmvar          0.427  420732
 10  createvar      0.382  403211
```

Current master on CPU:
```
Total elapsed time:             197.526 sec.
Total compilation time:         1.548 sec.
Total execution time:           195.977 sec.
Number of compiled Spark inst:  7.
Number of executed Spark inst:  0.
Cache hits (Mem, WB, FS, HDFS): 648628/0/0/4.
Cache writes (WB, FS, HDFS):    438251/0/0.
Cache times (ACQr/m, RLS, EXP): 0.677/0.099/1.301/0.000 sec.
HOP DAGs recompiled (PRED, SB): 0/17536.
HOP DAGs recompile time:        15.635 sec.
Functions recompiled:           5.
Functions recompile time:       0.053 sec.
Spark ctx create time (lazy):   0.860 sec.
Spark trans counts (par,bc,col):0/0/0.
Spark trans times (par,bc,col): 0.000/0.000/0.000 secs.
Total JIT compile time:         38.547 sec.
Total JVM GC count:             624.
Total JVM GC time:              14.558 sec.
Heavy hitter instructions:
  #  Instruction  Time(s)   Count
  1  forward      195.852       5
  2  ba+*         146.526   17530
  3  leftIndex     16.139  105180
  4  sigmoid        7.662   17530
  5  rightIndex     3.845  122711
  6  tanh           2.267   35060
  7  *              1.088  210338
  8  append         0.673   17530
  9  rmvar          0.452  438262
 10  createvar      0.404  438271
```

@dusenberrymw @prithvirajsen can you please review this PR ?

@bertholdreinwald @mboehm7 