### PR TITLE
Adds Commons-Lang3 to Standalone JAR Dependencies

### DIFF
--- a/src/assembly/standalone-jar.xml
+++ b/src/assembly/standalone-jar.xml
@@ -81,7 +81,7 @@
 				<include>*:commons-configuration*</include>
 				<include>*:commons-httpclient*</include>
 				<include>*:commons-io*</include>
-				<include>*:commons-lang</include>
+				<include>*:commons-lang*</include>
 				<include>*:commons-logging*</include>
 				<include>*:commons-math3*</include>
 				<include>*:guava*</include>


### PR DESCRIPTION
JMLC has a dependency on `org/apache/commons/lang3/EnumUtils` which causes a `NoClassDefFoundError` when running with the standalone jar. This PR adds this dependency. @bertholdreinwald @niketanpansare can you please take a look and let me know if you approve. 