### PR TITLE
[MINOR] Fix code coverage tool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
 					<threadCount>12</threadCount>
 					<!-- 1C means the number of threads times 1 possible maximum forks for testing-->
 					<forkCount>1C</forkCount>
-					<argLine>-Xms4g -Xmx4g</argLine>
+					<argLine>${argLine} -Xms4g -Xmx4g</argLine>
 					<reuseForks>false</reuseForks>
 					<reportFormat>brief</reportFormat>
 					<trimStackTrace>true</trimStackTrace>
@@ -332,6 +332,26 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>generate-code-coverage-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+			</plugin>
+
+			<!-- <plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.7.6.201602180812</version>
 				<executions>
 					<execution>
@@ -341,7 +361,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin> -->
 
 			<plugin>
 				<groupId>org.eluder.coveralls</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -332,36 +332,22 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>generate-code-coverage-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-			</plugin>
-
-			<!-- <plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.6.201602180812</version>
+				<version>0.8.5</version>
 				<executions>
 					<execution>
-						<id>prepare-agent</id>
 						<goals>
 							<goal>prepare-agent</goal>
 						</goals>
 					</execution>
+					<execution>
+						<id>generate-code-coverage-report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
 				</executions>
-			</plugin> -->
+			</plugin>
 
 			<plugin>
 				<groupId>org.eluder.coveralls</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,9 @@
 		<enableGPU>false</enableGPU>
 		<jcuda.scope>provided</jcuda.scope>
 		<jcuda.version>10.2.0</jcuda.version>
+		<!-->Testing settings<!-->
 		<skipTests>true</skipTests>
+		<argLine>-Xms4g -Xmx4g</argLine>
 	</properties>
 
 	<repositories>
@@ -260,7 +262,6 @@
 					<threadCount>12</threadCount>
 					<!-- 1C means the number of threads times 1 possible maximum forks for testing-->
 					<forkCount>1C</forkCount>
-					<argLine>${argLine} -Xms4g -Xmx4g</argLine>
 					<reuseForks>false</reuseForks>
 					<reportFormat>brief</reportFormat>
 					<trimStackTrace>true</trimStackTrace>


### PR DESCRIPTION
Minor change to pom to update and reenable code coverage in testing.
when testing using the following command (replace ??? with package name)

`mvn test -DskipTests=false -Dtest=org.apache.sysds.???`

This uses jacoco to produce a folder containing a webpage in
`target/site` that show coverage.

![image](https://user-images.githubusercontent.com/9947148/83941416-62811000-a7eb-11ea-9494-d5ff00ca1ab1.png)
