### PR TITLE
[SYSTEMDS-413] Cache MultiReturnBuiltin instructions

### DIFF
--- a/dev/docs/Tasks.txt
+++ b/dev/docs/Tasks.txt
@@ -318,6 +318,8 @@ SYSTEMDS-400 Spark Backend Improvements
 
 SYSTEMDS-410 Lineage Tracing, Reuse and Integration II
  * 411 Improved handling of multi-level cache duplicates              OK 
+ * 412 Robust lineage tracing (non-recursive, parfor)                 OK
+ * 413 Cache and reuse MultiReturnBuiltin instructions                OK
 
 Others:
  * Break append instruction to cbind and rbind 

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/MultiReturnBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/MultiReturnBuiltinCPInstruction.java
@@ -97,6 +97,10 @@ public class MultiReturnBuiltinCPInstruction extends ComputationCPInstruction {
 		}
 
 	}
+	
+	public int getNumOutputs() {
+		return _outputs.size();
+	}
 
 	@Override 
 	public void processInstruction(ExecutionContext ec) {

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -37,6 +37,7 @@ import org.apache.sysds.runtime.instructions.cp.CPInstruction.CPType;
 import org.apache.sysds.runtime.instructions.cp.ComputationCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.cp.MMTSJCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.MultiReturnBuiltinCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ParameterizedBuiltinCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig.LineageCacheStatus;
@@ -79,38 +80,65 @@ public class LineageCache
 		// will always fit in memory and hence can be pinned unconditionally
 		if (LineageCacheConfig.isReusable(inst, ec)) {
 			ComputationCPInstruction cinst = (ComputationCPInstruction) inst;
-			LineageItem item = cinst.getLineageItem(ec).getValue();
+			LineageItem instLI = cinst.getLineageItem(ec).getValue();
+			HashMap<LineageItem, LineageCacheEntry> liMap = new HashMap<>();
+			if (inst instanceof MultiReturnBuiltinCPInstruction) {
+				MultiReturnBuiltinCPInstruction mrInst = (MultiReturnBuiltinCPInstruction)inst;
+				for (int i=0; i<mrInst.getNumOutputs(); i++) {
+					String opcode = instLI.getOpcode() + String.valueOf(i);
+					liMap.put(new LineageItem(opcode, instLI.getInputs()), null);
+				}
+			}
+			else
+				liMap.put(instLI, null);
 			
 			//atomic try reuse full/partial and set placeholder, without
 			//obtaining value to avoid blocking in critical section
 			LineageCacheEntry e = null;
+			Boolean reuseAll = true;
 			synchronized( _cache ) {
 				//try to reuse full or partial intermediates
-				if (LineageCacheConfig.getCacheType().isFullReuse())
-					e = LineageCache.probe(item) ? getIntern(item) : null;
-				//TODO need to also move execution of compensation plan out of here
-				//(create lazily evaluated entry)
-				if (e == null && LineageCacheConfig.getCacheType().isPartialReuse())
-					if( LineageRewriteReuse.executeRewrites(inst, ec) )
-						e = getIntern(item);
-				reuse = (e != null);
-				
-				//create a placeholder if no reuse to avoid redundancy
-				//(e.g., concurrent threads that try to start the computation)
-				if(!reuse && isMarkedForCaching(inst, ec)) {
-					putIntern(item, cinst.output.getDataType(), null, null,  0);
+				for (LineageItem item : liMap.keySet()) {
+					if (LineageCacheConfig.getCacheType().isFullReuse())
+						e = LineageCache.probe(item) ? getIntern(item) : null;
+					//TODO need to also move execution of compensation plan out of here
+					//(create lazily evaluated entry)
+					if (e == null && LineageCacheConfig.getCacheType().isPartialReuse())
+						if( LineageRewriteReuse.executeRewrites(inst, ec) )
+							e = getIntern(item);
+					//TODO: MultiReturnBuiltin and partial rewrites
+					reuseAll &= (e != null);
+					liMap.put(item, e);
+					
+					//create a placeholder if no reuse to avoid redundancy
+					//(e.g., concurrent threads that try to start the computation)
+					if(e == null && isMarkedForCaching(inst, ec)) {
+						putIntern(item, cinst.output.getDataType(), null, null,  0);
+						//FIXME: different o/p datatypes for MultiReturnBuiltins.
+					}
 				}
 			}
+			reuse = reuseAll;
 			
 			if(reuse) { //reuse
 				//put reuse value into symbol table (w/ blocking on placeholders)
-				if (e.isMatrixValue())
-					ec.setMatrixOutput(cinst.output.getName(), e.getMBValue());
-				else
-					ec.setScalarOutput(cinst.output.getName(), e.getSOValue());
+				for (Map.Entry<LineageItem, LineageCacheEntry> entry : liMap.entrySet()) {
+					e = entry.getValue();
+					String outName = null;
+					if (inst instanceof MultiReturnBuiltinCPInstruction)
+						outName = ((MultiReturnBuiltinCPInstruction)inst).
+							getOutput(entry.getKey().getOpcode().charAt(entry.getKey().getOpcode().length()-1)-'0').getName(); 
+					else
+						outName = cinst.output.getName();
+
+					if (e.isMatrixValue())
+						ec.setMatrixOutput(outName, e.getMBValue());
+					else
+						ec.setScalarOutput(outName, e.getSOValue());
+					reuse = true;
+				}
 				if (DMLScript.STATISTICS)
 					LineageCacheStatistics.incrementInstHits();
-				reuse = true;
 			}
 		}
 		
@@ -220,23 +248,38 @@ public class LineageCache
 			return;
 		if (LineageCacheConfig.isReusable(inst, ec) ) {
 			//if (!isMarkedForCaching(inst, ec)) return;
-			LineageItem item = ((LineageTraceable) inst).getLineageItem(ec).getValue();
-			Data data = ec.getVariable(((ComputationCPInstruction) inst).output);
+			HashMap<LineageItem, Data> liDataMap = new HashMap<>();
+			LineageItem instLI = ((LineageTraceable) inst).getLineageItem(ec).getValue();
+			if (inst instanceof MultiReturnBuiltinCPInstruction) {
+				MultiReturnBuiltinCPInstruction mrInst = (MultiReturnBuiltinCPInstruction)inst;
+				for (int i=0; i<mrInst.getNumOutputs(); i++) {
+					String opcode = instLI.getOpcode() + String.valueOf(i);
+					LineageItem li = new LineageItem(opcode, instLI.getInputs());
+					Data value = ec.getVariable(mrInst.getOutput(i));
+					liDataMap.put(li, value);
+				}
+			}
+			else
+				liDataMap.put(instLI, ec.getVariable(((ComputationCPInstruction) inst).output));
 			synchronized( _cache ) {
-				if (data instanceof MatrixObject)
-					_cache.get(item).setValue(((MatrixObject)data).acquireReadAndRelease(), computetime);
-				else if (data instanceof ScalarObject)
-					_cache.get(item).setValue((ScalarObject)data, computetime);
-				else
-					throw new DMLRuntimeException("Lineage Cache: unsupported data: "+data.getDataType());
+				for (Map.Entry<LineageItem, Data> entry : liDataMap.entrySet()) {
+					LineageItem item = entry.getKey();
+					Data data = entry.getValue();
+					if (data instanceof MatrixObject)
+						_cache.get(item).setValue(((MatrixObject)data).acquireReadAndRelease(), computetime);
+					else if (data instanceof ScalarObject)
+						_cache.get(item).setValue((ScalarObject)data, computetime);
+					else
+						throw new DMLRuntimeException("Lineage Cache: unsupported data: "+data.getDataType());
 
-				//maintain order for eviction
-				LineageCacheEviction.addEntry(_cache.get(item));
+					//maintain order for eviction
+					LineageCacheEviction.addEntry(_cache.get(item));
 
-				long size = _cache.get(item).getSize();
-				if (!LineageCacheEviction.isBelowThreshold(size))
-					LineageCacheEviction.makeSpace(_cache, size);
-				LineageCacheEviction.updateSize(size, true);
+					long size = _cache.get(item).getSize();
+					if (!LineageCacheEviction.isBelowThreshold(size))
+						LineageCacheEviction.makeSpace(_cache, size);
+					LineageCacheEviction.updateSize(size, true);
+				}
 			}
 		}
 	}
@@ -258,6 +301,7 @@ public class LineageCache
 				boundLI.resetVisitStatusNR();
 			if (boundLI == null || !LineageCache.probe(li) || !LineageCache.probe(boundLI)) {
 				AllOutputsCacheable = false;
+				//FIXME: if boundLI is for a MultiReturnBuiltin instruction 
 			}
 			FuncLIMap.put(li, boundLI);
 		}

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -37,7 +37,8 @@ public class LineageCacheConfig
 		"tsmm", "ba+*", "*", "/", "+", "||", "nrow", "ncol", "round", "exp", "log",
 		"rightIndex", "leftIndex", "groupedagg", "r'", "solve", "spoof",
 		"uamean", "max", "min", "ifelse", "-", "sqrt", ">", "uak+", "<=",
-		"^", "uamax", "uark+"
+		"^", "uamax", "uark+", "uacmean", "eigen", "ctableexpand", "replace",
+		"^2", "uack+"
 		//TODO: Reuse everything. 
 	};
 	private static String[] REUSE_OPCODES  = new String[] {};

--- a/src/test/java/org/apache/sysds/test/functions/lineage/LineageReuseAlg.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/LineageReuseAlg.java
@@ -39,7 +39,7 @@ public class LineageReuseAlg extends AutomatedTestBase {
 	
 	protected static final String TEST_DIR = "functions/lineage/";
 	protected static final String TEST_NAME = "LineageReuseAlg";
-	protected static final int TEST_VARIANTS = 3;
+	protected static final int TEST_VARIANTS = 4;
 	protected String TEST_CLASS_DIR = TEST_DIR + LineageReuseAlg.class.getSimpleName() + "/";
 	
 	@Override
@@ -63,6 +63,11 @@ public class LineageReuseAlg extends AutomatedTestBase {
 	public void testMultiLogRegHybrid() {
 		testLineageTrace(TEST_NAME+"3", ReuseCacheType.REUSE_HYBRID);
 	}
+
+	@Test
+	public void testPCAHybrid() {
+		testLineageTrace(TEST_NAME+"4", ReuseCacheType.REUSE_HYBRID);
+	}
 	
 	@Test
 	public void testStepLMFull() {
@@ -77,6 +82,11 @@ public class LineageReuseAlg extends AutomatedTestBase {
 	@Test
 	public void testMultiLogRegFull() {
 		testLineageTrace(TEST_NAME+"3", ReuseCacheType.REUSE_FULL);
+	}
+
+	@Test
+	public void testPCAFull() {
+		testLineageTrace(TEST_NAME+"4", ReuseCacheType.REUSE_FULL);
 	}
 
 	public void testLineageTrace(String testname, ReuseCacheType reuseType) {

--- a/src/test/scripts/functions/lineage/LineageReuseAlg4.dml
+++ b/src/test/scripts/functions/lineage/LineageReuseAlg4.dml
@@ -1,0 +1,82 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# INPUT PARAMETERS:
+# ---------------------------------------------------------------------------------------------
+# NAME   TYPE   DEFAULT  MEANING
+# ---------------------------------------------------------------------------------------------
+# INPUT  String ---      Location to read the matrix A of feature vectors
+# K      Int    ---      Indicates dimension of the new vector space constructed from eigen vector
+# CENTER Int    0        Indicates whether or not to center data
+# SCALE  Int    0        Indicates whether or not to scale data
+# PROJDATA Int  0      This argument indicates if the data should be projected or not
+# ---------------------------------------------------------------------------------------------
+
+PCA = function(Matrix[Double] A, Integer K = ncol(A), Integer center = 1, Integer scale = 1,
+    Integer projectData = 1) return(Matrix[Double] newA)
+{
+  evec_dominant = matrix(0,cols=1,rows=1);
+
+  N = nrow(A);
+  D = ncol(A);
+
+  # perform z-scoring (centering and scaling)
+  A = scale(A, center==1, scale==1);
+
+  # co-variance matrix
+  mu = colSums(A)/N;
+  C = (t(A) %*% A)/(N-1) - (N/(N-1))*t(mu) %*% mu;
+
+  # compute eigen vectors and values
+  [evalues, evectors] = eigen(C);
+
+  decreasing_Idx = order(target=evalues,by=1,decreasing=TRUE,index.return=TRUE);
+  diagmat = table(seq(1,D),decreasing_Idx);
+  # sorts eigenvalues by decreasing order
+  evalues = diagmat %*% evalues;
+  # sorts eigenvectors column-wise in the order of decreasing eigenvalues
+  evectors = evectors %*% diagmat;
+
+
+  # select K dominant eigen vectors
+  nvec = ncol(evectors);
+
+  eval_dominant = evalues[1:K, 1];
+  evec_dominant = evectors[,1:K];
+
+  # the square root of eigenvalues
+  eval_stdev_dominant = sqrt(eval_dominant);
+
+  if (projectData == 1){
+    # Construct new data set by treating computed dominant eigenvectors as the basis vectors
+    newA = A %*% evec_dominant;
+  }
+}
+
+A = rand(rows=100, cols=10, seed=42);
+R = matrix(0, rows=1, cols=ncol(A));
+for (i in 1:ncol(A)) {
+  newA = PCA(A=A, K=i);
+  while(FALSE){}
+  R[,i] = sum(newA);
+}
+write(R, $1, format="text");
+


### PR DESCRIPTION
This patch enables caching of multi-return instructions like eigen.
Furthermore, this includes a new partial rewrite and adds PCA
as a test case.