### PR TITLE
[SYSTEMML-2416] Use synchronized method instead of single thread pool

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/LocalParamServer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/LocalParamServer.java
@@ -19,8 +19,6 @@
 
 package org.apache.sysml.runtime.controlprogram.paramserv;
 
-import java.util.concurrent.ExecutionException;
-
 import org.apache.sysml.parser.Statement;
 import org.apache.sysml.runtime.DMLRuntimeException;
 import org.apache.sysml.runtime.controlprogram.context.ExecutionContext;
@@ -35,16 +33,7 @@ public class LocalParamServer extends ParamServer {
 
 	@Override
 	public void push(int workerID, ListObject gradients) {
-		try {
-			_gradientsQueue.put(new Gradient(workerID, gradients));
-		} catch (InterruptedException e) {
-			throw new DMLRuntimeException(e);
-		}
-		try {
-			launchService();
-		} catch (ExecutionException | InterruptedException e) {
-			throw new DMLRuntimeException("Aggregate service: some error occurred: ", e);
-		}
+		launchService(new Gradient(workerID, gradients));
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysml/runtime/instructions/cp/ParamservBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/cp/ParamservBuiltinCPInstruction.java
@@ -160,8 +160,6 @@ public class ParamservBuiltinCPInstruction extends ParameterizedBuiltinCPInstruc
 			throw new DMLRuntimeException("ParamservBuiltinCPInstruction: some error occurred: ", e);
 		} finally {
 			es.shutdownNow();
-			// Should shutdown the thread pool in param server
-			ps.shutdown();
 		}
 	}
 


### PR DESCRIPTION
Hi @mboehm7 ,

Here is the PR for leveraging the synchronized update method instead of the callable method. I think that we do not need the single thread pool because the agg service is always invoked in a synchronized manner.

Thanks for the review,
Guobao