### PR TITLE
[SYSTEMDS-15] Travis remove badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ limitations under the License.
 
 ## Status
 
-[![Build Status](https://travis-ci.org/apache/systemml.svg?branch=master)](https://travis-ci.org/apache/systemml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-gre.svg)](https://opensource.org/licenses/Apache-2.0)
-
 ![Build](https://github.com/apache/systemml/workflows/Build/badge.svg)
 ![Documentation](https://github.com/apache/systemml/workflows/Documentation/badge.svg)
 ![Component Test](https://github.com/apache/systemml/workflows/Component%20Test/badge.svg)

--- a/docs/Tasks.txt
+++ b/docs/Tasks.txt
@@ -9,7 +9,7 @@ SYSTEMDS-10 Compiler Rework / Misc
  * 12 Remove unnecessary HOP/LOP indirections                         OK
  * 13 Refactoring test cases into component/integration               OK
  * 14 Complete removal of external functions from all scripts
- * 15 Travis integration w/ subset of tests                           OK
+ * 15 Travis integration w/ subset of tests                           Removed for Github Actions
  * 16 Remove instruction patching
  * 17 Refactoring of program block hierarchy                          OK
  * 18 Improve API for new dml-bodied builtin functions                OK


### PR DESCRIPTION
Missed that the badge still was in the README.
This is now removed, furthermore the task associated with Travis have
been modified to reflect that it is removed, and why.

NOTE: this could be minor, but it is associated with task 15. 