### PR TITLE
[MINOR] Fix parent-child link bug in Hop rewrite

### DIFF
--- a/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
+++ b/src/main/java/org/apache/sysml/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
@@ -440,6 +440,8 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 				{
 					gen.setInput(DataExpression.RAND_MIN, right);
 					gen.setInput(DataExpression.RAND_MAX, right);
+					right.getParent().add(gen);
+					right.getParent().add(gen);
 					//rewire all parents (avoid anomalies with replicated datagen)
 					List<Hop> parents = new ArrayList<>(bop.getParent());
 					for( Hop p : parents )


### PR DESCRIPTION
The rewrite `fuseDatagenAndBinaryOperation3a` in `RewriteAlgebraicSimplificationStatic` fails to change the parents when rewiring DataGen Hops.  This patch adds the correct parents.
The problem arises in `LinearLogRegDMLTest` if the `ProgramRewriter`'s `CHECK` flag is set to true (thereby invoking the HopDagValidator).