### PR TITLE
Updates to JMLC Memory Profiling

### DIFF
--- a/docs/jmlc.md
+++ b/docs/jmlc.md
@@ -55,12 +55,8 @@ JMLC can be configured to gather runtime statistics, as in the MLContext API, by
 method with a value of `true`. JMLC can also be configured to gather statistics on the memory used by matrices and
 frames in the DML script. To enable collection of memory statistics, call Connection's `gatherMemStats()` method
 with a value of `true`. When finegrained statistics are enabled in `SystemML.conf`, JMLC will also report the variables
-in the DML script which used the most memory. By default, the memory use reported will be an overestimte of the actual
-memory required to run the program. When finegrained statistics are enabled, JMLC will gather more accurate statistics
-by keeping track of garbage collection events and reducing the memory estimate accordingly. The most accurate way to
-determine the memory required by a script is to run the script in a single thread and enable finegrained statistics.
-
-An example showing how to enable statistics in JMLC is presented in the section below.
+in the DML script which used the most memory. An example showing how to enable statistics in JMLC is presented in the
+section below.
 
 ---
 

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/caching/CacheableData.java
@@ -487,6 +487,8 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 		if( DMLScript.STATISTICS ){
 			long t1 = System.nanoTime();
 			CacheStatistics.incrementAcquireMTime(t1-t0);
+			if (DMLScript.JMLC_MEMORY_STATISTICS)
+				Statistics.addCPMemObject(System.identityHashCode(this), getDataSize());
 		}
 		
 		return ret;
@@ -504,9 +506,6 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 		
 		setDirty(true);
 		_isAcquireFromEmpty = false;
-
-		if (DMLScript.JMLC_MEMORY_STATISTICS)
-			Statistics.addCPMemObject(newData);
 		
 		//set references to new data
 		if (newData == null)
@@ -573,11 +572,6 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 				}
 				_requiresLocalWrite = false;
 			}
-
-			if ((DMLScript.JMLC_MEMORY_STATISTICS) && (this._data != null)) {
-				int hash = System.identityHashCode(this._data);
-				Statistics.removeCPMemObject(hash);
-			}
 			
 			//create cache
 			createCache();
@@ -608,10 +602,6 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 			  ||(_data!=null && !isCachingActive()) )) //additional condition for JMLC
 			freeEvictedBlob();
 
-		if ((DMLScript.JMLC_MEMORY_STATISTICS) && (this._data != null)) {
-			int hash = System.identityHashCode(this._data);
-			Statistics.removeCPMemObject(hash);
-		}
 		// clear the in-memory data
 		_data = null;
 		clearCache();

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/context/ExecutionContext.java
@@ -59,6 +59,7 @@ import org.apache.sysml.runtime.matrix.data.OutputInfo;
 import org.apache.sysml.runtime.matrix.data.Pair;
 import org.apache.sysml.runtime.util.MapReduceTool;
 import org.apache.sysml.utils.GPUStatistics;
+import org.apache.sysml.utils.Statistics;
 
 
 public class ExecutionContext {
@@ -600,6 +601,8 @@ public class ExecutionContext {
 	}
 	
 	public void cleanupCacheableData(CacheableData<?> mo) {
+		if (DMLScript.JMLC_MEMORY_STATISTICS)
+			Statistics.removeCPMemObject(System.identityHashCode(mo));
 		//early abort w/o scan of symbol table if no cleanup required
 		boolean fileExists = (mo.isHDFSFileExists() && mo.getFileName() != null);
 		if( !CacheableData.isCachingActive() && !fileExists )

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/context/SparkExecutionContext.java
@@ -1097,6 +1097,9 @@ public class SparkExecutionContext extends ExecutionContext
 		//and hence is transparently used by rmvar instructions and other users. The
 		//core difference is the lineage-based cleanup of RDD and broadcast variables.
 
+		if (DMLScript.JMLC_MEMORY_STATISTICS)
+			Statistics.removeCPMemObject(System.identityHashCode(mo));
+
 		if( !mo.isCleanupEnabled() )
 			return;
 		


### PR DESCRIPTION
Following the conversation in https://github.com/apache/systemml/pull/794 with @mboehm7 I have a made a couple improvements to the method used to profile memory use in JMLC:

1. Removed the use of `SoftReference` to track when an object has been garbage collected. Objects are now removed (i.e. the memory used by them is subtracted from the total) when `ExectutionContext.cleanUpCacheableData` is called. This ensures that we always get a consistent maximum memory use which does not change depending on the max heap size used to initialize the JVM.
2. Removed some unneeded code which won't be called during JMLC execution.

Documentation was also updated accordingly.