### PR TITLE
[MINOR] Adds method to unpin data in JMLC

### DIFF
--- a/src/main/java/org/apache/sysml/api/jmlc/PreparedScript.java
+++ b/src/main/java/org/apache/sysml/api/jmlc/PreparedScript.java
@@ -73,7 +73,7 @@ public class PreparedScript implements ConfigurableAPI
 	//input/output specification
 	private final HashSet<String> _inVarnames;
 	private final HashSet<String> _outVarnames;
-	private final HashMap<String,Data> _inVarReuse;
+	private final LocalVariableMap _inVarReuse;
 	
 	//internal state (reused)
 	private final Program _prog;
@@ -92,7 +92,7 @@ public class PreparedScript implements ConfigurableAPI
 		_vars.setRegisteredOutputs(that._outVarnames);
 		_inVarnames = that._inVarnames;
 		_outVarnames = that._outVarnames;
-		_inVarReuse = new HashMap<>(that._inVarReuse);
+		_inVarReuse = new LocalVariableMap(that._inVarReuse);
 		_dmlconf = that._dmlconf;
 		_cconf = that._cconf;
 	}
@@ -115,7 +115,7 @@ public class PreparedScript implements ConfigurableAPI
 		Collections.addAll(_inVarnames, inputs);
 		_outVarnames = new HashSet<>();
 		Collections.addAll(_outVarnames, outputs);
-		_inVarReuse = new HashMap<>();
+		_inVarReuse = new LocalVariableMap();
 		
 		//attach registered outputs (for dynamic recompile)
 		_vars.setRegisteredOutputs(_outVarnames);
@@ -433,7 +433,16 @@ public class PreparedScript implements ConfigurableAPI
 	public void clearParameters() {
 		_vars.removeAll();
 	}
-	
+
+	/**
+	 * Remove all references to pinned variables from this script.
+	 * Note: this *does not* remove the underlying data. It merely
+	 * removes a reference to it from this prepared script. This is
+	 * useful if you want to maintain an independent cache of weights
+	 * and allow the JVM to garbage collect under memory pressure.
+	 */
+	public void clearPinnedData() { _inVarReuse.removeAll(); }
+
 	/**
 	 * Executes the prepared script over the bound inputs, creating the
 	 * result variables according to bound and registered outputs.

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/LocalVariableMap.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/LocalVariableMap.java
@@ -96,6 +96,8 @@ public class LocalVariableMap implements Cloneable
 		localMap.putAll(vals);
 	}
 
+	public void putAll(LocalVariableMap vars) { putAll(vars.localMap); }
+
 	public Data remove( String name ) {
 		return localMap.remove( name );
 	}


### PR DESCRIPTION
There are instances in which it's useful to be able to "unpin" variables in JMLC. For example, when executing several different JMLC scripts in the same JVM, I manage model weights externally using a cache of `SoftReferences` to the underlying matrix blocks. Each script gets a slice of time on a CPU during which I want the weights pinned. However, once I am done with a script I would like the weights to be free for garbage collection under memory pressure which is not possible if the script holds a reference to the weight as a reused variable. For the sake of consistency, I have also switched from storing references to pinned data in a `HashMap<String,Data>` to a `LocalVariableMap`. 