### PR TITLE
[MINOR] Remove redundant `int n` from fm::init() function 

### DIFF
--- a/scripts/nn/layers/fm.dml
+++ b/scripts/nn/layers/fm.dml
@@ -109,7 +109,7 @@ backward = function(matrix[double] dout, matrix[double] X, matrix[double] w0, ma
   # dV = mean(dout) * (t(X) %*% X %*%V) - g_V2
 }
 
-init = function(int n, int d, int k)
+init = function(int d, int k)
     return (matrix[double] w0, matrix[double] W, matrix[double] V) {
   /*
    * This function initializes the parameters.

--- a/scripts/nn/test/grad_check.dml
+++ b/scripts/nn/test/grad_check.dml
@@ -1142,7 +1142,7 @@ fm = function() {
   k = 2 # factorization dimensionality
   X = rand(rows=n, cols=d)
   y = rand(rows=n, cols=1)
-  [w0, W, V] = fm::init(n, d, k)
+  [w0, W, V] = fm::init(d, k)
 
   # Compute analytical gradients of loss wrt parameters
   out = fm::forward(X, w0, W, V)

--- a/scripts/staging/fm-binclass.dml
+++ b/scripts/staging/fm-binclass.dml
@@ -56,7 +56,7 @@ train = function(matrix[double] X, matrix[double] y, matrix[double] X_val, matri
     k = 2; # factorization dimensionality, only(=2) possible for now.
 
     # 1.initialize fm core
-    [w0, W, V] = fm::init(n, d, k);
+    [w0, W, V] = fm::init(d, k);
 
     # 2.initialize adam optimizer
     ## Default values for some parameters

--- a/scripts/staging/fm-regression.dml
+++ b/scripts/staging/fm-regression.dml
@@ -55,7 +55,7 @@ train = function(matrix[double] X, matrix[double] y, matrix[double] X_val, matri
                 #   only (=2) possible
 
     # 1.initialize fm core
-    [w0, W, V] = fm::init(n, d, k);
+    [w0, W, V] = fm::init(d, k);
 
     # 2.initialize adam optimizer
     ## Default values for some parameters


### PR DESCRIPTION
Removed the redundant variable `n`.

- [x] Ran the dummy data scripts to ensure everything works properly.