### PR TITLE
[MINOR]New partial rewrites and bugfixes

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/DataGenCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/DataGenCPInstruction.java
@@ -164,6 +164,10 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 	public long getSeed() {
 		return seed;
 	}
+	
+	public boolean isOnesCol() {
+		return minValue == maxValue && minValue == 1 && sparsity == 1 && getCols() == 1;
+	}
 
 	public static DataGenCPInstruction parseInstruction(String str)
 	{

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ListIndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ListIndexingCPInstruction.java
@@ -25,6 +25,8 @@ import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.lineage.LineageItem;
+import org.apache.sysds.runtime.lineage.LineageItemUtils;
 
 public final class ListIndexingCPInstruction extends IndexingCPInstruction {
 
@@ -92,5 +94,10 @@ public final class ListIndexingCPInstruction extends IndexingCPInstruction {
 		}
 		else
 			throw new DMLRuntimeException("Invalid opcode (" + opcode +") encountered in ListIndexingCPInstruction.");
+	}
+	@Override
+	public LineageItem[] getLineageItems(ExecutionContext ec) {
+		return new LineageItem[]{new LineageItem(output.getName(), getOpcode(),
+			LineageItemUtils.getLineage(ec, input1,input2,input3,rowLower,rowUpper))};
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
@@ -410,6 +410,14 @@ public class ParameterizedBuiltinCPInstruction extends ComputationCPInstruction 
 			return new LineageItem[]{new LineageItem(output.getName(),
 				getOpcode(), LineageItemUtils.getLineage(ec, target, groups, weights, fn, ngroups))};
 		}
+		else if (opcode.equalsIgnoreCase("rmempty")) {
+			CPOperand target = new CPOperand(params.get("target"), ValueType.FP64, DataType.MATRIX);
+			CPOperand margin = new CPOperand(params.get("margin"), ValueType.STRING, DataType.SCALAR, true);
+			String sl = params.containsKey("select") ? params.get("select") : String.valueOf(-1);
+			CPOperand select = new CPOperand(sl, ValueType.FP64, DataType.MATRIX); 
+			return new LineageItem[]{new LineageItem(output.getName(),
+				getOpcode(), LineageItemUtils.getLineage(ec, target, margin, select))};
+		}
 		//TODO: generic interface to support all the ops
 		else
 			return new LineageItem[]{new LineageItem(output.getName(),

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -237,8 +237,10 @@ public class LineageCache
 			synchronized( _cache ) {
 				if (data instanceof MatrixObject)
 					_cache.get(item).setValue(((MatrixObject)data).acquireReadAndRelease(), computetime);
-				else
+				else if (data instanceof ScalarObject)
 					_cache.get(item).setValue((ScalarObject)data, computetime);
+				else
+					throw new DMLRuntimeException("Lineage Cache: unsupported data: "+data.getDataType());
 				long size = _cache.get(item).getSize();
 				
 				if (!isBelowThreshold(size))

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -24,6 +24,7 @@ import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.cp.ComputationCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.ListIndexingCPInstruction;
 
 import java.util.ArrayList;
 
@@ -101,9 +102,11 @@ public class LineageCacheConfig {
 	}
 	
 	public static boolean isReusable (Instruction inst, ExecutionContext ec) {
-		return inst instanceof ComputationCPInstruction
-			&& (ArrayUtils.contains(REUSE_OPCODES, inst.getOpcode())
+		boolean insttype = inst instanceof ComputationCPInstruction 
+				&& !(inst instanceof ListIndexingCPInstruction);
+		boolean rightop = (ArrayUtils.contains(REUSE_OPCODES, inst.getOpcode())
 				|| (inst.getOpcode().equals("append") && isVectorAppend(inst, ec)));
+		return insttype && rightop;
 	}
 	
 	private static boolean isVectorAppend(Instruction inst, ExecutionContext ec) {

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageMap.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageMap.java
@@ -25,6 +25,7 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.EvalNaryCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.FunctionCallCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
 import org.apache.sysds.runtime.instructions.spark.WriteSPInstruction;
@@ -51,7 +52,8 @@ public class LineageMap {
 	}
 	
 	public void trace(Instruction inst, ExecutionContext ec) {
-		if( inst instanceof FunctionCallCPInstruction )
+		if( inst instanceof FunctionCallCPInstruction ||
+				inst instanceof EvalNaryCPInstruction)
 			return; // no need for lineage tracing
 		if (!(inst instanceof LineageTraceable))
 			throw new DMLRuntimeException("Unknown Instruction (" + inst.getOpcode() + ") traced.");

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageRewriteReuse.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageRewriteReuse.java
@@ -24,14 +24,15 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.common.Types.AggOp;
+import org.apache.sysds.common.Types.Direction;
 import org.apache.sysds.common.Types.OpOp2;
 import org.apache.sysds.common.Types.OpOpN;
 import org.apache.sysds.common.Types.ParamBuiltinOp;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.hops.AggBinaryOp;
+import org.apache.sysds.hops.AggUnaryOp;
 import org.apache.sysds.hops.BinaryOp;
 import org.apache.sysds.hops.DataOp;
 import org.apache.sysds.hops.Hop;
@@ -50,9 +51,12 @@ import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContextFactory;
 import org.apache.sysds.runtime.instructions.Instruction;
+import org.apache.sysds.runtime.instructions.InstructionParser;
 import org.apache.sysds.runtime.instructions.cp.ComputationCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.DataGenCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ParameterizedBuiltinCPInstruction;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig.ReuseCacheType;
+import org.apache.sysds.runtime.lineage.LineageItem.LineageItemType;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.meta.MetaData;
 import org.apache.sysds.utils.Explain;
@@ -63,7 +67,7 @@ public class LineageRewriteReuse
 	private static final String LR_VAR = "__lrwrt";
 	private static BasicProgramBlock _lrPB = null;
 	private static ExecutionContext _lrEC = null;
-	private static final Log LOG = LogFactory.getLog(LineageRewriteReuse.class.getName());
+	private static boolean DEBUG = false;
 	
 	public static boolean executeRewrites (Instruction curr, ExecutionContext ec)
 	{
@@ -74,14 +78,18 @@ public class LineageRewriteReuse
 		DMLScript.EXPLAIN = ExplainType.NONE;
 		
 		//check applicability and apply rewrite
+		//tsmm(cbind(X, ones)) -> rbind(t(colSums(cbind(X, ones))[, 1:ncol-1]), colSums(cbind(X, ones)))
+		ArrayList<Instruction> newInst = rewriteTsmmCbindOnes(curr, ec, lrwec);
 		//tsmm(cbind(X, deltaX)) -> rbind(cbind(tsmm(X), t(X) %*% deltaX), cbind(t(deltaX) %*%X, tsmm(deltaX)))
-		ArrayList<Instruction> newInst = rewriteTsmmCbind(curr, ec, lrwec);
+		newInst = (newInst == null) ? rewriteTsmmCbind(curr, ec, lrwec) : newInst;
 		//tsmm(cbind(cbind(X, deltaX), ones)) -> TODO
 		newInst = (newInst == null) ? rewriteTsmm2Cbind(curr, ec, lrwec) : newInst;
 		//tsmm(rbind(X, deltaX)) -> tsmm(X) + tsmm(deltaX)
 		newInst = (newInst == null) ? rewriteTsmmRbind(curr, ec, lrwec) : newInst;
 		//rbind(X,deltaX) %*% Y -> rbind(X %*% Y, deltaX %*% Y)
 		newInst = (newInst == null) ? rewriteMatMulRbindLeft(curr, ec, lrwec) : newInst;
+		//X %*% cbind(Y,ones)) -> cbind(X %*% Y, rowSums(X))
+		newInst = (newInst == null) ? rewriteMatMulCbindRightOnes(curr, ec, lrwec) : newInst;
 		//X %*% cbind(Y,deltaY)) -> cbind(X %*% Y, X %*% deltaY)
 		newInst = (newInst == null) ? rewriteMatMulCbindRight(curr, ec, lrwec) : newInst;
 		//rbind(X, deltaX) * rbind(Y, deltaY) -> rbind(X * Y, deltaX * deltaY)
@@ -147,10 +155,10 @@ public class LineageRewriteReuse
 		// cell topRight = t(oldMatrix) %*% lastCol
 		ReorgOp tOldM = HopRewriteUtils.createTranspose(oldMatrix);
 		AggBinaryOp topRight = HopRewriteUtils.createMatrixMultiply(tOldM, lastCol);
-		// cell bottomLeft = t(lastCol) %*% oldMatrix
-		ReorgOp tLastCol = HopRewriteUtils.createTranspose(lastCol);
-		AggBinaryOp bottomLeft = HopRewriteUtils.createMatrixMultiply(tLastCol, oldMatrix);
+		// cell bottomLeft = t(lastCol) %*% oldMatrix = t(topRight)
+		ReorgOp bottomLeft = HopRewriteUtils.createTranspose(topRight);
 		// bottomRight = t(lastCol) %*% lastCol
+		ReorgOp tLastCol = HopRewriteUtils.createTranspose(lastCol);
 		AggBinaryOp bottomRight = HopRewriteUtils.createMatrixMultiply(tLastCol, lastCol);
 		// rowOne = cbind(lastRes, topRight)
 		BinaryOp rowOne = HopRewriteUtils.createBinary(lastRes, topRight, OpOp2.CBIND);
@@ -161,7 +169,50 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		LOG.debug("LINEAGE REWRITE rewriteTsmmCbind APPLIED");
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteTsmmCbind APPLIED");
+		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
+
+		if (DMLScript.STATISTICS) {
+			LineageCacheStatistics.incrementPRewriteTime(System.nanoTime() - t0);
+			LineageCacheStatistics.incrementPRewrites();
+		}
+		return inst;
+	}
+
+	private static ArrayList<Instruction> rewriteTsmmCbindOnes (Instruction curr, ExecutionContext ec, ExecutionContext lrwec) 
+	{
+		// This is a specialization of rewriteTsmmCbind. This qualifies if 
+		// the appended matrix is a column matrix of 1s (deltaX = 1s). 
+		// Check the applicability of this rewrite.
+		Map<String, MatrixBlock> inCache = new HashMap<>();
+		if(!isTsmmCbindOnes(curr, ec, inCache))
+			return null;
+		
+		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
+		// Create a transient read op over the cached tsmm result
+		MatrixBlock cachedEntry = inCache.get("lastMatrix");
+		lrwec.setVariable("cachedEntry", convMBtoMO(cachedEntry));
+		DataOp lastRes = HopRewriteUtils.createTransientRead("cachedEntry", cachedEntry);
+		// Create a transient read op over current input
+		MatrixObject mo = ec.getMatrixObject(((ComputationCPInstruction)curr).input1);
+		lrwec.setVariable("newMatrix", mo);
+		DataOp newMatrix = HopRewriteUtils.createTransientRead("newMatrix", mo);
+		// rowTwo = colSums(newMatrix)
+		AggUnaryOp rowTwo = HopRewriteUtils.createAggUnaryOp(newMatrix, AggOp.SUM, Direction.Col);
+		// topRight = t(rowTwo[, 1:ncols-1])
+		IndexingOp tmp = HopRewriteUtils.createIndexingOp(rowTwo, new LiteralOp(1), new LiteralOp(1), 
+				new LiteralOp(1), new LiteralOp(mo.getNumColumns()-1));
+		ReorgOp topRight = HopRewriteUtils.createTranspose(tmp);
+		// rowOne = cbind(lastRes, topRight)
+		BinaryOp rowOne = HopRewriteUtils.createBinary(lastRes, topRight, OpOp2.CBIND);
+		// rbind(rowOne, rowTwo)
+		BinaryOp lrwHop= HopRewriteUtils.createBinary(rowOne, rowTwo, OpOp2.RBIND);
+		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
+
+		// generate runtime instructions
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteTsmmCbindOnes APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 
 		if (DMLScript.STATISTICS) {
@@ -204,7 +255,8 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		LOG.debug("LINEAGE REWRITE rewriteTsmmRbind APPLIED");
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteTsmmRbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 
 		if (DMLScript.STATISTICS) {
@@ -266,7 +318,8 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		LOG.debug("LINEAGE REWRITE rewriteTsmm2Cbind APPLIED");
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteTsmm2Cbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 
 		if (DMLScript.STATISTICS) {
@@ -310,7 +363,8 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		LOG.debug("LINEAGE REWRITE rewriteMetMulRbindLeft APPLIED");
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteMetMulRbindLeft APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 
 		if (DMLScript.STATISTICS) {
@@ -348,13 +402,48 @@ public class LineageRewriteReuse
 		}
 		lastCol = HopRewriteUtils.createIndexingOp(rightMatrix, new LiteralOp(1), new LiteralOp(moR.getNumRows()), 
 				new LiteralOp(moR.getNumColumns()), new LiteralOp(moR.getNumColumns()));
-		// ba+*(X, Y+lastCol) = cbind(ba+*(X, Y), ba+*(X, lastCol))
-		AggBinaryOp rowTwo = HopRewriteUtils.createMatrixMultiply(leftMatrix, lastCol);
-		BinaryOp lrwHop= HopRewriteUtils.createBinary(lastRes, rowTwo, OpOp2.CBIND);
+		// ba+*(X, cbind(Y, lastCol)) = cbind(ba+*(X, Y), ba+*(X, lastCol))
+		AggBinaryOp colTwo = HopRewriteUtils.createMatrixMultiply(leftMatrix, lastCol);
+		BinaryOp lrwHop= HopRewriteUtils.createBinary(lastRes, colTwo, OpOp2.CBIND);
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		LOG.debug("LINEAGE REWRITE rewriteMatMulCbindRight APPLIED");
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteMatMulCbindRight APPLIED");
+		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
+
+		if (DMLScript.STATISTICS) {
+			LineageCacheStatistics.incrementPRewriteTime(System.nanoTime() - t0);
+			LineageCacheStatistics.incrementPRewrites();
+		}
+		return inst;
+	}
+
+	private static ArrayList<Instruction> rewriteMatMulCbindRightOnes (Instruction curr, ExecutionContext ec, ExecutionContext lrwec) 
+	{
+		// This is a specialization of rewriteMatMulCbindRight. This qualifies
+		// if the right matrix is appended with a matrix of 1s (deltaY == 1s).
+		// Check the applicability of this rewrite.
+		Map<String, MatrixBlock> inCache = new HashMap<>();
+		if (!isMatMulCbindRightOnes(curr, ec, inCache))
+			return null;
+
+		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
+		// Create a transient read op over the last ba+* result
+		MatrixBlock cachedEntry = inCache.get("lastMatrix");
+		lrwec.setVariable("cachedEntry", convMBtoMO(cachedEntry));
+		DataOp lastRes = HopRewriteUtils.createTransientRead("cachedEntry", cachedEntry);
+		MatrixObject moL = ec.getMatrixObject(((ComputationCPInstruction)curr).input1);
+		lrwec.setVariable("leftMatrix", moL);
+		DataOp leftMatrix = HopRewriteUtils.createTransientRead("leftMatrix", moL);
+		// ba+*(X, cbind(Y, ones)) = cbind(ba+*(X, Y), rowSums(X))
+		AggUnaryOp colTwo = HopRewriteUtils.createAggUnaryOp(leftMatrix, AggOp.SUM, Direction.Row);
+		BinaryOp lrwHop= HopRewriteUtils.createBinary(lastRes, colTwo, OpOp2.CBIND);
+		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
+
+		// generate runtime instructions
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteMatMulCbindRightOnes APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 
 		if (DMLScript.STATISTICS) {
@@ -409,7 +498,8 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		LOG.debug("LINEAGE REWRITE rewriteElementMulRbind APPLIED");
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteElementMulRbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 
 		if (DMLScript.STATISTICS) {
@@ -464,7 +554,8 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		LOG.debug("LINEAGE REWRITE rewriteElementMulCbind APPLIED");
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteElementMulCbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 
 		if (DMLScript.STATISTICS) {
@@ -519,7 +610,8 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		LOG.debug("LINEAGE REWRITE rewriteElementMulCbind APPLIED");
+		if (DEBUG)
+			System.out.println("LINEAGE REWRITE rewriteElementMulCbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 
 		if (DMLScript.STATISTICS) {
@@ -539,8 +631,8 @@ public class LineageRewriteReuse
 
 		// If the input to tsmm came from cbind, look for both the inputs in cache.
 		LineageItem[] items = ((ComputationCPInstruction) curr).getLineageItems(ec);
-		LineageItem item = items[0];
-		for (LineageItem source : item.getInputs())
+		if (curr.getOpcode().equalsIgnoreCase("tsmm")) {
+			LineageItem source = items[0].getInputs()[0];
 			if (source.getOpcode().equalsIgnoreCase("cbind")) {
 				//for (LineageItem input : source.getInputs()) {
 				// create tsmm lineage on top of the input of last append
@@ -552,7 +644,37 @@ public class LineageRewriteReuse
 				if (LineageCache.probe(source.getInputs()[1])) 
 					inCache.put("deltaX", LineageCache.getMatrix(source.getInputs()[1]));
 			}
+		}
 		// return true only if the last tsmm is found
+		return inCache.containsKey("lastMatrix") ? true : false;
+	}
+
+	private static boolean isTsmmCbindOnes(Instruction curr, ExecutionContext ec, Map<String, MatrixBlock> inCache)
+	{
+		if (!LineageCacheConfig.isReusable(curr, ec)) {
+			return false;
+		}
+
+		// If the input to tsmm came from cbind, look for both the inputs in cache.
+		LineageItem[] items = ((ComputationCPInstruction) curr).getLineageItems(ec);
+		if (curr.getOpcode().equalsIgnoreCase("tsmm")) {
+			LineageItem source = items[0].getInputs()[0];
+			if (source.getOpcode().equalsIgnoreCase("cbind")) {
+				// check if the appended column is a matrix of 1s
+				LineageItem input2 = source.getInputs()[1];
+				if (input2.getType() != LineageItemType.Creation)
+					return false;
+				Instruction ins = InstructionParser.parseSingleInstruction(input2.getData());
+				if (!((DataGenCPInstruction)ins).isOnesCol())
+					return false;
+				// create tsmm lineage on top of the input of last append
+				LineageItem input1 = source.getInputs()[0];
+				LineageItem tmp = new LineageItem("toProbe", curr.getOpcode(), new LineageItem[] {input1});
+				if (LineageCache.probe(tmp)) 
+					inCache.put("lastMatrix", LineageCache.getMatrix(tmp));
+			}
+		}
+		// return true only if the last tsmm result is found
 		return inCache.containsKey("lastMatrix") ? true : false;
 	}
 
@@ -563,8 +685,8 @@ public class LineageRewriteReuse
 
 		// If the input to tsmm came from rbind, look for both the inputs in cache.
 		LineageItem[] items = ((ComputationCPInstruction) curr).getLineageItems(ec);
-		LineageItem item = items[0];
-		for (LineageItem source : item.getInputs())
+		if (curr.getOpcode().equalsIgnoreCase("tsmm")) {
+			LineageItem source = items[0].getInputs()[0];
 			if (source.getOpcode().equalsIgnoreCase("rbind")) {
 				// create tsmm lineage on top of the input of last append
 				LineageItem input1 = source.getInputs()[0];
@@ -575,6 +697,7 @@ public class LineageRewriteReuse
 				if (LineageCache.probe(source.getInputs()[1])) 
 					inCache.put("deltaX", LineageCache.getMatrix(source.getInputs()[1]));
 			}
+		}
 		// return true only if the last tsmm is found
 		return inCache.containsKey("lastMatrix") ? true : false;
 	}
@@ -587,9 +710,9 @@ public class LineageRewriteReuse
 		//TODO: support nary cbind
 		// If the input to tsmm came from cbind, look for both the inputs in cache.
 		LineageItem[] items = ((ComputationCPInstruction) curr).getLineageItems(ec);
-		LineageItem item = items[0];
 		// look for two consecutive cbinds
-		for (LineageItem source : item.getInputs())
+		if (curr.getOpcode().equalsIgnoreCase("tsmm")) {
+			LineageItem source = items[0].getInputs()[0];
 			if (source.getOpcode().equalsIgnoreCase("cbind")) {
 				LineageItem input = source.getInputs()[0];
 				if (input.getOpcode().equalsIgnoreCase("cbind")) {
@@ -603,6 +726,7 @@ public class LineageRewriteReuse
 						inCache.put("deltaX", LineageCache.getMatrix(input.getInputs()[1]));
 				}
 			}
+		}
 		// return true only if the last tsmm is found
 		return inCache.containsKey("lastMatrix") ? true : false;
 	}
@@ -651,6 +775,34 @@ public class LineageRewriteReuse
 				// look for the appended column in cache
 				if (LineageCache.probe(right.getInputs()[1])) 
 					inCache.put("deltaY", LineageCache.getMatrix(right.getInputs()[1]));
+			}
+		}
+		return inCache.containsKey("lastMatrix") ? true : false;
+	}
+
+	private static boolean isMatMulCbindRightOnes(Instruction curr, ExecutionContext ec, Map<String, MatrixBlock> inCache)
+	{
+		if (!LineageCacheConfig.isReusable(curr, ec))
+			return false;
+
+		// If the right input to ba+* came from cbind of a matrix and ones.
+		LineageItem[] items = ((ComputationCPInstruction) curr).getLineageItems(ec);
+		if (curr.getOpcode().equalsIgnoreCase("ba+*")) {
+			LineageItem left = items[0].getInputs()[0];
+			LineageItem right = items[0].getInputs()[1];
+			if (right.getOpcode().equalsIgnoreCase("cbind")) {
+				LineageItem rightSource1 = right.getInputs()[0]; //left input of cbind is X
+				LineageItem rightSource2 = right.getInputs()[1]; 
+				// check if the right input to cbind is a matrix of 1s.
+				if (rightSource2.getType() != LineageItemType.Creation)
+					return false;
+				Instruction ins = InstructionParser.parseSingleInstruction(rightSource2.getData());
+				if (!((DataGenCPInstruction)ins).isOnesCol())
+					return false;
+				// create ba+* lineage on top of the input of last append
+				LineageItem tmp = new LineageItem("toProbe", curr.getOpcode(), new LineageItem[] {left, rightSource1});
+				if (LineageCache.probe(tmp))
+					inCache.put("lastMatrix", LineageCache.getMatrix(tmp));
 			}
 		}
 		return inCache.containsKey("lastMatrix") ? true : false;
@@ -747,8 +899,11 @@ public class LineageRewriteReuse
 		ArrayList<Instruction> newInst = Recompiler.recompileHopsDag(hops, ec.getVariables(), null, true, true, 0);
 		if (DMLScript.STATISTICS) 
 			LineageCacheStatistics.incrementPRwExecTime(System.nanoTime()-t0);
-		LOG.debug("EXPLAIN LINEAGE REWRITE \nGENERIC (line "+hops.getBeginLine()+"):\n" + Explain.explain(hops,1));
-		LOG.debug("EXPLAIN LINEAGE REWRITE \nGENERIC (line "+hops.getBeginLine()+"):\n" + Explain.explain(newInst,1));
+		if (DEBUG) {
+			System.out.println("COMPENSATION PLAN: ");
+			System.out.println("EXPLAIN LINEAGE REWRITE (HOP) \n" + Explain.explain(hops,1));
+			System.out.println("EXPLAIN LINEAGE REWRITE (INSTRUCTION) \n" + Explain.explain(newInst,1));
+		}
 		return newInst;
 	}
 	

--- a/src/test/java/org/apache/sysds/test/functions/lineage/LineageRewriteTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/LineageRewriteTest.java
@@ -41,6 +41,7 @@ public class LineageRewriteTest extends AutomatedTestBase {
 	protected static final String TEST_NAME6 = "RewriteTest10";
 	protected static final String TEST_NAME7 = "RewriteTest11";
 	protected static final String TEST_NAME8 = "RewriteTest12";
+	protected static final String TEST_NAME9 = "RewriteTest13";
 	
 	protected String TEST_CLASS_DIR = TEST_DIR + LineageRewriteTest.class.getSimpleName() + "/";
 	
@@ -58,6 +59,7 @@ public class LineageRewriteTest extends AutomatedTestBase {
 		addTestConfiguration(TEST_NAME6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6));
 		addTestConfiguration(TEST_NAME7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME7));
 		addTestConfiguration(TEST_NAME8, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME8));
+		addTestConfiguration(TEST_NAME9, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME9));
 	}
 	
 	@Test
@@ -100,6 +102,12 @@ public class LineageRewriteTest extends AutomatedTestBase {
 		testRewrite(TEST_NAME8, false, 2);
 	}
 
+	@Test
+	public void testTsmmCbindOnes() {
+		// This also tests testMatmulCbindRightOnes.
+		testRewrite(TEST_NAME9, false, 0);
+	}
+
 	private void testRewrite(String testname, boolean elementwise, int classes) {
 		try {
 			getAndLoadTestConfiguration(testname);
@@ -130,8 +138,6 @@ public class LineageRewriteTest extends AutomatedTestBase {
 			HashMap<MatrixValue.CellIndex, Double> R_orig = readDMLMatrixFromHDFS("Res");
 
 			proArgs.clear();
-			proArgs.add("-explain");
-			proArgs.add("recompile_hops");
 			proArgs.add("-stats");
 			proArgs.add("-lineage");
 			proArgs.add("reuse_hybrid");

--- a/src/test/scripts/functions/lineage/LineageReuseAlg1.dml
+++ b/src/test/scripts/functions/lineage/LineageReuseAlg1.dml
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rand(rows=100, cols=10, sparsity=1.0, seed=1);
+y = X %*% rand(rows=10, cols=1, sparsity=1.0, seed=1);
+R = matrix(0, 101, 2);
+
+[C, S] = steplm(X=X, y=y, icpt=2);
+S = cbind(S, matrix(1, 1, 1));
+R[1:nrow(C) ,1] = C;
+R[1:ncol(S) ,2] = t(S);
+
+write(R, $1, format="text");

--- a/src/test/scripts/functions/lineage/LineageReuseAlg2.dml
+++ b/src/test/scripts/functions/lineage/LineageReuseAlg2.dml
@@ -1,0 +1,60 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+l2norm = function(Matrix[Double] X, Matrix[Double] y, Matrix[Double] B) return (Matrix[Double] loss) {
+  loss = as.matrix(sum((y - X%*%B)^2));
+}
+
+randColSet = function(Matrix[Double] X, Integer seed, Double sample) return (Matrix[Double] Xi) {
+  temp = rand(rows=ncol(X), cols=1, min = 0, max = 1, sparsity=1, seed=seed) <= sample
+  sel = diag(temp)
+  sel = removeEmpty(target = sel, margin = "cols")
+  Xi = X %*% sel
+}
+
+X = rand(rows=100, cols=100, sparsity=1.0, seed=1);
+y = rand(rows=100, cols=1, sparsity=1.0, seed=1);
+
+Rbeta = matrix(0, rows=525, cols=ncol(X)); #nrows = 5*5*3*7 = 525
+k = 1;
+for (i in 1:5) 
+{
+  #randomly select 15% columns in every iteration
+  Xi = randColSet(X, i, 0.15);
+
+  #TODO: Use generalized gridsearch builtin after lineage integration with list.
+  for (h1 in -4:0) {       #reg - values:10^-4 to 10^0
+    for (h2 in 0:2) {      #icpt - range: 0, 1, 2
+      for (h3 in -12:-6) { #tol -values: 10^-12 to 10^-6
+        reg = 10^h1;
+        icpt = h2;
+        tol = 10^h3;
+        beta = lm(X=Xi, y=y, icpt=icpt, reg=reg, tol=tol, maxi=0, verbose=FALSE);
+        Rbeta[k, 1:nrow(beta)] = t(beta);
+        k = k + 1;
+      }
+    }
+  }
+}
+
+while(FALSE) {}
+write(Rbeta, $1, format="text");
+

--- a/src/test/scripts/functions/lineage/RewriteTest13.dml
+++ b/src/test/scripts/functions/lineage/RewriteTest13.dml
@@ -19,15 +19,21 @@
 #
 #-------------------------------------------------------------
 
-# Increase rows and cols for better performance gains
+X = read($1);
+y = rand(rows=nrow(X), cols=1, sparsity=1.0, seed=2);
 
-X = rand(rows=100, cols=10, sparsity=1.0, seed=1);
-y = X %*% rand(rows=10, cols=1, sparsity=1.0, seed=1);
-R = matrix(0, 101, 2);
+R = matrix(0, 1, 1);
 
-[C, S] = steplm(X=X, y=y, icpt=2);
-S = cbind(S, matrix(1, 1, 1));
-R[1:nrow(C) ,1] = C;
-R[1:ncol(S) ,2] = t(S);
+Res1 = t(X) %*% X;
+Res2 = t(X) %*% y;
 
-write(R, $1, format="text");
+while(FALSE) {}
+
+X = cbind(X, matrix(1, rows=nrow(X), cols=1));
+Res11 = t(X) %*% X;
+Res22 = t(X) %*% y;
+while(FALSE) {}
+R[1,1] = sum(Res1) + sum(Res2) + sum(Res11) + sum(Res22);
+
+
+write(R, $3, format="text");


### PR DESCRIPTION
This patch contains
- two new partial rewrites which are specialization of existing
rewrites,
- bugfixes and optimizations in partial rewrites,
- lineage tracing for removeEmpty,
- a new test class to test algorithms and builtins with reuse,
- extension of lineage tracing of list objects.
Note that lineage doesn't work with most of the list handling methods
today. Due to that the current generalized grid search builtin is far
from working with lineage framework.