### PR TITLE
[SYSTEMML-1313] Add runtime support to broadcast inputs for parfor block

### DIFF
--- a/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
@@ -201,6 +201,11 @@ public class OptimizerUtils
 	 */
 	public static final boolean ALLOW_COMBINE_FILE_INPUT_FORMAT = true;
 
+	/**
+	 * Enables to broadcast inputs for PARFOR block
+	 */
+	public static final boolean ALLOW_BROADCAST_INPUTS_PAR_FOR = false;
+
 	//////////////////////
 	// Optimizer levels //
 	//////////////////////

--- a/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysml/hops/OptimizerUtils.java
@@ -201,11 +201,6 @@ public class OptimizerUtils
 	 */
 	public static final boolean ALLOW_COMBINE_FILE_INPUT_FORMAT = true;
 
-	/**
-	 * Enables to broadcast inputs for PARFOR block
-	 */
-	public static final boolean ALLOW_BROADCAST_INPUTS_PAR_FOR = false;
-
 	//////////////////////
 	// Optimizer levels //
 	//////////////////////

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ParForProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ParForProgramBlock.java
@@ -316,6 +316,9 @@ public class ParForProgramBlock extends ForProgramBlock
 	public static final String PARFOR_DATAPARTITIONS_FNAME  = PARFOR_FNAME_PREFIX + "%ID%_datapartitions%VAR%"; 
 	
 	public static final String PARFOR_COUNTER_GROUP_NAME    = "SystemML ParFOR Counters";
+
+
+	public static final boolean ALLOW_BROADCAST_INPUTS = false; // enables to broadcast inputs
 	
 	// static ID generator sequences
 	private final static IDSequence _pfIDSeq = new IDSequence();

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
@@ -195,7 +195,12 @@ public class ExecutionContext {
 		
 		return (MatrixObject) dat;
 	}
-	
+
+	public boolean isFrameObject(String varName) {
+		Data d = getVariable(varName);
+		return d instanceof FrameObject;
+	}
+
 	public FrameObject getFrameObject(CPOperand input) {
 		return getFrameObject(input.getName());
 	}

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/CachedReuseVariables.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/CachedReuseVariables.java
@@ -23,8 +23,14 @@ import java.lang.ref.SoftReference;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
+import org.apache.spark.broadcast.Broadcast;
 import org.apache.sysml.runtime.controlprogram.LocalVariableMap;
+import org.apache.sysml.runtime.controlprogram.ParForProgramBlock;
+import org.apache.sysml.runtime.controlprogram.caching.CacheBlock;
+import org.apache.sysml.runtime.controlprogram.caching.CacheableData;
+import org.apache.sysml.runtime.instructions.cp.Data;
 
 public class CachedReuseVariables
 {
@@ -38,7 +44,13 @@ public class CachedReuseVariables
 		return _data.containsKey(pfid);
 	}
 	
-	public synchronized void reuseVariables(long pfid, LocalVariableMap vars, Collection<String> blacklist) {
+	public synchronized void reuseVariables(long pfid, LocalVariableMap vars, Collection<String> blacklist, Map<String, Broadcast<CacheBlock>> _brInputs) {
+
+		//fetch the broadcast variables
+		if (ParForProgramBlock.ALLOW_BROADCAST_INPUTS && !containsVariables(pfid)) {
+			loadBroadcastVariables(vars, _brInputs);
+		}
+
 		//check for existing reuse map
 		LocalVariableMap tmp = null;
 		if( _data.containsKey(pfid) )
@@ -60,5 +72,20 @@ public class CachedReuseVariables
 
 	public synchronized void clearVariables(long pfid) {
 		_data.remove(pfid);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void loadBroadcastVariables(LocalVariableMap variables, Map<String, Broadcast<CacheBlock>> _brInputs) {
+		for (String key : variables.keySet()) {
+			if (!_brInputs.containsKey(key)) {
+				continue;
+			}
+			Data d = variables.get(key);
+			CacheableData<CacheBlock> cdcb = (CacheableData<CacheBlock>) d;
+			CacheBlock cb = _brInputs.get(key).getValue();
+			cdcb.acquireModify(cb);
+			cdcb.setEmptyStatus();// set status from modified to empty
+			cdcb.refreshMetaData();
+		}
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/CachedReuseVariables.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/CachedReuseVariables.java
@@ -33,6 +33,10 @@ public class CachedReuseVariables
 	public CachedReuseVariables() {
 		_data = new HashMap<>();
 	}
+
+	public synchronized boolean containsVariables(long pfid) {
+		return _data.containsKey(pfid);
+	}
 	
 	public synchronized void reuseVariables(long pfid, LocalVariableMap vars, Collection<String> blacklist) {
 		//check for existing reuse map

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/ProgramConverter.java
@@ -1309,6 +1309,19 @@ public class ProgramConverter
 		return body;
 	}
 
+	public static ArrayList<ResultVar> getResultVariables(String in) {
+		//header elimination
+		String tmpin = in.replaceAll(NEWLINE, ""); //normalization
+		tmpin = tmpin.substring(PARFORBODY_BEGIN.length(), tmpin.length() - PARFORBODY_END.length()); //remove start/end
+		HierarchyAwareStringTokenizer st = new HierarchyAwareStringTokenizer(tmpin, COMPONENTS_DELIM);
+		//handle result variable names
+		for (int i = 0; i < 4; i++) {
+			st.nextToken();
+		}
+		String rvarStr = st.nextToken();
+		return parseResultVariables(rvarStr);
+	}
+
 	public static Program parseProgram( String in, int id ) {
 		String lin = in.substring( PARFOR_PROG_BEGIN.length(),in.length()-PARFOR_PROG_END.length()).trim(); 
 		

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForSparkWorker.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/parfor/RemoteParForSparkWorker.java
@@ -24,16 +24,26 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.util.LongAccumulator;
+import org.apache.sysml.hops.OptimizerUtils;
 import org.apache.sysml.runtime.codegen.CodegenUtils;
+import org.apache.sysml.runtime.controlprogram.LocalVariableMap;
 import org.apache.sysml.runtime.controlprogram.caching.CacheableData;
+import org.apache.sysml.runtime.controlprogram.caching.FrameObject;
+import org.apache.sysml.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysml.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
 import org.apache.sysml.runtime.controlprogram.parfor.util.IDHandler;
+import org.apache.sysml.runtime.instructions.cp.Data;
+import org.apache.sysml.runtime.matrix.MatrixCharacteristics;
+import org.apache.sysml.runtime.matrix.data.FrameBlock;
+import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.util.LocalFileUtils;
 import org.apache.sysml.runtime.util.UtilFunctions;
 
@@ -53,8 +63,10 @@ public class RemoteParForSparkWorker extends ParWorker implements PairFlatMapFun
 	
 	private final LongAccumulator _aTasks;
 	private final LongAccumulator _aIters;
+
+	private final Map<String, Broadcast> _brInputs;
 	
-	public RemoteParForSparkWorker(long jobid, String program, HashMap<String, byte[]> clsMap, boolean cpCaching, LongAccumulator atasks, LongAccumulator aiters) {
+	public RemoteParForSparkWorker(long jobid, String program, HashMap<String, byte[]> clsMap, boolean cpCaching, LongAccumulator atasks, LongAccumulator aiters, Map<String, Broadcast> brInputs) {
 		_jobid = jobid;
 		_prog = program;
 		_clsMap = clsMap;
@@ -63,6 +75,7 @@ public class RemoteParForSparkWorker extends ParWorker implements PairFlatMapFun
 		//setup spark accumulators
 		_aTasks = atasks;
 		_aIters = aiters;
+		_brInputs = brInputs;
 	}
 	
 	@Override 
@@ -107,7 +120,12 @@ public class RemoteParForSparkWorker extends ParWorker implements PairFlatMapFun
 		_resultVars  = body.getResultVariables();
 		_numTasks    = 0;
 		_numIters    = 0;
-		
+
+		//fetch the broadcast variables
+		if (OptimizerUtils.ALLOW_BROADCAST_INPUTS_PAR_FOR && !reuseVars.containsVariables(_jobid)) {
+			loadBroadcastVariables(_ec.getVariables(), _brInputs);
+		}
+
 		//reuse shared inputs (to read shared inputs once per process instead of once per core; 
 		//we reuse everything except result variables and partitioned input matrices)
 		_ec.pinVariables(_ec.getVarList()); //avoid cleanup of shared inputs
@@ -142,7 +160,29 @@ public class RemoteParForSparkWorker extends ParWorker implements PairFlatMapFun
 		//mark as initialized
 		_initialized = true;
 	}
-	
+
+	private void loadBroadcastVariables(LocalVariableMap variables, Map<String, Broadcast> _brInputs) {
+		for (String key : variables.keySet()) {
+			if (!_brInputs.containsKey(key)) {
+				continue;
+			}
+			Data d = variables.get(key);
+			if (d instanceof MatrixObject) {
+				MatrixObject mo = (MatrixObject) d;
+				MatrixBlock mb = (MatrixBlock) _brInputs.get(key).getValue();
+				mo.acquireModify(mb);
+				mo.setEmptyStatus();// set status from modified to empty
+				mo.updateMatrixCharacteristics(new MatrixCharacteristics(mb.getNumRows(), mb.getNumColumns(), 1, 1));
+			} else if (d instanceof FrameObject) {
+				FrameObject fo = (FrameObject) d;
+				FrameBlock fb = (FrameBlock) _brInputs.get(key).getValue();
+				fo.acquireModify(fb);
+				fo.setEmptyStatus(); // set status from modified to empty
+				fo.updateMatrixCharacteristics(new MatrixCharacteristics(fb.getNumRows(), fb.getNumColumns(), 1, 1));
+			}
+		}
+	}
+
 	public static void cleanupCachedVariables(long pfid) {
 		reuseVars.clearVariables(pfid);
 	}

--- a/src/main/java/org/apache/sysml/runtime/matrix/data/FrameBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/matrix/data/FrameBlock.java
@@ -117,7 +117,11 @@ public class FrameBlock implements Writable, CacheBlock, Externalizable
 		for( int i=0; i<data.length; i++ )
 			appendRow(data[i]);
 	}
-	
+
+	public boolean isEmpty() {
+		return _numRows == 0;
+	}
+
 	/**
 	 * Get the number of rows of the frame block.
 	 * 


### PR DESCRIPTION
Hi,
This PR adds the runtime support to broadcast inputs for remote parfor. It is disabled by default and needs to set `OptimizerUtils.ALLOW_BROADCAST_INPUTS_PAR_FOR` to true for test. However, the extension of parfor optimizer will be completed later in another PR.