### PR TITLE
[SYSTEMDS-414] New rewrite for PCA -> lmDS pipeline

### DIFF
--- a/dev/Tasks.txt
+++ b/dev/Tasks.txt
@@ -339,6 +339,7 @@ SYSTEMDS-410 Lineage Tracing, Reuse and Integration II
  * 411 Improved handling of multi-level cache duplicates              OK 
  * 412 Robust lineage tracing (non-recursive, parfor)                 OK
  * 413 Cache and reuse MultiReturnBuiltin instructions                OK
+ * 414 New rewrite for PCA --> lmDS pipeline                          OK
 
 SYSTEMDS-500 Documentation Webpage Reintroduction
  * 501 Make Documentation webpage framework                           OK

--- a/src/test/java/org/apache/sysds/test/functions/lineage/LineageReuseAlg.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/LineageReuseAlg.java
@@ -39,7 +39,7 @@ public class LineageReuseAlg extends AutomatedTestBase {
 	
 	protected static final String TEST_DIR = "functions/lineage/";
 	protected static final String TEST_NAME = "LineageReuseAlg";
-	protected static final int TEST_VARIANTS = 5;
+	protected static final int TEST_VARIANTS = 6;
 	protected String TEST_CLASS_DIR = TEST_DIR + LineageReuseAlg.class.getSimpleName() + "/";
 	
 	@Override
@@ -72,6 +72,11 @@ public class LineageReuseAlg extends AutomatedTestBase {
 	@Test
 	public void testGridSearchL2svmHybrid() {
 		testLineageTrace(TEST_NAME+"5", ReuseCacheType.REUSE_HYBRID);
+	}
+
+	@Test
+	public void testPCA_LM_pipeline() {
+		testLineageTrace(TEST_NAME+"6", ReuseCacheType.REUSE_HYBRID);
 	}
 	
 	@Test

--- a/src/test/scripts/functions/lineage/LineageReuseAlg6.dml
+++ b/src/test/scripts/functions/lineage/LineageReuseAlg6.dml
@@ -1,0 +1,97 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+#PCA -> LM pipeline
+
+checkR2 = function(Matrix[double] X, Matrix[double] y, Matrix[double] y_p,
+          Matrix[double] beta, Integer icpt) return (Double R2_ad)
+{
+  n = nrow(X);
+  m = ncol(X);
+  m_ext = m;
+  if (icpt == 1|icpt == 2)
+      m_ext = m+1; #due to extra column ones
+  avg_tot = sum(y)/n;
+  ss_tot = sum(y^2);
+  ss_avg_tot = ss_tot - n*avg_tot^2;
+  y_res = y - y_p;
+  avg_res = sum(y - y_p)/n;
+  ss_res = sum((y - y_p)^2);
+  R2 = 1 - ss_res/ss_avg_tot;
+  dispersion = ifelse(n>m_ext, ss_res/(n-m_ext), NaN);
+  R2_ad = ifelse(n>m_ext, 1-dispersion/(ss_avg_tot/(n-1)), NaN);
+}
+
+PCA = function(Matrix[Double] A, Integer K = ncol(A), Integer center = 1, Integer scale = 1,
+    Integer projectData = 1) return(Matrix[Double] newA)
+{
+  N = nrow(A);
+  D = ncol(A);
+
+  # perform z-scoring (centering and scaling)
+  A = scale(A, center==1, scale==1);
+
+  # co-variance matrix
+  mu = colSums(A)/N;
+  C = (t(A) %*% A)/(N-1) - (N/(N-1))*t(mu) %*% mu;
+
+  # compute eigen vectors and values
+  [evalues, evectors] = eigen(C);
+
+  decreasing_Idx = order(target=evalues,by=1,decreasing=TRUE,index.return=TRUE);
+  diagmat = table(seq(1,D),decreasing_Idx);
+  # sorts eigenvalues by decreasing order
+  evalues = diagmat %*% evalues;
+  # sorts eigenvectors column-wise in the order of decreasing eigenvalues
+  evectors = evectors %*% diagmat;
+
+
+  # select K dominant eigen vectors
+  nvec = ncol(evectors);
+
+  eval_dominant = evalues[1:K, 1];
+  evec_dominant = evectors[,1:K];
+
+  # the square root of eigenvalues
+  eval_stdev_dominant = sqrt(eval_dominant);
+
+  if (projectData == 1){
+    # Construct new data set by treating computed dominant eigenvectors as the basis vectors
+    newA = A %*% evec_dominant;
+  }
+}
+
+M = 1000;
+A = rand(rows=M, cols=100, seed=42);
+y = rand(rows=M, cols=1, seed=1);
+R = matrix(0, rows=1, cols=20);
+
+Kc = floor(ncol(A) * 0.8);
+
+for (i in 1:10) {
+  newA1 = PCA(A=A, K=Kc+i);
+  beta1 = lm(X=newA1, y=y, icpt=1, reg=0.0001, verbose=FALSE);
+  y_predict1 = lmpredict(X=newA1, w=beta1, icpt=1);
+  R2_ad1 = checkR2(newA1, y, y_predict1, beta1, 1);
+  R[,i] = R2_ad1;
+}
+
+write(R, $1, format="text");


### PR DESCRIPTION
This patch contains a rewrite to reuse tsmm result in lmDS if
called after PCA incrementally for increasing number of columns.