### PR TITLE
[SYSTEMML-2380] Should shutdown the thread pool of agg service

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamServer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamServer.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysml.parser.DMLProgram;
@@ -71,7 +72,10 @@ public abstract class ParamServer {
 		catch (InterruptedException e) {
 			throw new DMLRuntimeException("Param server: failed to broadcast the initial model.", e);
 		}
-		_es = Executors.newSingleThreadExecutor();
+		BasicThreadFactory factory = new BasicThreadFactory.Builder()
+			.namingPattern("agg-service-pool-thread-%d")
+			.build();
+		_es = Executors.newSingleThreadExecutor(factory);
 	}
 
 	public abstract void push(int workerID, ListObject value);

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ParamservBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ParamservBuiltinCPInstruction.java
@@ -152,22 +152,20 @@ public class ParamservBuiltinCPInstruction extends ParameterizedBuiltinCPInstruc
 				mode, workerNum, freq, updateType, scheme));
 		}
 
-		// Launch the worker threads and wait for completion
 		try {
+			// Launch the worker threads and wait for completion
 			for (Future<Void> ret : es.invokeAll(workers))
 				ret.get(); //error handling
+			// Fetch the final model from ps
+			ListObject result = ps.getResult();
+			ec.setVariable(output.getName(), result);
 		} catch (InterruptedException | ExecutionException e) {
 			throw new DMLRuntimeException("ParamservBuiltinCPInstruction: some error occurred: ", e);
 		} finally {
 			es.shutdownNow();
+			// Should shutdown the thread pool in param server
+			ps.shutdown();
 		}
-
-		// Fetch the final model from ps
-		ListObject result = ps.getResult();
-		ec.setVariable(output.getName(), result);
-
-		// Should shutdown the thread pool in param server
-		ps.shutdown();
 	}
 
 	private PSModeType getPSMode() {


### PR DESCRIPTION
Hi @mboehm7 ,

Here is a patch for fixing the problem of hanging at the end of the paramserv dml script execution. In general, the reason is that the thread pool of agg service is not shutdowned at the end of execution.

Thanks for the review,
Guobao