### PR TITLE
Systemml 2526 Date.getTime() can be changed to System.currentTimeMillis()

### DIFF
--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -334,7 +334,7 @@ public class MLContext implements ConfigurableAPI
 		try {
 			executionScript = script;
 
-			Long time = System.currentTimeMillis();
+			Long time = new Long(System.currentTimeMillis());
 			if ((script.getName() == null) || (script.getName().equals(""))) {
 				script.setName(time.toString());
 			}

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContext.java
@@ -334,7 +334,7 @@ public class MLContext implements ConfigurableAPI
 		try {
 			executionScript = script;
 
-			Long time = new Long((new Date()).getTime());
+			Long time = System.currentTimeMillis();
 			if ((script.getName() == null) || (script.getName().equals(""))) {
 				script.setName(time.toString());
 			}

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -1255,7 +1255,7 @@ public final class MLContextUtil {
 			}
 			scriptExecutor.setMaintainSymbolTable(mlCtx.isMaintainSymbolTable());
 
-			Long time = new Long((new Date()).getTime());
+			Long time = System.currentTimeMillis();
 			if ((script.getName() == null) || (script.getName().equals(""))) {
 				script.setName(time.toString());
 			}

--- a/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
+++ b/src/main/java/org/apache/sysml/api/mlcontext/MLContextUtil.java
@@ -1255,7 +1255,7 @@ public final class MLContextUtil {
 			}
 			scriptExecutor.setMaintainSymbolTable(mlCtx.isMaintainSymbolTable());
 
-			Long time = System.currentTimeMillis();
+			Long time = new Long(System.currentTimeMillis());
 			if ((script.getName() == null) || (script.getName().equals(""))) {
 				script.setName(time.toString());
 			}


### PR DESCRIPTION
new Date() is just a thin wrapper around System.currentTimeMillis(). Using System.currentTimeMillis() can help speed up the system