### PR TITLE
[DOC] Documentation for builtin KMeans function

### DIFF
--- a/docs/builtins-reference.md
+++ b/docs/builtins-reference.md
@@ -123,12 +123,12 @@ kmeans(x, centers, iter.max, nstart)
 
 ### Arguments
 
-| Name     | Type            | Default  | Description |
-| :--      | :--             | --       | :--         |
-| x        | Matrix[Numeric] | required |The input Matrix to do KMeans on..|
-| centers  | Int             | --       |The no. of cenetrs                |
-| iter.max |Int              | `10`        |Max no. of iterations allowed     |
-| nstart   |Int              | `10`        |No. of random starting positions  |
+| Name    | Type            | Default  | Description |
+| :----   | :-------------  | --       | :------------------------------- |
+| x       | Matrix[Numeric] | required |The input Matrix to do KMeans on..|
+| centers | Int             | --       |The no. of cenetrs                |
+|iter.max |Int              |`10`        |Max no. of iterations allowed     |
+|nstart   |Int              |`10`       |No. of random starting positions  |
 
 
 
@@ -139,13 +139,13 @@ kmeans(x, centers, iter.max, nstart)
 | String         |The output matrix with the centroids |
 
 
-
-**DML-bodied built-in functions** are written as DML-Scripts and executed as such when called.
 ### Example
 
+
+
+**DML-bodied built-in functions** are written as DML-Scripts and executed as such when called.
 ```h2o.kmeans(x = predictors, k = 100, estimate_k = T, standardize = F,
                              training_frame = train, validation_frame=valid, seed = 1234)```
-
 
 
 ## `lm`-Function

--- a/docs/builtins-reference.md
+++ b/docs/builtins-reference.md
@@ -144,8 +144,10 @@ kmeans(x, centers, iter.max, nstart)
 
 
 **DML-bodied built-in functions** are written as DML-Scripts and executed as such when called.
-```h2o.kmeans(x = predictors, k = 100, estimate_k = T, standardize = F,
-                             training_frame = train, validation_frame=valid, seed = 1234)```
+```
+h2o.kmeans(x = predictors, k = 100, estimate_k = T, standardize = F,
+                             training_frame = train, validation_frame=valid, seed = 1234)
+```
 
 
 ## `lm`-Function

--- a/docs/builtins-reference.md
+++ b/docs/builtins-reference.md
@@ -106,8 +106,50 @@ print(toString(D))
 Note that reshape construction is not yet supported for **SPARK** execution.
 
 # DML-Bodied Built-In Functions
+# Introduction
+
+
+The DML (Declarative Machine Learning) language has built-in functions which enable access to both low- and high-level function
+
+
+
+## `KMeans`-Function
+
+The kmeans() function in R requires, at a minimum, numeric data and a number of centers (or clusters). 
+The cluster centers are pulled out by using $centers.
+
+
+
+### Usage
+```r
+kmeans(x, centers, iter.max, nstart)
+```
+
+### Arguments
+
+| Name   | Type            | Default  | Description |
+| :----  | :-------------  | -------- | :------------------------------- |
+| x      | Matrix[Numeric] | required |The input Matrix to do KMeans on..|
+|centers | Int             | -------- |The no. of cenetrs                |
+|iter.max|Int              |10        |Max no. of iterations allowed     |
+|nstart  |Int              |10        |No. of random starting positions  |
+
+
+
+### Returns
+| Type           | Description |
+| :------------- | :---------- |
+| String         | The mapping of records to centroids |
+| String         |The output matrix with the centroids |
+
+
+### Example
+
+KMeans = rand(Matrix x, centers k=0,int iter.max=25,int nstart=10)
+return(Matrix[numerical] C,Matrix[numerical] Y)
 
 **DML-bodied built-in functions** are written as DML-Scripts and executed as such when called.
+
 
 ## `lm`-Function
 

--- a/docs/builtins-reference.md
+++ b/docs/builtins-reference.md
@@ -145,8 +145,9 @@ kmeans(x, centers, iter.max, nstart)
 
 **DML-bodied built-in functions** are written as DML-Scripts and executed as such when called.
 ```
-h2o.kmeans(x = predictors, k = 100, estimate_k = T, standardize = F,
-                             training_frame = train, validation_frame=valid, seed = 1234)
+m_kmeans = function(Matrix[Double] X, Integer k = 0, Integer runs = 10, Integer max_iter = 1000,
+    Double eps = 0.000001, Boolean is_verbose = FALSE, Integer avg_sample_size_per_centroid = 50)
+  return (Matrix[Double] C, Matrix[Double] Y)
 ```
 
 

--- a/docs/builtins-reference.md
+++ b/docs/builtins-reference.md
@@ -23,6 +23,7 @@ limitations under the License.
   * [Built-In Construction Functions](#built-in-construction-functions)
     * [`tensor`-Function](#tensor-function)
   * [DML-Bodied Built-In functions](#dml-bodied-built-in-functions)
+    * [`KMeans`-Function](#KMeans-function)
     * [`lm`-Function](#lm-function)
     * [`lmDS`-Function](#lmds-function)
     * [`lmCG`-Function](#lmcg-function)

--- a/docs/builtins-reference.md
+++ b/docs/builtins-reference.md
@@ -109,10 +109,6 @@ Note that reshape construction is not yet supported for **SPARK** execution.
 # Introduction
 
 
-The DML (Declarative Machine Learning) language has built-in functions which enable access to both low- and high-level function
-
-
-
 ## `KMeans`-Function
 
 The kmeans() function in R requires, at a minimum, numeric data and a number of centers (or clusters). 
@@ -127,12 +123,12 @@ kmeans(x, centers, iter.max, nstart)
 
 ### Arguments
 
-| Name   | Type            | Default  | Description |
-| :----  | :-------------  | -------- | :------------------------------- |
-| x      | Matrix[Numeric] | required |The input Matrix to do KMeans on..|
-|centers | Int             | -------- |The no. of cenetrs                |
-|iter.max|Int              |10        |Max no. of iterations allowed     |
-|nstart  |Int              |10        |No. of random starting positions  |
+| Name     | Type            | Default  | Description |
+| :--      | :--             | --       | :--         |
+| x        | Matrix[Numeric] | required |The input Matrix to do KMeans on..|
+| centers  | Int             | --       |The no. of cenetrs                |
+| iter.max |Int              | `10`        |Max no. of iterations allowed     |
+| nstart   |Int              | `10`        |No. of random starting positions  |
 
 
 
@@ -143,12 +139,13 @@ kmeans(x, centers, iter.max, nstart)
 | String         |The output matrix with the centroids |
 
 
-### Example
-
-KMeans = rand(Matrix x, centers k=0,int iter.max=25,int nstart=10)
-return(Matrix[numerical] C,Matrix[numerical] Y)
 
 **DML-bodied built-in functions** are written as DML-Scripts and executed as such when called.
+### Example
+
+```h2o.kmeans(x = predictors, k = 100, estimate_k = T, standardize = F,
+                             training_frame = train, validation_frame=valid, seed = 1234)```
+
 
 
 ## `lm`-Function


### PR DESCRIPTION
[KMeans.txt](https://github.com/apache/systemml/files/4709296/KMeans.txt)

Edit (by @j143):
This function adds documentation for the `KMeans` builtin function.