### PR TITLE
Update python package, making use of java distribution bin zip

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,7 +57,7 @@ jobs:
           ${{ runner.os }}-maven-
   
     - name: Maven clean & package
-      run: mvn clean package -Pdistribution
+      run: mvn clean package -P distribution
 
     - name: Setup Python
       uses: actions/setup-python@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,7 +57,7 @@ jobs:
           ${{ runner.os }}-maven-
   
     - name: Maven clean & package
-      run: mvn clean package
+      run: mvn clean package -Pdistribution
 
     - name: Setup Python
       uses: actions/setup-python@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -86,16 +86,5 @@ jobs:
         cd src/main/python
         ls tests/
         echo "Beginning tests"
-        python tests/test_matrix_binary_op.py
-        echo "Exit Status: " $?
-        sleep 3
-        python tests/test_matrix_aggregations.py
-        echo "Exit Status: " $?
-        sleep 3
-        python tests/test_l2svm.py
-        echo "Exit Status: " $?
-        python tests/test_lineagetrace.py
-        sleep 3
-        echo "Exit Status: " $?
-        python tests/test_l2svm_lineage.py
+        python -m unittest tests/*.py
         echo "Exit Status: " $?

--- a/src/main/python/BUILD_INSTRUCTIONS.md
+++ b/src/main/python/BUILD_INSTRUCTIONS.md
@@ -41,8 +41,8 @@ python3 create_python_dist.py
 
 - Follow the instructions from the [Guide](https://packaging.python.org/tutorials/packaging-projects/)
     1. Create an API-Token in the account (leave the page open or copy the token, it will only be shown once)
-        - Optional: `pip install keyrings.alt` if you get `UserWarning: No recommended backend was available.`
     2. Execute the command `python3 -m twine upload dist/*`
+        - Optional: `pip install keyrings.alt` if you get `UserWarning: No recommended backend was available.`
     3. Username is `__token__`
     4. Password is the created API-Token **with** `pypi-` prefix
 

--- a/src/main/python/BUILD_INSTRUCTIONS.md
+++ b/src/main/python/BUILD_INSTRUCTIONS.md
@@ -23,7 +23,7 @@ limitations under the License.
 
 The following steps have to be done for both cases
 
-- Build SystemDS with maven first `mvn package -DskipTests -Pdistribution`, with the working directory being `SYSTEMDS_ROOT` (Root directory of SystemDS)
+- Build SystemDS with maven first `mvn package -Pdistribution`, with the working directory being `SYSTEMDS_ROOT` (Root directory of SystemDS)
 - `cd` to this folder (basically `SYSTEMDS_ROOT/src/main/python`
 
 ### Building package for release
@@ -50,7 +50,7 @@ python3 create_python_dist.py
 
 If we want to build the package just locally for development, the following steps will suffice
 
-- Run `pre_setup.py` (this will copy `lib` and `systemds-VERSION-SNAPSHOT.jar`)
+- Run `pre_setup.py` (this will copy necessary jars to `systemds/systemds-java/lib` from `systemds-VERSION-SNAPSHOT-bin.zip`)
 
 ```bash
 python3 create_python_dist.py

--- a/src/main/python/BUILD_INSTRUCTIONS.md
+++ b/src/main/python/BUILD_INSTRUCTIONS.md
@@ -23,13 +23,14 @@ limitations under the License.
 
 The following steps have to be done for both cases
 
-- Build SystemDS with maven first `mvn package -DskipTests`, with the working directory being `SYSTEMDS_ROOT` (Root directory of SystemDS)
+- Build SystemDS with maven first `mvn package -DskipTests -Pdistribution`, with the working directory being `SYSTEMDS_ROOT` (Root directory of SystemDS)
 - `cd` to this folder (basically `SYSTEMDS_ROOT/src/main/python`
 
-### Building package
+### Building package for release
 
 If we want to build the package for uploading to the repository via `python3 -m twine upload --repository-url [URL] dist/*` (will be automated in the future)
 
+- Install twine with `pip install --upgrade twine`
 - Run `create_python_dist.py`
 
 ```bash
@@ -37,7 +38,13 @@ python3 create_python_dist.py
 ```
 
 - now in the `./dist` directory there will exist the source distribution `systemds-VERSION.tar.gz` and the wheel distribution `systemds-VERSION-py3-none-any.whl`, with `VERSION` being the current version number
-- Finished. We can now upload it with `python3 -m twine upload --repository-url [URL] dist/*`
+
+- Follow the instructions from the [Guide](https://packaging.python.org/tutorials/packaging-projects/)
+    1. Create an API-Token in the account (leave the page open or copy the token, it will only be shown once)
+        - Optional: `pip install keyrings.alt` if you get `UserWarning: No recommended backend was available.`
+    2. Execute the command `python3 -m twine upload dist/*`
+    3. Username is `__token__`
+    4. Password is the created API-Token **with** `pypi-` prefix
 
 ### Building for development
 

--- a/src/main/python/PUBLISH_INSTRUCTIONS.md
+++ b/src/main/python/PUBLISH_INSTRUCTIONS.md
@@ -17,20 +17,17 @@ limitations under the License.
 {% end comment %}
 -->
 
-# Build instructions
+# Publishing Instructions
 
-## Basic steps
+## Building SystemDS jar (with dependency jars)
 
 The following steps have to be done for both cases
 
-- Build SystemDS with maven first `mvn package -Pdistribution`, with the working directory being `SYSTEMDS_ROOT` (Root directory of SystemDS)
+- Build SystemDS with maven first `mvn package -P distribution`, with the working directory being `SYSTEMDS_ROOT` (Root directory of SystemDS)
 - `cd` to this folder (basically `SYSTEMDS_ROOT/src/main/python`
 
-### Building package for release
+## Building python package
 
-If we want to build the package for uploading to the repository via `python3 -m twine upload --repository-url [URL] dist/*` (will be automated in the future)
-
-- Install twine with `pip install --upgrade twine`
 - Run `create_python_dist.py`
 
 ```bash
@@ -39,25 +36,15 @@ python3 create_python_dist.py
 
 - now in the `./dist` directory there will exist the source distribution `systemds-VERSION.tar.gz` and the wheel distribution `systemds-VERSION-py3-none-any.whl`, with `VERSION` being the current version number
 
+## Publishing package
+
+If we want to build the package for uploading to the repository via `python3 -m twine upload dist/*` (will be automated in the future)
+
+- Install twine with `pip install --upgrade twine`
+
 - Follow the instructions from the [Guide](https://packaging.python.org/tutorials/packaging-projects/)
     1. Create an API-Token in the account (leave the page open or copy the token, it will only be shown once)
     2. Execute the command `python3 -m twine upload dist/*`
         - Optional: `pip install keyrings.alt` if you get `UserWarning: No recommended backend was available.`
     3. Username is `__token__`
     4. Password is the created API-Token **with** `pypi-` prefix
-
-### Building for development
-
-If we want to build the package just locally for development, the following steps will suffice
-
-- Run `pre_setup.py` (this will copy necessary jars to `systemds/systemds-java/lib` from `systemds-VERSION-SNAPSHOT-bin.zip`)
-
-```bash
-python3 create_python_dist.py
-```
-
-- Finished. Test by running a test case of your choice:
-
-```bash
-python3 tests/test_matrix_binary_op.py
-```

--- a/src/main/python/README.md
+++ b/src/main/python/README.md
@@ -1,6 +1,24 @@
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% end comment %}
+-->
 # SystemDS
 
-[![Build Status](https://travis-ci.com/tugraz-isds/systemds.svg?branch=master)](https://travis-ci.com/tugraz-isds/systemds)
+![Python Test](https://github.com/apache/systemml/workflows/Python%20Test/badge.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-gre.svg)](https://opensource.org/licenses/Apache-2.0)
 
 This package provides a Pythonic interface for working with SystemDS.

--- a/src/main/python/README.md
+++ b/src/main/python/README.md
@@ -1,4 +1,7 @@
-# Python Readme
+# SystemDS
+
+[![Build Status](https://travis-ci.com/tugraz-isds/systemds.svg?branch=master)](https://travis-ci.com/tugraz-isds/systemds)
+[![License](https://img.shields.io/badge/License-Apache%202.0-gre.svg)](https://opensource.org/licenses/Apache-2.0)
 
 This package provides a Pythonic interface for working with SystemDS.
 

--- a/src/main/python/docs/source/install.rst
+++ b/src/main/python/docs/source/install.rst
@@ -68,7 +68,7 @@ Then to build the system you do the following
 
 - Clone the Git Repository: https://github.com/apache/systemml.git
 - Open an terminal at the root of the repository.
-- Package the Java code using the ``mvn package`` command
+- Package the Java code using the ``mvn package -P distribution`` command
 - ``cd src/main/python`` to point at the root of the SystemDS Python library.
 - Copy `jars` with ``python pre_setup.py``
 - Install with ``pip install .``

--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -20,7 +20,6 @@
 #
 #-------------------------------------------------------------
 
-from __future__ import print_function
 import sys
 from setuptools import find_packages, setup
 import time
@@ -49,20 +48,8 @@ setup(
     name=ARTIFACT_NAME,
     version=ARTIFACT_VERSION_SHORT,
     description='SystemDS is a distributed and declarative machine learning platform.',
-    long_description='''SystemDS is a versatile system for the end-to-end data science lifecycle from data integration,
-     cleaning, and feature engineering, over efficient, local and distributed ML model training,
-     to deployment and serving.
-     To facilitate this, bindings from different languages and different system abstractions provide help for:
-     (1) the different tasks of the data-science lifecycle, and 
-     (2) users with different expertise. 
-
-
-     These high-level scripts are compiled into hybrid execution plans of local, in-memory CPU and GPU operations, 
-     as well as distributed operations on Apache Spark. In contrast to existing systems 
-     - that either provide homogeneous tensors or 2D Datasets - and in order to serve the entire
-     data science lifecycle, the underlying data model are DataTensors, i.e.,
-     tensors (multi-dimensional arrays) whose first dimension may have a heterogeneous and nested schema.''',
-    url='https://github.com/apache/systemml',
+    long_description=open('README.md').read(),
+    url='https://github.com/tugraz-isds/systemds',
     author='SystemDS',
     author_email='dev@systemml.apache.org',
     packages=find_packages(),
@@ -79,6 +66,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -36,7 +36,7 @@ ARTIFACT_VERSION = __project_version__
 ARTIFACT_VERSION_SHORT = ARTIFACT_VERSION.split("-")[0]
 
 REQUIRED_PACKAGES = [
-    'numpy >= 1.8.2',  # we might want to recheck this version
+    'numpy >= 1.8.2',
     'py4j >= 0.10.0'
 ]
 
@@ -49,7 +49,7 @@ setup(
     version=ARTIFACT_VERSION_SHORT,
     description='SystemDS is a distributed and declarative machine learning platform.',
     long_description=open('README.md').read(),
-    url='https://github.com/tugraz-isds/systemds',
+    url='https://github.com/apache/systemml',
     author='SystemDS',
     author_email='dev@systemml.apache.org',
     packages=find_packages(),


### PR DESCRIPTION
Updates the `setup.py`, making it read the `README.md` to remove redundancy and using the new github link.

Additionally now the steps for python packaging require calling `mvn package -DskipTests -Pdistribution` instead of just `mvn package -DskipTests`, because we now use the generated `systemds-*-SNAPSHOT-bin.zip` from which we copy the fewer jars used.