### PR TITLE
[SYSTEMML-445] Added a rewrite for batch normalization train

### DIFF
--- a/src/main/java/org/apache/sysml/hops/Hop.java
+++ b/src/main/java/org/apache/sysml/hops/Hop.java
@@ -1537,6 +1537,7 @@ public abstract class Hop implements ParseInfo
 		HopsData2String.put(DataOpTypes.PERSISTENTWRITE, "PWrite");
 		HopsData2String.put(DataOpTypes.TRANSIENTWRITE, "TWrite");
 		HopsData2String.put(DataOpTypes.TRANSIENTREAD, "TRead");
+		HopsData2String.put(DataOpTypes.FUNCTIONOUTPUT, "FunOut");
 	}
 
 	public static OpOp2 getOpOp2ForOuterVectorOperation(String op) 

--- a/src/main/java/org/apache/sysml/lops/FunctionCallCP.java
+++ b/src/main/java/org/apache/sysml/lops/FunctionCallCP.java
@@ -46,6 +46,7 @@ public class FunctionCallCP extends Lop
 			for(Hop h : outputHops) {
 				Lop outputLop = h.constructLops();
 				_outputLops.add( outputLop );
+				addOutput(outputLop);
 				// Update the output level if necessary for correct instruction ordering
 				if(outputLop.getLevel() <= getLevel()) {
 					outputLop.updateLevel(getLevel()+1);

--- a/src/main/java/org/apache/sysml/lops/FunctionCallCP.java
+++ b/src/main/java/org/apache/sysml/lops/FunctionCallCP.java
@@ -42,8 +42,15 @@ public class FunctionCallCP extends Lop
 		this(inputs, fnamespace, fname, outputs, et);
 		if(outputHops != null) {
 			_outputLops = new ArrayList<>();
-			for(Hop h : outputHops)
-				_outputLops.add( h.constructLops() );
+			setLevel();
+			for(Hop h : outputHops) {
+				Lop outputLop = h.constructLops();
+				_outputLops.add( outputLop );
+				// Update the output level if necessary for correct instruction ordering
+				if(outputLop.getLevel() <= getLevel()) {
+					outputLop.updateLevel(getLevel()+1);
+				}
+			}
 		}
 	}
 	

--- a/src/main/java/org/apache/sysml/lops/Lop.java
+++ b/src/main/java/org/apache/sysml/lops/Lop.java
@@ -343,6 +343,19 @@ public abstract class Lop
 		lps.setLevel(inputs);
 	}
 	
+	protected void updateLevel(int newLevel) {
+		if(newLevel < getLevel()) {
+			throw new RuntimeException("Decrement the levels not supported.");
+		}
+		else if(newLevel > getLevel()) {
+			lps.setLevel(newLevel);
+			for(Lop out : outputs) {
+				if(out.getLevel() < newLevel+1)
+					out.updateLevel(newLevel+1);
+			}
+		}
+	}
+	
 	/**
 	 * Method to get the location property of LOP
 	 * 

--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -2001,8 +2001,8 @@ public class DMLTranslator
 				String[] outputNames = new String[targetList.size()]; 
 				outputNames[0] = ((DataIdentifier)targetList.get(0)).getName();
 				outputNames[1] = ((DataIdentifier)targetList.get(1)).getName();
-				outputs.add(new DataOp(outputNames[0], DataType.MATRIX, ValueType.DOUBLE, inputs.get(0), DataOpTypes.FUNCTIONOUTPUT, outputNames[0]));
-				outputs.add(new DataOp(outputNames[1], DataType.FRAME, ValueType.STRING, inputs.get(0), DataOpTypes.FUNCTIONOUTPUT, outputNames[1]));
+				outputs.add(new DataOp(outputNames[0], DataType.MATRIX, ValueType.DOUBLE, inputs.get(0), DataOpTypes.FUNCTIONOUTPUT, inputs.get(0).getFilename()));
+				outputs.add(new DataOp(outputNames[1], DataType.FRAME, ValueType.STRING, inputs.get(0), DataOpTypes.FUNCTIONOUTPUT, inputs.get(0).getFilename()));
 				
 				currBuiltinOp = new FunctionOp(ftype, nameSpace, source.getOpCode().toString(), inputs, outputNames, outputs);
 				break;
@@ -2234,7 +2234,7 @@ public class DMLTranslator
 			String[] outputNames = new String[targetList.size()]; 
 			for ( int i=0; i < targetList.size(); i++ ) {
 				outputNames[i] = ((DataIdentifier)targetList.get(i)).getName();
-				Hop output = new DataOp(outputNames[i], DataType.MATRIX, ValueType.DOUBLE, inputs.get(0), DataOpTypes.FUNCTIONOUTPUT, outputNames[i]);
+				Hop output = new DataOp(outputNames[i], DataType.MATRIX, ValueType.DOUBLE, inputs.get(0), DataOpTypes.FUNCTIONOUTPUT, inputs.get(0).getFilename());
 				outputs.add(output);
 			}
 			

--- a/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
@@ -61,6 +61,7 @@ public class GPUInstructionParser  extends InstructionParser
 		String2GPUInstructionType.put( "batch_norm2d",           GPUINSTRUCTION_TYPE.Dnn);
 		String2GPUInstructionType.put( "batch_norm2d_backward",  GPUINSTRUCTION_TYPE.Dnn);
 		String2GPUInstructionType.put( "batch_norm2d_test",      GPUINSTRUCTION_TYPE.Dnn);
+		String2GPUInstructionType.put( "batch_norm2d_train",      GPUINSTRUCTION_TYPE.Dnn);
 		
 		// Matrix Multiply Operators
 		String2GPUInstructionType.put( "ba+*",  GPUINSTRUCTION_TYPE.AggregateBinary);

--- a/src/test/java/org/apache/sysml/test/gpu/BatchNormTest.java
+++ b/src/test/java/org/apache/sysml/test/gpu/BatchNormTest.java
@@ -46,10 +46,10 @@ public class BatchNormTest extends GPUTests {
 		testBatchNormForward("test");
 	}
 	
-//	@Test
-//	public void testBatchNormForwardTrain() {
-//		testBatchNormForward("train");
-//	}
+	@Test
+	public void testBatchNormForwardTrain() {
+		testBatchNormForward("train");
+	}
 	
 	private void testBatchNormForward(String mode) {
 		int imgSize = 32; 

--- a/src/test/java/org/apache/sysml/test/gpu/BatchNormTest.java
+++ b/src/test/java/org/apache/sysml/test/gpu/BatchNormTest.java
@@ -79,7 +79,6 @@ public class BatchNormTest extends GPUTests {
 			// Handle loss of precision in CuDNN kernel 
 			threshold[2] = 1e-3;
 			for(int i = 0; i < outputs.size()-1; i++) {
-				System.out.println(">>> " + i);
 				assertEqualObjects(outCPU.get(i), outGPU.get(i), threshold[i]);
 			}
 		}

--- a/src/test/java/org/apache/sysml/test/gpu/GPUTests.java
+++ b/src/test/java/org/apache/sysml/test/gpu/GPUTests.java
@@ -349,6 +349,7 @@ public abstract class GPUTests extends AutomatedTestBase {
 		// and other side effects.
 		synchronized(GPUTests.class) {
 			MLContext gpuMLC = new MLContext(spark);
+			// gpuMLC.setExplain(true); gpuMLC.setExplainLevel("recompile_runtime");
 			gpuMLC.setConfigProperty("sysml.floating.point.precision", FLOATING_POINT_PRECISION);
 			if(IGNORE_CLEAR_MEMORY_BUG)
 				gpuMLC.setConfigProperty("sysml.gpu.eager.cudaFree", "true");


### PR DESCRIPTION
- This PR fuses a batch normalization train pattern into a FunctionOp. The method `batchNormTrain` in `RewriteGPUSpecificOps` performs the fusing.
- This rewrite is only enabled if none of the outputs are persistent writes. It replaces the existing outputs of the matched pattern with transient reads.

@mboehm7 @bertholdreinwald @nakul02 Since this is a multi-output hop rewrite, can you please review this PR and let me know if there are any major concerns ? We can use this approach to add more GPU rewrites that can invoke CuDNN kernels.