### PR TITLE
[SYSTEMML-2469] Fix the overhead problem

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/LocalPSWorker.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/LocalPSWorker.java
@@ -191,8 +191,8 @@ public class LocalPSWorker extends PSWorker implements Callable<Void> {
 		// Get the gradients
 		ListObject gradients = (ListObject) _ec.getVariable(_output.getName());
 
-		ParamservUtils.cleanupData(_ec, bFeatures);
-		ParamservUtils.cleanupData(_ec, bLabels);
+		ParamservUtils.cleanupData(_ec, Statement.PS_FEATURES);
+		ParamservUtils.cleanupData(_ec, Statement.PS_LABELS);
 		return gradients;
 	}
 	

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamservUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamservUtils.java
@@ -145,14 +145,14 @@ public class ParamservUtils {
 		CacheableData<?> cd = (CacheableData<?>) data;
 		cd.enableCleanup(true);
 		ec.cleanupCacheableData(cd);
-		if (LOG.isDebugEnabled()) {
-			LOG.debug(String.format("%s has been deleted.", cd.getFileName()));
-		}
 	}
 
-	public static void cleanupMatrixObject(ExecutionContext ec, MatrixObject mo) {
-		mo.enableCleanup(true);
-		ec.cleanupCacheableData(mo);
+	public static void cleanupData(ExecutionContext ec, String varName) {
+		cleanupData(ec, ec.removeVariable(varName));
+	}
+
+	public static void cleanupListObject(ListObject lo) {
+		cleanupListObject(ExecutionContextFactory.createContext(), lo);
 	}
 
 	public static MatrixObject newMatrixObject(MatrixBlock mb) {

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamservUtils.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/ParamservUtils.java
@@ -335,35 +335,23 @@ public class ParamservUtils {
 	/**
 	 * Assemble the matrix of features and labels according to the rowID
 	 *
-	 * @param numRows row size of the data
 	 * @param featuresRDD indexed features matrix block
 	 * @param labelsRDD indexed labels matrix block
 	 * @return Assembled rdd with rowID as key while matrix of features and labels as value (rowID -> features, labels)
 	 */
-	public static JavaPairRDD<Long, Tuple2<MatrixBlock, MatrixBlock>> assembleTrainingData(long numRows, JavaPairRDD<MatrixIndexes, MatrixBlock> featuresRDD, JavaPairRDD<MatrixIndexes, MatrixBlock> labelsRDD) {
-		JavaPairRDD<Long, MatrixBlock> fRDD = groupMatrix(numRows, featuresRDD);
-		JavaPairRDD<Long, MatrixBlock> lRDD = groupMatrix(numRows, labelsRDD);
+	public static JavaPairRDD<Long, Tuple2<MatrixBlock, MatrixBlock>> assembleTrainingData(JavaPairRDD<MatrixIndexes, MatrixBlock> featuresRDD, JavaPairRDD<MatrixIndexes, MatrixBlock> labelsRDD) {
+		JavaPairRDD<Long, MatrixBlock> fRDD = groupMatrix(featuresRDD);
+		JavaPairRDD<Long, MatrixBlock> lRDD = groupMatrix(labelsRDD);
 		//TODO Add an additional physical operator which broadcasts the labels directly (broadcast join with features) if certain memory budgets are satisfied
 		return fRDD.join(lRDD);
 	}
 
-	private static JavaPairRDD<Long, MatrixBlock> groupMatrix(long numRows, JavaPairRDD<MatrixIndexes, MatrixBlock> rdd) {
+	private static JavaPairRDD<Long, MatrixBlock> groupMatrix(JavaPairRDD<MatrixIndexes, MatrixBlock> rdd) {
 		//TODO could use join and aggregation to avoid unnecessary shuffle introduced by reduceByKey
 		return rdd.mapToPair(input -> new Tuple2<>(input._1.getRowIndex(), new Tuple2<>(input._1.getColumnIndex(), input._2)))
 			.aggregateByKey(new LinkedList<Tuple2<Long, MatrixBlock>>(),
-				new Partitioner() {
-					private static final long serialVersionUID = -7032660778344579236L;
-					@Override
-					public int getPartition(Object rblkID) {
-						return Math.toIntExact((Long) rblkID);
-					}
-					@Override
-					public int numPartitions() {
-						return Math.toIntExact(numRows);
-					}
-				},
 				(list, input) -> {
-					list.add(input); 
+					list.add(input);
 					return list;
 				}, 
 				(l1, l2) -> {
@@ -392,7 +380,7 @@ public class ParamservUtils {
 
 		DataPartitionerSparkMapper mapper = new DataPartitionerSparkMapper(scheme, workerNum, sec, (int) features.getNumRows());
 		JavaPairRDD<Integer, Tuple2<MatrixBlock, MatrixBlock>> result = ParamservUtils
-			.assembleTrainingData(features.getNumRows(), featuresRDD, labelsRDD) // Combine features and labels into a pair (rowBlockID => (features, labels))
+			.assembleTrainingData(featuresRDD, labelsRDD) // Combine features and labels into a pair (rowBlockID => (features, labels))
 			.flatMapToPair(mapper) // Do the data partitioning on spark (workerID => (rowBlockID, (single row features, single row labels))
 			// Aggregate the partitioned matrix according to rowID for each worker
 			// i.e. (workerID => ordered list[(rowBlockID, (single row features, single row labels)]

--- a/src/test/java/org/apache/sysml/test/integration/functions/paramserv/RpcObjectTest.java
+++ b/src/test/java/org/apache/sysml/test/integration/functions/paramserv/RpcObjectTest.java
@@ -32,27 +32,27 @@ import org.junit.Test;
 
 public class RpcObjectTest {
 
-	@Test
-	public void testPSRpcCall() throws IOException {
+	private ListObject generateData() {
 		MatrixObject mo1 = SerializationTest.generateDummyMatrix(10);
 		MatrixObject mo2 = SerializationTest.generateDummyMatrix(20);
-		ListObject lo = new ListObject(Arrays.asList(mo1, mo2));
-		PSRpcCall expected = new PSRpcCall(PSRpcObject.PUSH, 1, lo);
+		return new ListObject(Arrays.asList(mo1, mo2));
+	}
+
+	@Test
+	public void testPSRpcCall() throws IOException {
+		PSRpcCall expected = new PSRpcCall(PSRpcObject.PUSH, 1, generateData());
 		PSRpcCall actual = new PSRpcCall(expected.serialize());
 		Assert.assertTrue(Arrays.equals(
-			expected.serialize().array(),
+			new PSRpcCall(PSRpcObject.PUSH, 1, generateData()).serialize().array(),
 			actual.serialize().array()));
 	}
 
 	@Test
 	public void testPSRpcResponse() throws IOException {
-		MatrixObject mo1 = SerializationTest.generateDummyMatrix(10);
-		MatrixObject mo2 = SerializationTest.generateDummyMatrix(20);
-		ListObject lo = new ListObject(Arrays.asList(mo1, mo2));
-		PSRpcResponse expected = new PSRpcResponse(PSRpcResponse.Type.SUCCESS, lo);
+		PSRpcResponse expected = new PSRpcResponse(PSRpcResponse.Type.SUCCESS, generateData());
 		PSRpcResponse actual = new PSRpcResponse(expected.serialize());
 		Assert.assertTrue(Arrays.equals(
-			expected.serialize().array(),
+			new PSRpcResponse(PSRpcResponse.Type.SUCCESS, generateData()).serialize().array(),
 			actual.serialize().array()));
 	}
 }


### PR DESCRIPTION
Hi @mboehm7 ,

Here is the PR for fixing the problem of overhead in the context of distributed ps. In general, the problem of large task is resolved by removing the incorrect partitioner which is for assembling features and labels together. And the problem of missing cleanup for some rpc objects is due to that the way of communication between ps and workers in distributed ps is different from the local ps. All the data will be transferred by deep serialization so they should be cleaned up after the rpc operation, while in local ps the data will be shared for execution directly between threads.

Thanks for the review,
Guobao