### PR TITLE
[SYSTEMML-1325] Bugfix when cleaning up temporary GPU memory via JMLC

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUMatrixMemoryManager.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUMatrixMemoryManager.java
@@ -94,10 +94,12 @@ public class GPUMatrixMemoryManager {
 	 * Get pointers from the first memory sections "Matrix Memory"
 	 * @param locked return locked pointers if true
 	 * @param dirty return dirty pointers if true
+	 * @param isCleanupEnabled return pointers marked for cleanup if true
 	 * @return set of pointers
 	 */
-	Set<Pointer> getPointers(boolean locked, boolean dirty) {
-		return gpuObjects.stream().filter(gObj -> gObj.isLocked() == locked && gObj.isDirty() == dirty).flatMap(gObj -> getPointers(gObj).stream()).collect(Collectors.toSet());
+	Set<Pointer> getPointers(boolean locked, boolean dirty, boolean isCleanupEnabled) {
+		return gpuObjects.stream().filter(gObj -> gObj.isLocked() == locked && gObj.isDirty() == dirty
+				&& gObj.mat.isCleanupEnabled() == isCleanupEnabled).flatMap(gObj -> getPointers(gObj).stream()).collect(Collectors.toSet());
 	}
 	
 	/**

--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUMemoryManager.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUMemoryManager.java
@@ -516,8 +516,10 @@ public class GPUMemoryManager {
 	 * Clears up the memory used by non-dirty pointers.
 	 */
 	public void clearTemporaryMemory() {
-		// To record the cuda block sizes needed by allocatedGPUObjects, others are cleared up.
-		Set<Pointer> unlockedDirtyPointers = matrixMemoryManager.getPointers(false, true);
+		// We cleanup non-dirty pointers, except those that are:
+		// 1. Locked by other instructions AND
+		// 2. Not marked for cleanup  by JMLC API.
+		Set<Pointer> unlockedDirtyPointers = matrixMemoryManager.getPointers(false, true, false);
 		Set<Pointer> temporaryPointers = nonIn(allPointers.keySet(), unlockedDirtyPointers);
 		for(Pointer tmpPtr : temporaryPointers) {
 			guardedCudaFree(tmpPtr);


### PR DESCRIPTION
- When cleaning up the temporary GPU memory, we should skip unpinned
matrices.

@thomas9t can you please review this PR ?