### PR TITLE
Fixes a minor bug in LRU cache

### DIFF
--- a/src/main/java/org/apache/sysml/utils/PersistentLRUCache.java
+++ b/src/main/java/org/apache/sysml/utils/PersistentLRUCache.java
@@ -462,7 +462,7 @@ class DataWrapper {
 			return _dArr.length*Double.BYTES;
 		else if(_fArr != null)
 			return _fArr.length*Float.BYTES;
-		else if(_fArr != null)
+		else if(_mb != null)
 			return _mb.getInMemorySize();
 		else
 			throw new DMLRuntimeException("Not implemented");


### PR DESCRIPTION
@niketanpansare There is a minor bug in `PersistentLRUCache` which causes an exception to be improperly thrown when caching `MatrixBlock`. This PR should fix the issue.