### PR TITLE
[SYSTEMML-2537] Improve the consistency of predicates in "if-then-else" expressions

### DIFF
--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -1546,15 +1546,28 @@ public class DMLTranslator
 			} else if ((predicate instanceof IntIdentifier && ((IntIdentifier) predicate).getValue() == 1)
 					|| (predicate instanceof DoubleIdentifier && ((DoubleIdentifier) predicate).getValue() == 1.0)) {
 				cp.setPredicate(new BooleanIdentifier(true, predicate));
-			} else if (predicate instanceof IntIdentifier || predicate instanceof DoubleIdentifier) {
-				cp.setPredicate(new BooleanIdentifier(true, predicate));
-				LOG.warn(predicate.printWarningLocation() + "Numerical value '" + predicate.toString()
-						+ "' (!= 0/1) is converted to boolean TRUE by DML");
-			} else if (predicate instanceof StringIdentifier) {
-				throw new ParseException(predicate.printErrorLocation() + "String value '" + predicate.toString()
-						+ "' is not allowed for iterable predicate");
-			}
-			predicateHops = processExpression(cp.getPredicate(), null, _ids);
+                        } else if (predicate instanceof IntIdentifier) {
+                          if (((IntIdentifier) predicate).getValue() < 0) {
+                            cp.setPredicate(new BooleanIdentifier(false, predicate));
+                            LOG.warn(predicate.printWarningLocation() + "Numerical value '" + predicate.toString() + "' (!= 0/1) is converted to boolean FALSE by DML");
+                          }
+                          else {
+                            cp.setPredicate(new BooleanIdentifier(true, predicate));
+                            LOG.warn(predicate.printWarningLocation() + "Numerical value '" + predicate.toString() + "' (!= 0/1) is converted to boolean TRUE by DML");
+                          }
+                        } else if (predicate instanceof DoubleIdentifier) {
+                          if (((DoubleIdentifier) predicate).getValue() < 0) {
+                            cp.setPredicate(new BooleanIdentifier(false, predicate));
+                            LOG.warn(predicate.printWarningLocation() + "Numerical value '" + predicate.toString() + "' (!= 0/1) is converted to boolean FALSE by DML");
+                          } else {
+                            cp.setPredicate(new BooleanIdentifier(true, predicate));
+                            LOG.warn(predicate.printWarningLocation() + "Numerical value '" + predicate.toString() + "' (!= 0/1) is converted to boolean TRUE by DML");
+                          }
+                        } else if (predicate instanceof StringIdentifier) {
+                                throw new ParseException(predicate.printErrorLocation() + "String value '" + predicate.toString()
+                                                + "' is not allowed for iterable predicate");
+                        }
+                        predicateHops = processExpression(cp.getPredicate(), null, _ids);
 		}
 		
 		//create transient write to internal variable name on top of expression


### PR DESCRIPTION
The original issue i noticed was when the conditional predicate in the if-expression didn't seem what i was used to as in the C-programming language (where negative values were interpreted as _false_ while the converse values were interpreted as _true_) and that caused some discomfort.

Below is an example of the issue
```
// This is a session i ran from running SystemML
scala> import org.apache.sysml.api.mlcontext._
scala> import org.apache.sysml.api.mlcontext.ScriptFactory._
scala> val ml = new MLContext(spark)
scala> val s = dml(""" if(-42) print("Yes!") else print("No!") """)
scala> ml.execute(s)
Yes!
```
In the Scala programming language, this would be a type-error
```
scala> if (-31) println("yes") else println("no")
           ^
       error: type mismatch;
        found   : Int(-31)
        required: Boolean
```

So i started mucking around _Antlr4_ and start poking around and discovered a potential fix for it. Running this fix after a build on my local machine, here's the desired result:
```
Using Scala version 2.11.12 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_202)
Type in expressions to have them evaluated.
Type :help for more information.

scala> import org.apache.sysml.api.mlcontext._
import org.apache.sysml.api.mlcontext._

scala> import org.apache.sysml.api.mlcontext.ScriptFactory._
import org.apache.sysml.api.mlcontext.ScriptFactory._

scala> val ml = new MLContext(spark)

Welcome to Apache SystemML!
Version 1.3.0-SNAPSHOT
ml: org.apache.sysml.api.mlcontext.MLContext = org.apache.sysml.api.mlcontext.MLContext@380cd266

scala> val s = dml(""" if(-42) print("Yes!") else print("No!") """)
s: org.apache.sysml.api.mlcontext.Script =
Inputs:
None

Outputs:
None

scala> ml.execute(s)
ANTLR Tool version 4.5.3 used for code generation does not match the current runtime version 4.7ANTLR Runtime version 4.5.3 used for parser compilation does not match the current runtime version 4.7ANTLR Tool version 4.5.3 used for code generation does not match the current runtime version 4.7ANTLR Runtime version 4.5.3 used for parser compilation does not match the current runtime version 4.720/03/25 09:10:54 WARN DMLTranslator: WARNING: [line 1:4] -> -42 -- Numerical value '-42' (!= 0/1) is converted to boolean FALSE by DML
No!
SystemML Statistics:
Total execution time:		0.010 sec.
Number of executed Spark inst:	0.

res0: org.apache.sysml.api.mlcontext.MLResults =
None

```