### PR TITLE
[SYSTEMML-1325] Bugfix for GPU memory manager clear temporary memory

### DIFF
--- a/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/gpu/context/GPUObject.java
@@ -68,7 +68,7 @@ public class GPUObject {
 	/**
 	 * Pointer to the underlying sparse matrix block on GPU
 	 */
-	private CSRPointer jcudaSparseMatrixPtr = null;
+	CSRPointer jcudaSparseMatrixPtr = null;
 
 	/**
 	 * whether the block attached to this {@link GPUContext} is dirty on the device and needs to be copied back to host


### PR DESCRIPTION
In `GPUMemoryManager.clearTemporaryMemory()` we deallocate pointers but do not set the corresponding `Pointer` slots to `null` in the associated `GPUObject` instances. This can lead to attempted double-freeing of Pointers which results in an exception. This PR fixes this issue by creating a list of GPU objects associated with Pointers that have been freed as part of `clearTemporaryMemory()` and setting the corresponding pointer slots to `null`. This PR also addresses a minor issue with cleanup in JMLC which was causing Pointers for pinned data to be improperly cleared. Note this PR will reduce performance of `GPUMemoryManager.clearTemporaryMemory()` because it is now necessary to search through the list of managed `GPUObjects` to find the ones corresponding to pointers being freed. However, this method is only called once at the end of script invocation and so the performance cost will be small.

@niketanpansare can you please take a look and let me know what you think?