### PR TITLE
[MINOR] change hadoop version from 2.6.0 to 2.7.7 in pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ SystemML's distinguishing characteristics are:
   2. **Multiple execution modes**, including Spark MLContext API, Spark Batch, Hadoop Batch, Standalone, and JMLC.
   3. **Automatic optimization** based on data and cluster characteristics to ensure both efficiency and scalability.
 
-The latest version of SystemML supports: Java 8+, Scala 2.11+, Python 2.7/3.5+, Hadoop 2.6+, and Spark 2.1+.
+The latest version of SystemML supports: Java 8+, Scala 2.11+, Python 2.7/3.5+, Hadoop 2.7.7+, and Spark 2.1+.
 
 
 ## Algorithm Customizability

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 	</mailingLists>
 
 	<properties>
-		<hadoop.version>2.6.0</hadoop.version>
+		<hadoop.version>2.7.7</hadoop.version>
 		<antlr.version>4.5.3</antlr.version>
 		<spark.version>2.1.0</spark.version>
 		<scala.version>2.11.8</scala.version>


### PR DESCRIPTION
Hadoop 2.6.0 has several vulnerabilities. We upgrade to 2.7.7 to avoid
these vulnerabilities.