### PR TITLE
Replaced tabs with spaces for consistency

### DIFF
--- a/src/main/python/systemml/mllearn/estimators.py
+++ b/src/main/python/systemml/mllearn/estimators.py
@@ -946,7 +946,7 @@ class Keras2DML(Caffe2DML):
         self.name = keras_model.name
         createJavaObject(sparkSession._sc, 'dummy')
         if not hasattr(keras_model, 'optimizer'):
-		    keras_model.compile(loss='categorical_crossentropy', optimizer=keras.optimizers.SGD(lr=0.01, momentum=0.95, decay=5e-4, nesterov=True))
+            keras_model.compile(loss='categorical_crossentropy', optimizer=keras.optimizers.SGD(lr=0.01, momentum=0.95, decay=5e-4, nesterov=True))
         convertKerasToCaffeNetwork(keras_model, self.name + ".proto", int(batch_size))
         convertKerasToCaffeSolver(keras_model, self.name + ".proto", self.name + "_solver.proto", int(max_iter), int(test_iter), int(test_interval), int(display), lr_policy, weight_decay, regularization_type)
         self.weights = tempfile.mkdtemp() if weights is None else weights


### PR DESCRIPTION
Replaced the tabs on line 949 with spaces for consistency. This prevents conflict with some IDEs causing errors when mixing tabs and spaces. For example:
![systemmml example](https://user-images.githubusercontent.com/13501239/40140551-da6c3d0c-5918-11e8-8662-0050b016f402.JPG)
