### PR TITLE
[WIP][SYSTEMDS-XXX]Handling multiple cache entries pointing to same data

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -336,14 +336,23 @@ public class LineageCache
 			else
 				e.setValue(oe.getSOValue(), computetime);
 			e._origItem = probeItem; 
+			// Add the SB/func entry to the end of the list of items pointing to the same data.
+			// No cache size update is necessary.
+			LineageCacheEntry tmp = oe;
+			while (tmp._nextEntry != null)
+				tmp = tmp._nextEntry;
+			tmp._nextEntry = e;
+			e._prevEntry = tmp;
+			if (e._nextEntry != null )
+				System.out.println("next = prev");
 			
 			//maintain order for eviction
 			LineageCacheEviction.addEntry(e);
 
-			long size = oe.getSize();
+			/*long size = oe.getSize();
 			if(!LineageCacheEviction.isBelowThreshold(size)) 
 				LineageCacheEviction.makeSpace(_cache, size);
-			LineageCacheEviction.updateSize(size, true);
+			LineageCacheEviction.updateSize(size, true);*/
 		}
 		else
 			_cache.remove(item);    //remove the placeholder

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
@@ -33,6 +33,8 @@ public class LineageCacheEntry {
 	protected long _computeTime;
 	protected long _timestamp = 0;
 	protected LineageCacheStatus _status;
+	protected LineageCacheEntry _prevEntry;
+	protected LineageCacheEntry _nextEntry;
 	protected LineageItem _origItem;
 	
 	public LineageCacheEntry(LineageItem key, DataType dt, MatrixBlock Mval, ScalarObject Sval, long computetime) {
@@ -42,6 +44,8 @@ public class LineageCacheEntry {
 		_SOval = Sval;
 		_computeTime = computetime;
 		_status = isNullVal() ? LineageCacheStatus.EMPTY : LineageCacheStatus.CACHED;
+		_prevEntry = null;
+		_nextEntry = null;
 		_origItem = null;
 	}
 	


### PR DESCRIPTION
This patch updates the cacheing logic to maintain a linkedlist between
the entries having the same result data. Cache size is also being
updated accordingly, once per linkedlist. Eviction logic and reading
from disk is also updated.
This patch increases number of entries in the cache at any given
time, but also increases number entries to be evicted to recover certain
amount of space.