### PR TITLE
[MINOR] GitHub Workflows Cache Dependencies

### DIFF
--- a/.github/workflows/applicationTests.yml
+++ b/.github/workflows/applicationTests.yml
@@ -39,7 +39,8 @@ jobs:
         os: [ubuntu-latest]
     name:  Ap Test ${{ matrix.tests }} 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v2
 
     - name: Run all tests starting with "${{ matrix.tests }}"
       uses: ./.github/action/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v2
 
-    - name: Set up JDK 1.8
+    - name: Setup Java 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
 
-    - name: Build with Maven
+    - name: Cache Maven Dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Build
       run: mvn package

--- a/.github/workflows/componentTests.yml
+++ b/.github/workflows/componentTests.yml
@@ -30,15 +30,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java: [ 1.8 ]
     name: Component Tests ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v2
 
-    - name: Setup Java
+    - name: Setup Java 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: ${{ matrix.java }}
+        java-version: 1.8
+
+    - name: Cache Maven Dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
 
     - name: Maven clean compile & test-compile
       run: mvn clean compile test-compile

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,13 +31,22 @@ jobs:
     runs-on: ubuntu-latest
     name: Documentation Java
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v2
 
-    - name: Setup Java
+    - name: Setup Java 1.8
       uses: actions/setup-java@v1
       with:
-        java-version:  1.8
+        java-version: 1.8
 
+    - name: Cache Maven Dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+  
     - name: Make Documentation SystemDS Java
       run: mvn -P distribution package
 
@@ -51,14 +60,23 @@ jobs:
     runs-on: ubuntu-latest
     name: Documentation Python
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v2
 
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
         architecture: 'x64'
-        
+
+    - name: Cache Pip Dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-docs-${{ hashFiles('src/main/python/docs/requires-docs.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-docs-
+
     - name: Install Dependencies
       run: |
         cd src/main/python/docs

--- a/.github/workflows/functionsTests.yml
+++ b/.github/workflows/functionsTests.yml
@@ -77,7 +77,8 @@ jobs:
         os: [ubuntu-latest]
     name:  Func Test ${{ matrix.tests }} 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v2
 
     - name: Run all tests starting with "${{ matrix.tests }}"
       uses: ./.github/action/

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,13 +40,22 @@ jobs:
         java: [ 1.8 ]
     name:  Python Test
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v2
 
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
 
+    - name: Cache Maven Dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+  
     - name: Maven clean & package
       run: mvn clean package
 
@@ -56,11 +65,18 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
 
+    - name: Cache Pip Dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('src/main/python/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+  
     - name: Install pip Dependencies
       run: pip install numpy py4j wheel
 
     - name: Build Python Package
-      # TODO: Find out how to make if statement correctly: suggestion but not working: if: ${{ matrix.tests }} == P
       run: |
         cd src/main/python
         python create_python_dist.py


### PR DESCRIPTION
Workflows cache dependencies.
In small test cases this reduce the time to execute tests to half.
Especially true in the python tests cases.

Note:
- Cache size is at max 5 GB for a repository, and it will slowly build up.
- Cache change if changes happen in
  - pom.xml for maven dependencies.
  - src/main/python/setup.py or src/main/python/docs/requires-docs.txt for python.

First Pull request Apache ! :+1: :smiley: :racehorse: 