### PR TITLE
[MINOR]update depreciated brew commands for installing Java and Spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,13 @@ Before you get started on SystemML, make sure that your environment is set up an
 
   2. **Install Java (need Java 8).**
   ```
-  brew tap caskroom/cask
-  brew install Caskroom/cask/java
+  brew tap caskroom/versions
+  brew cask install java8
   ```
 
-  3. **Install Spark 2.1.**
+  3. **Install Spark (Newest).**
   ```
-  brew tap homebrew/versions
-  brew install apache-spark21
+  brew install apache-spark
   ```
 
   4. **Download SystemML.**

--- a/docs/beginners-guide-python.md
+++ b/docs/beginners-guide-python.md
@@ -52,19 +52,17 @@ If you already have an Apache Spark installation, you can skip this step.
 <div data-lang="OSX" markdown="1">
 ```bash
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-brew tap caskroom/cask
-brew install Caskroom/cask/java
-brew tap homebrew/versions
-brew install apache-spark16
+brew tap caskroom/versions
+brew cask install java8
+brew install apache-spark
 ```
 </div>
 <div data-lang="Linux" markdown="1">
 ```bash
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install)"
-brew tap caskroom/cask
-brew install Caskroom/cask/java
-brew tap homebrew/versions
-brew install apache-spark16
+brew tap caskroom/versions
+brew cask install java8
+brew install apache-spark
 ```
 </div>
 </div>

--- a/src/main/standalone/README.txt
+++ b/src/main/standalone/README.txt
@@ -90,14 +90,13 @@ Before you get started on SystemML, make sure that your environment is set up an
 
   2. **Install Java (need Java 8).**
   ```
-  brew tap caskroom/cask
-  brew install Caskroom/cask/java
+  brew tap caskroom/versions
+  brew cask install java8
   ```
 
-  3. **Install Spark 2.1.**
+  3. **Install Spark (Newest)**
   ```
-  brew tap homebrew/versions
-  brew install apache-spark21
+  brew install apache-spark
   ```
 
   4. **Download SystemML.**


### PR DESCRIPTION
The current brew install commands automatically downloads Java 9 but there were version conflicts with Scala. Also, "brew tap homebrew/versions" is depreciated and there is no way to set version 2.1 for Apache Spark. The current change simply downloads the newest version but perhaps it can be included in the Maven dependency if version specification is necessary. 