### PR TITLE
[SYSTEMML-2446] Fix the cleanup of list object

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/LocalPSWorker.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/LocalPSWorker.java
@@ -85,7 +85,7 @@ public class LocalPSWorker extends PSWorker implements Callable<Void> {
 				// Update the local model with gradients
 				if( j < totalIter - 1 )
 					params = updateModel(params, gradients, i, j, totalIter);
-				ParamservUtils.cleanupListObject(gradients);
+				ParamservUtils.cleanupListObject(_ec, gradients);
 			}
 
 			// Push the gradients to ps
@@ -183,8 +183,8 @@ public class LocalPSWorker extends PSWorker implements Callable<Void> {
 		// Get the gradients
 		ListObject gradients = (ListObject) _ec.getVariable(_output.getName());
 
-		ParamservUtils.cleanupData(bFeatures);
-		ParamservUtils.cleanupData(bLabels);
+		ParamservUtils.cleanupData(_ec, bFeatures);
+		ParamservUtils.cleanupData(_ec, bLabels);
 		return gradients;
 	}
 }

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamServer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamServer.java
@@ -192,11 +192,11 @@ public abstract class ParamServer
 		// Invoke the aggregate function
 		_inst.processInstruction(ec);
 
-		// Get the output
+		// Get the new model
 		ListObject newModel = (ListObject) ec.getVariable(_outputName);
 
-		// Update the model with the new output
-		ParamservUtils.cleanupListObject(ec, Statement.PS_MODEL);
+		// Clean up the list according to the data referencing status
+		ParamservUtils.cleanupListObject(ec, Statement.PS_MODEL, newModel.getStatus());
 		ParamservUtils.cleanupListObject(ec, Statement.PS_GRADIENTS);
 		return newModel;
 	}

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamServer.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamServer.java
@@ -138,7 +138,7 @@ public abstract class ParamServer
 							_accGradients, gradients, true);
 					else
 						updateGlobalModel(gradients);
-					ParamservUtils.cleanupListObject(gradients);
+					ParamservUtils.cleanupListObject(_ec, gradients);
 
 					if (allFinished()) {
 						// Update the global model with accrued gradients

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamservUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamservUtils.java
@@ -108,7 +108,7 @@ public class ParamservUtils {
 	 */
 	public static void cleanupListObject(ExecutionContext ec, String lName) {
 		ListObject lo = (ListObject) ec.removeVariable(lName);
-		cleanupListObject(lo, lo.getStatus());
+		cleanupListObject(ec, lo, lo.getStatus());
 	}
 
 	/**
@@ -119,28 +119,28 @@ public class ParamservUtils {
 	 */
 	public static void cleanupListObject(ExecutionContext ec, String lName, boolean[] status) {
 		ListObject lo = (ListObject) ec.removeVariable(lName);
-		cleanupListObject(lo, status);
+		cleanupListObject(ec, lo, status);
 	}
 
-	public static void cleanupListObject(ListObject lo) {
-		cleanupListObject(lo, lo.getStatus());
+	public static void cleanupListObject(ExecutionContext ec, ListObject lo) {
+		cleanupListObject(ec, lo, lo.getStatus());
 	}
 
-	public static void cleanupListObject(ListObject lo, boolean[] status) {
+	public static void cleanupListObject(ExecutionContext ec, ListObject lo, boolean[] status) {
 		for (int i = 0; i < lo.getLength(); i++) {
 			if (status != null && !status[i]) {
 				continue; // data referenced by other object (could not be cleaned up)
 			}
-			ParamservUtils.cleanupData(lo.getData().get(i));
+			ParamservUtils.cleanupData(ec, lo.getData().get(i));
 		}
 	}
 
-	public static void cleanupData(Data data) {
+	public static void cleanupData(ExecutionContext ec, Data data) {
 		if (!(data instanceof CacheableData))
 			return;
 		CacheableData<?> cd = (CacheableData<?>) data;
 		cd.enableCleanup(true);
-		cd.clearData();
+		ec.cleanupCacheableData(cd);
 	}
 
 	public static MatrixObject newMatrixObject(MatrixBlock mb) {

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamservUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamservUtils.java
@@ -101,13 +101,38 @@ public class ParamservUtils {
 		return new ListObject(newData, lo.getNames());
 	}
 
+	/**
+	 * Clean up the list object according to its own data status
+	 * @param ec execution context
+	 * @param lName list var name
+	 */
 	public static void cleanupListObject(ExecutionContext ec, String lName) {
 		ListObject lo = (ListObject) ec.removeVariable(lName);
-		cleanupListObject(lo);
+		cleanupListObject(lo, lo.getStatus());
+	}
+
+	/**
+	 * Clean up the list object according to the given array of data status (i.e., false => not be removed)
+	 * @param ec execution context
+	 * @param lName list var name
+	 * @param status data status
+	 */
+	public static void cleanupListObject(ExecutionContext ec, String lName, boolean[] status) {
+		ListObject lo = (ListObject) ec.removeVariable(lName);
+		cleanupListObject(lo, status);
 	}
 
 	public static void cleanupListObject(ListObject lo) {
-		lo.getData().forEach(ParamservUtils::cleanupData);
+		cleanupListObject(lo, lo.getStatus());
+	}
+
+	public static void cleanupListObject(ListObject lo, boolean[] status) {
+		for (int i = 0; i < lo.getLength(); i++) {
+			if (status != null && !status[i]) {
+				continue; // data referenced by other object (could not be cleaned up)
+			}
+			ParamservUtils.cleanupData(lo.getData().get(i));
+		}
 	}
 
 	public static void cleanupData(Data data) {


### PR DESCRIPTION
Hi @mboehm7 ,

Here is the PR for fixing the cleanup of list object. The idea is to not remove the matrix block which is referenced in the previous matrix object. Because when doing the partial model update, there will be some parameters unchanged (i.e., the matrix block remains the same).

Thanks for the review,
Guobao