### PR TITLE
Profile memory use in JMLC execution

### DIFF
--- a/src/main/java/org/apache/sysml/api/DMLScript.java
+++ b/src/main/java/org/apache/sysml/api/DMLScript.java
@@ -167,6 +167,7 @@ public class DMLScript
 	public static RUNTIME_PLATFORM  rtplatform          = DMLOptions.defaultOptions.execMode;    // the execution mode
 	public static boolean           STATISTICS          = DMLOptions.defaultOptions.stats;       // whether to print statistics
 	public static boolean           FINEGRAINED_STATISTICS  = false;   						     // whether to print fine-grained statistics
+	public static boolean			JMLC_MEMORY_STATISTICS = false; 							 // whether to gather memory use stats in JMLC
 	public static int               STATISTICS_COUNT    = DMLOptions.defaultOptions.statsCount;  // statistics maximum heavy hitter count
 	public static int               STATISTICS_MAX_WRAP_LEN = 30;                                // statistics maximum wrap length
 	public static boolean           ENABLE_DEBUG_MODE   = DMLOptions.defaultOptions.debug;       // debug mode

--- a/src/main/java/org/apache/sysml/api/jmlc/Connection.java
+++ b/src/main/java/org/apache/sysml/api/jmlc/Connection.java
@@ -178,6 +178,24 @@ public class Connection implements Closeable
 		
 		setLocalConfigs();
 	}
+
+	/**
+	 * Sets a boolean flag indicating if runtime statistics should be gathered
+	 * Same behavior as in "MLContext.setStatistics()"
+	 *
+	 * @param stats boolean value with true indicating statistics should be gathered
+	 */
+	public void setStatistics(boolean stats) { DMLScript.STATISTICS = stats; }
+
+	/**
+	 * Sets a boolean flag indicating if memory profiling statistics should be
+	 * gathered.
+	 * @param stats
+	 */
+	public void gatherMemStats(boolean stats) {
+		DMLScript.STATISTICS = stats || DMLScript.STATISTICS;
+		DMLScript.JMLC_MEMORY_STATISTICS = stats;
+	}
 	
 	/**
 	 * Prepares (precompiles) a script and registers input and output variables.

--- a/src/main/java/org/apache/sysml/api/jmlc/PreparedScript.java
+++ b/src/main/java/org/apache/sysml/api/jmlc/PreparedScript.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysml.api.ConfigurableAPI;
 import org.apache.sysml.api.DMLException;
+import org.apache.sysml.api.DMLScript;
 import org.apache.sysml.conf.CompilerConfig;
 import org.apache.sysml.conf.ConfigurationManager;
 import org.apache.sysml.conf.DMLConfig;
@@ -60,6 +61,7 @@ import org.apache.sysml.runtime.matrix.data.MatrixBlock;
 import org.apache.sysml.runtime.matrix.data.OutputInfo;
 import org.apache.sysml.runtime.util.DataConverter;
 import org.apache.sysml.utils.Explain;
+import org.apache.sysml.utils.Statistics;
 
 /**
  * Representation of a prepared (precompiled) DML/PyDML script.
@@ -446,7 +448,7 @@ public class PreparedScript implements ConfigurableAPI
 		
 		//clear thread-local configurations
 		ConfigurationManager.clearLocalConfigs();
-		
+
 		return rvars;
 	}
 	
@@ -458,6 +460,13 @@ public class PreparedScript implements ConfigurableAPI
 	public String explain() {
 		return Explain.explain(_prog);
 	}
+
+	/**
+	 * Return a string containing runtime statistics. Note: these are not thread local
+	 * and will reflect execution in all threads
+	 * @return string containing statistics
+	 */
+	public String statistics() { return Statistics.display(); }
 	
 	/**
 	 * Enables function recompilation, selectively for the given functions. 

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/ProgramBlock.java
@@ -259,6 +259,8 @@ public class ProgramBlock implements ParseInfo
 				Statistics.maintainCPHeavyHitters(
 					tmp.getExtendedOpcode(), System.nanoTime()-t0);
 			}
+			if ((DMLScript.JMLC_MEMORY_STATISTICS) && (DMLScript.FINEGRAINED_STATISTICS))
+				ec.getVariables().getPinnedDataSize();
 
 			// optional trace information (instruction and runtime)
 			if( LOG.isTraceEnabled() ) {

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/caching/CacheableData.java
@@ -55,6 +55,7 @@ import org.apache.sysml.runtime.matrix.data.InputInfo;
 import org.apache.sysml.runtime.matrix.data.OutputInfo;
 import org.apache.sysml.runtime.util.LocalFileUtils;
 import org.apache.sysml.runtime.util.MapReduceTool;
+import org.apache.sysml.utils.Statistics;
 
 
 /**
@@ -503,6 +504,9 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 		
 		setDirty(true);
 		_isAcquireFromEmpty = false;
+
+		if (DMLScript.JMLC_MEMORY_STATISTICS)
+			Statistics.addCPMemObject(newData);
 		
 		//set references to new data
 		if (newData == null)
@@ -569,6 +573,11 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 				}
 				_requiresLocalWrite = false;
 			}
+
+			if ((DMLScript.JMLC_MEMORY_STATISTICS) && (this._data != null)) {
+				int hash = System.identityHashCode(this._data);
+				Statistics.removeCPMemObject(hash);
+			}
 			
 			//create cache
 			createCache();
@@ -597,8 +606,12 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 		// clear existing WB / FS representation (but prevent unnecessary probes)
 		if( !(isEmpty(true)||(_data!=null && isBelowCachingThreshold()) 
 			  ||(_data!=null && !isCachingActive()) )) //additional condition for JMLC
-			freeEvictedBlob();	
-		
+			freeEvictedBlob();
+
+		if ((DMLScript.JMLC_MEMORY_STATISTICS) && (this._data != null)) {
+			int hash = System.identityHashCode(this._data);
+			Statistics.removeCPMemObject(hash);
+		}
 		// clear the in-memory data
 		_data = null;
 		clearCache();


### PR DESCRIPTION
This PR adds utilities to profile memory use during execution in JMLC. Specifically, the following changes were made:

1. Added options `setStatistics()` and `gatherMemStats()` to `api.jmlc.Connection` which control whether or not statistics should be gathered, and if so, whether memory use should be profiled. Also added an appropriate method to `api.jmlc.PreparedScript` to display the resulting statistics. The following points are only applicable when running in JMLC mode, and memory statistics have been enabled. Both these options are `false` by default.
2. Modified `utils.Statistics` to track the memory used by **distinct** `CacheBlock` objects. At the conclusion of the script, the maximum memory use is reported. Memory use is computed by calling the object's `getInMemorySize()` method. This will generally be a slight over-estimate of the actual memory used by the object. 
3. If `FINEGRAINED_STATISTICS` are enabled, `Statistics` will also track the memory use by each named variable in a DML script and report this in a table as in `heavy hitter instructions`. The goal of this is to detect unexpected large intermediate matrices (e.g. resulting from an outer product `X %*% t(X)`).
4. If `FINEGRAINED_STATISTICS` are enabled, `Statistics` will attempt to measure more accurate memory use by checking to see if an object has been garbage collected. This is done by maintaining a soft reference to the object and periodically checking to see if it has become null. This is enabled only when using fine-grained statistics since it introduces potentially non-trivial overheads by scanning a list of live objects. Note that simply using `rmvar` to remove a live variable results in a substantial underestimate of memory used by the program and so this method is not used. When finegrained statistics are not enabled, the resulting statistics will be an overestimate.

Potential impacts to performance: when finegrained statistics are enabled there will be some performance degradation from maintaining the set of live variables.

Potential Improvements: Related to the above, it would be nice to find a way of accurately tracking when an object is actually released without resorting to checking whether a soft reference has become null. It might also be nice to include a line number indicating where a "heavy hitting object" was created to make debugging easier.

@niketanpansare can you please take a look at these changes when you have time and let me know what you think? Below is an example of what statistics output looks like from running a DML script under JMLC:

```
SystemML Statistics:
Total elapsed time:		0.000 sec.
Total compilation time:		0.000 sec.
Total execution time:		0.000 sec.
Number of compiled MR Jobs:	0.
Number of executed MR Jobs:	0.
Cache hits (Mem, WB, FS, HDFS):	227/0/0/0.
Cache writes (WB, FS, HDFS):	0/0/0.
Cache times (ACQr/m, RLS, EXP):	0.001/0.007/0.001/0.000 sec.
Max size of objects in CP memory:	3.794 GB (73 total objects)
HOP DAGs recompiled (PRED, SB):	0/0.
HOP DAGs recompile time:	0.000 sec.
Total JIT compile time:		4.119 sec.
Total JVM GC count:		14.
Total JVM GC time:		1.18 sec.
LibMatrixDNN dense count (conv/bwdF/bwdD/im2col/maxBwd):	0/0/0/0/0.
LibMatrixDNN sparse count (conv/bwdF/bwdD/im2col/maxBwd):	0/0/0/0/0.
LibMatrixDNN conv(im2col/matmult), bwdF (im2col/matmult), bwdD (col2im/matmult) time:	0.000/0.000/0.000/0.000/0.000/0.000 sec.
Heavy hitter instructions:
  #  Instruction            Time(s)  Count  Misc Timers
  1  lmSolve [96:0-96:16]    32.115      1                               
  2  tsmm [41:22-41:25]      26.177      8 rlsi[0.000s,8], aqrd[0.000s,8]
  3  rand [36:12-36:42]       5.030      8                               
  4  jacobian [25:8-25:24]    0.473      8                               
  5  * [79:10-79:10]          0.423      8 aqrd[0.000s,8], rlsi[0.000s,8]
  6  tsmm [31:27-31:27]       0.253      8 rlsi[0.000s,8], aqrd[0.000s,8]
  7  uak+ [80:8-80:13]        0.048      8                               
  8  uak+ [37:16-37:21]       0.040      8                               
  9  uak+ [42:16-42:21]       0.039      8                               
 10  solve [33:12-33:34]      0.036      8                               
Heavy hitter objects:
  #   Object   Memory
  1   _mVar41   762.939 MB
  2   P         762.939 MB
  3   _mVar35   190.735 MB
  4   J         7.629 MB
  5   X         7.629 MB
  6   _mVar32   7.629 MB
  7   _mVar0    7.629 MB
  8   _mVar66   78.168 KB
  9   _mVar68   78.168 KB
  10  _mVar48   78.168 KB
```