### PR TITLE
[SYSTEMML-2233]cleanup redundant error message logging

### DIFF
--- a/src/main/java/org/apache/sysml/parser/DMLProgram.java
+++ b/src/main/java/org/apache/sysml/parser/DMLProgram.java
@@ -79,7 +79,6 @@ public class DMLProgram
 	public HashMap<String, FunctionStatementBlock> getFunctionStatementBlocks(String namespaceKey) {
 		DMLProgram namespaceProgram = this.getNamespaces().get(namespaceKey);
 		if (namespaceProgram == null){
-			LOG.error("ERROR: namespace " + namespaceKey + " is undefined");
 			throw new LanguageException("ERROR: namespace " + namespaceKey + " is undefined");
 		}
 		// for the namespace DMLProgram, get the functions in its current namespace

--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -636,7 +636,6 @@ public class DMLTranslator
 				}
 				
 				if (!fstmt.getBody().isEmpty()){
-					LOG.error(fstmt.printErrorLocation() + "ExternalFunctionStatementBlock should have no statement blocks in body");
 					throw new LopsException(fstmt.printErrorLocation() + "ExternalFunctionStatementBlock should have no statement blocks in body");
 				}
 			}
@@ -655,7 +654,6 @@ public class DMLTranslator
 			
 			// check there are actually Lops in to process (loop stmt body will not have any)
 			if (fsb.getLops() != null && !fsb.getLops().isEmpty()){
-				LOG.error(fsb.printBlockErrorLocation() + "FunctionStatementBlock should have no Lops");
 				throw new LopsException(fsb.printBlockErrorLocation() + "FunctionStatementBlock should have no Lops");
 			}
 			
@@ -743,7 +741,6 @@ public class DMLTranslator
 				predicateLops.printMe();
 
 				if (wstb.getNumStatements() > 1){
-					LOG.error(wstb.printBlockErrorLocation() + "WhileStatementBlock has more than 1 statement");
 					throw new HopsException(wstb.printBlockErrorLocation() + "WhileStatementBlock has more than 1 statement");
 				}
 				WhileStatement ws = (WhileStatement)wstb.getStatement(0);
@@ -765,7 +762,6 @@ public class DMLTranslator
 				predicateLops.printMe();
 
 				if (istb.getNumStatements() > 1){
-					LOG.error(istb.printBlockErrorLocation() + "IfStatmentBlock has more than 1 statement");
 					throw new HopsException(istb.printBlockErrorLocation() + "IfStatmentBlock has more than 1 statement");
 				}
 				IfStatement is = (IfStatement)istb.getStatement(0);
@@ -810,7 +806,6 @@ public class DMLTranslator
 				}
 
 				if (fsb.getNumStatements() > 1){
-					LOG.error(fsb.printBlockErrorLocation() + "ForStatementBlock has more than 1 statement");
 					throw new HopsException(fsb.printBlockErrorLocation() + "ForStatementBlock has more than 1 statement");
 				}
 				ForStatement ws = (ForStatement)fsb.getStatement(0);
@@ -1322,7 +1317,6 @@ public class DMLTranslator
 					//error handling missing function
 					if (fsb == null){
 						String error = source.printErrorLocation() + "function " + fci.getName() + " is undefined in namespace " + fci.getNamespace(); 
-						LOG.error(error);
 						throw new LanguageException(error);
 					}
 					
@@ -1362,7 +1356,6 @@ public class DMLTranslator
 					FunctionStatementBlock fsb = this._dmlProg.getFunctionStatementBlock(fci.getNamespace(),fci.getName());
 					FunctionStatement fstmt = (FunctionStatement)fsb.getStatement(0);
 					if (fstmt == null){
-						LOG.error(source.printErrorLocation() + "function " + fci.getName() + " is undefined in namespace " + fci.getNamespace());
 						throw new LanguageException(source.printErrorLocation() + "function " + fci.getName() + " is undefined in namespace " + fci.getNamespace());
 					}
 					
@@ -1480,7 +1473,6 @@ public class DMLTranslator
 			DataOp read = null;
 			
 			if (var == null) {
-				LOG.error("variable " + varName + " not live variable for conditional predicate");
 				throw new ParseException("variable " + varName + " not live variable for conditional predicate");
 			} else {
 				long actualDim1 = (var instanceof IndexedIdentifier) ? ((IndexedIdentifier)var).getOrigDim1() : var.getDim1();
@@ -1522,8 +1514,6 @@ public class DMLTranslator
 				LOG.warn(predicate.printWarningLocation() + "Numerical value '" + predicate.toString()
 						+ "' (!= 0/1) is converted to boolean TRUE by DML");
 			} else if (predicate instanceof StringIdentifier) {
-				LOG.error(predicate.printErrorLocation() + "String value '" + predicate.toString()
-						+ "' is not allowed for iterable predicate");
 				throw new ParseException(predicate.printErrorLocation() + "String value '" + predicate.toString()
 						+ "' is not allowed for iterable predicate");
 			}
@@ -1569,7 +1559,6 @@ public class DMLTranslator
 					DataIdentifier var = fsb.liveIn().getVariable(varName);
 					DataOp read = null;
 					if (var == null) {
-						LOG.error("variable '" + varName + "' is not available for iterable predicate");
 						throw new ParseException("variable '" + varName + "' is not available for iterable predicate");
 					}
 					else {
@@ -1742,7 +1731,6 @@ public class DMLTranslator
 		// process the target to get targetHops
 		Hop targetOp = hops.get(target.getName());
 		if (targetOp == null){
-			LOG.error(target.printErrorLocation() + " must define matrix " + target.getName() + " before indexing operations are allowed ");
 			throw new ParseException(target.printErrorLocation() + " must define matrix " + target.getName() + " before indexing operations are allowed ");
 		}
 		
@@ -1922,7 +1910,6 @@ public class DMLTranslator
 		}
 
 		if (constLeft || constRight) {
-			LOG.error(source.printErrorLocation() + "Boolean expression with constant unsupported");
 			throw new RuntimeException(source.printErrorLocation() + "Boolean expression with constant unsupported");
 		}
 
@@ -1953,7 +1940,6 @@ public class DMLTranslator
 			} else if (source.getOpCode() == Expression.BooleanOp.LOGICALOR) {
 				op = OpOp2.OR;
 			} else {
-				LOG.error(source.printErrorLocation() + "Unknown boolean operation " + source.getOpCode());
 				throw new RuntimeException(source.printErrorLocation() + "Unknown boolean operation " + source.getOpCode());
 			}
 			currBop = new BinaryOp(target.getName(), target.getDataType(), target.getValueType(), op, left, right);
@@ -2195,10 +2181,6 @@ public class DMLTranslator
 			
 			
 		default:
-			LOG.error(source.printErrorLocation() + 
-					"processDataExpression():: Unknown operation:  "
-							+ source.getOpCode());
-			
 			throw new ParseException(source.printErrorLocation() + 
 					"processDataExpression():: Unknown operation:  "
 							+ source.getOpCode());
@@ -2444,7 +2426,6 @@ public class DMLTranslator
 			else if ( sop.equalsIgnoreCase("!=") )
 				operation = OpOp2.NOTEQUAL;
 			else {
-				LOG.error(source.printErrorLocation() + "Unknown argument (" + sop + ") for PPRED.");
 				throw new ParseException(source.printErrorLocation() + "Unknown argument (" + sop + ") for PPRED.");
 			}
 			currBuiltinOp = new BinaryOp(target.getName(), target.getDataType(), target.getValueType(), operation, expr, expr2);
@@ -2582,11 +2563,6 @@ public class DMLTranslator
 						mathOp2 = Hop.OpOp1.LOG;
 						break;
 					default:
-						
-						LOG.error(source.printErrorLocation() +
-								"processBuiltinFunctionExpression():: Could not find Operation type for builtin function: "
-										+ source.getOpCode());
-						
 						throw new ParseException(source.printErrorLocation() +
 								"processBuiltinFunctionExpression():: Could not find Operation type for builtin function: "
 										+ source.getOpCode());
@@ -2600,11 +2576,6 @@ public class DMLTranslator
 						mathOp3 = Hop.OpOp2.LOG;
 						break;
 					default:
-						
-						LOG.error(source.printErrorLocation() +
-								"processBuiltinFunctionExpression():: Could not find Operation type for builtin function: "
-										+ source.getOpCode());
-						
 						throw new ParseException(source.printErrorLocation() +
 								"processBuiltinFunctionExpression():: Could not find Operation type for builtin function: "
 										+ source.getOpCode());

--- a/src/main/java/org/apache/sysml/parser/DataExpression.java
+++ b/src/main/java/org/apache/sysml/parser/DataExpression.java
@@ -1868,7 +1868,6 @@ public class DataExpression extends DataIdentifier
 			}
 			
 		} catch (IOException e){
-			//LOG.error(this.printErrorLocation() + "Error reading MatrixMarket file: " + filename );
 			//throw new LanguageException(this.printErrorLocation() + "Error reading MatrixMarket file: " + filename );
 			throw new LanguageException(e);
 		}

--- a/src/main/java/org/apache/sysml/parser/ExternalFunctionStatement.java
+++ b/src/main/java/org/apache/sysml/parser/ExternalFunctionStatement.java
@@ -149,13 +149,11 @@ public class ExternalFunctionStatement extends FunctionStatement
 
 	@Override
 	public void initializeforwardLV(VariableSet activeIn) {
-		LOG.error(this.printErrorLocation() + "should never call initializeforwardLV for ExternalFunctionStatement");
 		throw new LanguageException(this.printErrorLocation() + "should never call initializeforwardLV for ExternalFunctionStatement");
 	}
 	
 	@Override
 	public VariableSet initializebackwardLV(VariableSet lo) {
-		LOG.error(this.printErrorLocation() + "should never call initializeforwardLV for ExternalFunctionStatement");
 		throw new LanguageException(this.printErrorLocation() + "should never call initializeforwardLV for ExternalFunctionStatement");
 		
 	}

--- a/src/main/java/org/apache/sysml/parser/ForStatement.java
+++ b/src/main/java/org/apache/sysml/parser/ForStatement.java
@@ -30,7 +30,6 @@ public class ForStatement extends Statement
 	
 	@Override
 	public Statement rewriteStatement(String prefix) {
-		LOG.error(this.printErrorLocation() + "should not call rewriteStatement for ForStatement");
 		throw new LanguageException(this.printErrorLocation() + "should not call rewriteStatement for ForStatement");
 	}
 	
@@ -85,13 +84,11 @@ public class ForStatement extends Statement
 
 	@Override
 	public void initializeforwardLV(VariableSet activeIn) {
-		LOG.error(this.printErrorLocation() + "should never call initializeforwardLV for ForStatement");
 		throw new LanguageException(this.printErrorLocation() + "should never call initializeforwardLV for ForStatement");
 	}
 	
 	@Override
 	public VariableSet initializebackwardLV(VariableSet lo) {
-		LOG.error(this.printErrorLocation() + "should never call initializeforwardLV for ForStatement");
 		throw new LanguageException(this.printErrorLocation() + "should never call initializeforwardLV for ForStatement");
 		
 	}

--- a/src/main/java/org/apache/sysml/parser/ForStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/ForStatementBlock.java
@@ -184,7 +184,6 @@ public class ForStatementBlock extends StatementBlock
 		
 		ForStatement fstmt = (ForStatement)_statements.get(0);
 		if (_statements.size() > 1){
-			LOG.error(_statements.get(0).printErrorLocation() + "ForStatementBlock should have only 1 statement (for statement)");
 			throw new LanguageException(_statements.get(0).printErrorLocation() + "ForStatementBlock should have only 1 statement (for statement)");
 		}
 		

--- a/src/main/java/org/apache/sysml/parser/FunctionStatement.java
+++ b/src/main/java/org/apache/sysml/parser/FunctionStatement.java
@@ -32,7 +32,6 @@ public class FunctionStatement extends Statement
 	
 	@Override
 	public Statement rewriteStatement(String prefix) {
-		LOG.error(this.printErrorLocation() + "should not call rewriteStatement for FunctionStatement");
 		throw new LanguageException(this.printErrorLocation() + "should not call rewriteStatement for FunctionStatement");
 	}
 	
@@ -114,13 +113,11 @@ public class FunctionStatement extends Statement
 
 	@Override
 	public void initializeforwardLV(VariableSet activeIn) {
-		LOG.error(this.printErrorLocation() + "should never call initializeforwardLV for FunctionStatement");
 		throw new LanguageException(this.printErrorLocation() + "should never call initializeforwardLV for FunctionStatement");
 	}
 	
 	@Override
 	public VariableSet initializebackwardLV(VariableSet lo) {
-		LOG.error(this.printErrorLocation() + "should never call initializeforwardLV for FunctionStatement");
 		throw new LanguageException(this.printErrorLocation() + "should never call initializeforwardLV for FunctionStatement");
 	}
 	

--- a/src/main/java/org/apache/sysml/parser/FunctionStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/FunctionStatementBlock.java
@@ -45,7 +45,6 @@ public class FunctionStatementBlock extends StatementBlock
 	public VariableSet validate(DMLProgram dmlProg, VariableSet ids, HashMap<String,ConstIdentifier> constVars, boolean conditional) 
 	{
 		if (_statements.size() > 1){
-			LOG.error(this.printBlockErrorLocation() + "FunctionStatementBlock should have only 1 statement (FunctionStatement)");
 			throw new LanguageException(this.printBlockErrorLocation() + "FunctionStatementBlock should have only 1 statement (FunctionStatement)");
 		}
 		FunctionStatement fstmt = (FunctionStatement) _statements.get(0);
@@ -110,10 +109,6 @@ public class FunctionStatementBlock extends StatementBlock
 							}
 							else {
 								// THROW EXCEPTION -- CANNOT CONVERT
-								LOG.error(curr.printErrorLocation() + "for function " + fstmt.getName() 
-										+ ", return variable " + curr.getName() + " value type of " 
-										+ curr.getValueType() + " does not match value type in function signature of " 
-										+ returnValue.getValueType() + " and cannot safely cast value");
 								throw new LanguageException(curr.printErrorLocation() + "for function " 
 										+ fstmt.getName() + ", return variable " + curr.getName() 
 										+ " value type of " + curr.getValueType() 
@@ -123,11 +118,6 @@ public class FunctionStatementBlock extends StatementBlock
 						}
 						if (returnValue.getValueType() == ValueType.INT){
 							// THROW EXCEPTION -- CANNOT CONVERT
-							LOG.error(curr.printErrorLocation() + "for function " + fstmt.getName() 
-									+ ", return variable " + curr.getName() + " value type of " 
-									+ curr.getValueType() + " does not match value type in function signature of " 
-									+ returnValue.getValueType() + " and cannot safely cast " + curr.getValueType() 
-									+ " as " + returnValue.getValueType());
 							throw new LanguageException(curr.printErrorLocation() + "for function " + fstmt.getName() 
 									+ ", return variable " + curr.getName() + " value type of " + curr.getValueType() 
 									+ " does not match value type in function signature of " 
@@ -137,7 +127,6 @@ public class FunctionStatementBlock extends StatementBlock
 						} 
 					}	
 					else {
-						LOG.error(curr.printErrorLocation() + "for function " + fstmt.getName() + ", return variable " + curr.getName() + " value type of " + curr.getValueType() + " does not match value type in function signature of " + returnValue.getValueType() + " and cannot safely cast double as int");
 						throw new LanguageException(curr.printErrorLocation() + "for function " + fstmt.getName() + ", return variable " + curr.getName() + " value type of " + curr.getValueType() + " does not match value type in function signature of " + returnValue.getValueType() + " and cannot safely cast " + curr.getValueType() + " as " + returnValue.getValueType());
 					}
 				}
@@ -193,7 +182,6 @@ public class FunctionStatementBlock extends StatementBlock
 	public VariableSet initializeforwardLV(VariableSet activeInPassed) {
 		FunctionStatement fstmt = (FunctionStatement)_statements.get(0);
 		if (_statements.size() > 1){
-			LOG.error(this.printBlockErrorLocation() + "FunctionStatementBlock should have only 1 statement (while statement)");
 			throw new LanguageException(this.printBlockErrorLocation() + "FunctionStatementBlock should have only 1 statement (while statement)");
 		}
 		_read = new VariableSet();
@@ -255,8 +243,7 @@ public class FunctionStatementBlock extends StatementBlock
 	
 	@Override
 	public VariableSet analyze(VariableSet loPassed) {
-		LOG.error(this.printBlockErrorLocation() + "Both liveIn and liveOut variables need to be specified for liveness analysis for FunctionStatementBlock");
-		throw new LanguageException(this.printBlockErrorLocation() + "Both liveIn and liveOut variables need to be specified for liveness analysis for FunctionStatementBlock");	
+		throw new LanguageException(this.printBlockErrorLocation() + "Both liveIn and liveOut variables need to be specified for liveness analysis for FunctionStatementBlock");
 	}
 	
 	public VariableSet analyze(VariableSet liPassed, VariableSet loPassed) {

--- a/src/main/java/org/apache/sysml/parser/IfStatement.java
+++ b/src/main/java/org/apache/sysml/parser/IfStatement.java
@@ -31,7 +31,6 @@ public class IfStatement extends Statement
 	
 	@Override
 	public Statement rewriteStatement(String prefix) {
-		LOG.error(this.printErrorLocation() + "should not call rewriteStatement for IfStatement");
 		throw new LanguageException(this.printErrorLocation() + "should not call rewriteStatement for IfStatement");
 	}
 	

--- a/src/main/java/org/apache/sysml/parser/IfStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/IfStatementBlock.java
@@ -287,7 +287,6 @@ public class IfStatementBlock extends StatementBlock
 	{
 		IfStatement ifstmt = (IfStatement)_statements.get(0);
 		if (_statements.size() > 1){
-			LOG.error(ifstmt.printErrorLocation() + "IfStatementBlock should have only 1 statement (if statement)");
 			throw new LanguageException(ifstmt.printErrorLocation() + "IfStatementBlock should have only 1 statement (if statement)");
 		}
 		_read = new VariableSet();
@@ -420,7 +419,6 @@ public class IfStatementBlock extends StatementBlock
 	{
 		IfStatement ifstmt = (IfStatement)_statements.get(0);
 		if (_statements.size() > 1){
-			LOG.error(ifstmt.printErrorLocation() + "IfStatementBlock should have only 1 statement (if statement)");
 			throw new LanguageException(ifstmt.printErrorLocation() + "IfStatementBlock should have only 1 statement (if statement)");
 		}
 		

--- a/src/main/java/org/apache/sysml/parser/ImportStatement.java
+++ b/src/main/java/org/apache/sysml/parser/ImportStatement.java
@@ -76,7 +76,6 @@ public class ImportStatement extends Statement
 
 	@Override
 	public Statement rewriteStatement(String prefix) {
-		LOG.error(this.printErrorLocation() + "rewriting for inlining not supported for ImportStatement");
 		throw new LanguageException(this.printErrorLocation() + "rewriting for inlining not supported for ImportStatement");
 	}
 	

--- a/src/main/java/org/apache/sysml/parser/IterablePredicate.java
+++ b/src/main/java/org/apache/sysml/parser/IterablePredicate.java
@@ -64,7 +64,6 @@ public class IterablePredicate extends Expression
 	public Expression rewriteExpression(String prefix) {
 		//DataIdentifier newIterVar = (DataIdentifier)_iterVar.rewriteExpression(prefix);
 		//return new IterablePredicate(newIterVar, _from, _to, _increment);
-		LOG.error(this.printErrorLocation() + "rewriteExpression not supported for IterablePredicate");
 		throw new LanguageException(this.printErrorLocation() + "rewriteExpression not supported for IterablePredicate");
 	}
 	
@@ -193,7 +192,6 @@ public class IterablePredicate extends Expression
 			(ident.getDataType() == DataType.SCALAR && (ident.getValueType() == ValueType.BOOLEAN || 
 			ident.getValueType() == ValueType.STRING || ident.getValueType() == ValueType.OBJECT)) )
 		{
-			LOG.error(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
 			throw new LanguageException(this.printErrorLocation() + "expression in iterable predicate in for loop '" + expr.toString() + "' must return a numeric scalar");
 		}
 	}

--- a/src/main/java/org/apache/sysml/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/StatementBlock.java
@@ -1149,8 +1149,6 @@ public class StatementBlock extends LiveVariableAnalysis implements ParseInfo
 		else  //error and exception if unconditional
 		{
 			String fullMsg = this.printErrorLocation() + msg;
-
-			//LOG.error( fullMsg ); //no redundant error
 			if( errorCode != null )
 				throw new LanguageException( fullMsg, errorCode );
 			else

--- a/src/main/java/org/apache/sysml/parser/WhileStatement.java
+++ b/src/main/java/org/apache/sysml/parser/WhileStatement.java
@@ -30,7 +30,6 @@ public class WhileStatement extends Statement
 	
 	@Override
 	public Statement rewriteStatement(String prefix) {
-		LOG.error(this.printErrorLocation() + "should not call rewriteStatement for WhileStatement");
 		throw new LanguageException(this.printErrorLocation() + "should not call rewriteStatement for WhileStatement");
 	}
 	

--- a/src/main/java/org/apache/sysml/parser/WhileStatementBlock.java
+++ b/src/main/java/org/apache/sysml/parser/WhileStatementBlock.java
@@ -166,7 +166,6 @@ public class WhileStatementBlock extends StatementBlock
 		
 		WhileStatement wstmt = (WhileStatement)_statements.get(0);
 		if (_statements.size() > 1){
-			LOG.error(_statements.get(0).printErrorLocation() + "WhileStatementBlock should have only 1 statement (while statement)");
 			throw new LanguageException(_statements.get(0).printErrorLocation() + "WhileStatementBlock should have only 1 statement (while statement)");
 		}
 		


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SYSTEMML-2233](url)

This task aims to cleanup redundant and thus unnecessary error logging in the package org.apache.sysml.parser. Specifically, there are many instances where the same (copied) error message is logged via LOG.error and thrown as an exception, which eventually ends up in the log as well. We should delete the redundant logging via LOG.error for all instances that are immediately followed by a thrown exception. As a byproduct this cleanup also increases maintainability because these redundant messages would otherwise require consistent updates.